### PR TITLE
Prettier downloadable figures

### DIFF
--- a/data.py
+++ b/data.py
@@ -60,6 +60,8 @@ def plot_data(oid, dr, data, fmt='png'):
     lcs = {}
     seen_filters = set()
     for lc_oid, lc in data.items():
+        if len(lc) == 0:
+            continue
         first_obs = lc[0]
         fltr = first_obs['filter']
         lcs[lc_oid] = {

--- a/data.py
+++ b/data.py
@@ -58,6 +58,7 @@ def plot_data(oid, dr, data, fmt='png'):
     usetex = fmt == 'pdf'
 
     lcs = {}
+    seen_filters = set()
     for lc_oid, lc in data.items():
         first_obs = lc[0]
         fltr = first_obs['filter']
@@ -66,11 +67,12 @@ def plot_data(oid, dr, data, fmt='png'):
             'm': [obs['mag'] for obs in lc],
             'err': [obs['magerr'] for obs in lc],
             'color': FILTER_COLORS[fltr],
-            'marker_size': 5 if lc_oid == oid else 3.5,
-            'label': rf'{fltr}, \texttt{{{lc_oid}}}' if usetex else f'{fltr}, {lc_oid}',
+            'marker_size': 24 if lc_oid == oid else 12,
+            'label': '' if fltr in seen_filters else fltr,
             'marker': 'o' if lc_oid == oid else 's',
             'zorder': 2 if lc_oid == oid else 1,
         }
+        seen_filters.add(fltr)
 
     fig = matplotlib.figure.Figure(dpi=300)
     ax = fig.subplots()
@@ -92,12 +94,21 @@ def plot_data(oid, dr, data, fmt='png'):
             lc['err'],
             c=lc['color'],
             label=lc['label'],
-            marker=lc['marker'],
-            markersize=lc['marker_size'],
-            markeredgewidth=0.5,
-            markeredgecolor='black',
+            marker='',
             zorder=lc['zorder'],
             ls='',
+            alpha=0.7,
+        )
+        ax.scatter(
+            lc['t'],
+            lc['m'],
+            c=lc['color'],
+            label='',
+            marker=lc['marker'],
+            s=lc['marker_size'],
+            linewidths=0.5,
+            edgecolors='black',
+            zorder=lc['zorder'],
             alpha=0.7,
         )
     ax.legend(loc='upper right')

--- a/data.py
+++ b/data.py
@@ -10,7 +10,7 @@ from matplotlib.ticker import AutoMinorLocator
 from app import app
 from cache import cache
 from cross import find_ztf_oid
-from util import mjd_to_datetime, NotFound, FILTER_COLORS
+from util import mjd_to_datetime, NotFound, FILTER_COLORS, FILTERS_ORDER
 
 
 @cache()
@@ -65,6 +65,7 @@ def plot_data(oid, dr, data, fmt='png'):
         first_obs = lc[0]
         fltr = first_obs['filter']
         lcs[lc_oid] = {
+            'filter': fltr,
             't': [obs['mjd'] for obs in lc],
             'm': [obs['mag'] for obs in lc],
             'err': [obs['magerr'] for obs in lc],
@@ -89,7 +90,7 @@ def plot_data(oid, dr, data, fmt='png'):
     ax.yaxis.set_minor_locator(AutoMinorLocator(2))
     ax.tick_params(which='major', direction='in', length=6, width=1.5)
     ax.tick_params(which='minor', direction='in', length=4, width=1)
-    for lc_oid, lc in lcs.items():
+    for lc_oid, lc in sorted(lcs.items(), key=lambda item: FILTERS_ORDER[item[1]['filter']]):
         ax.errorbar(
             lc['t'],
             lc['m'],

--- a/data.py
+++ b/data.py
@@ -113,7 +113,7 @@ def plot_data(oid, dr, data, fmt='png'):
             zorder=lc['zorder'],
             alpha=0.7,
         )
-    ax.legend(loc='upper right')
+    ax.legend(loc='upper right', ncol=min(5, len(seen_filters)))
     bytes_io = save_fig(fig, fmt)
     return bytes_io.getvalue()
 

--- a/util.py
+++ b/util.py
@@ -15,6 +15,11 @@ INF = float('inf')
 
 FILTER_COLORS = {'zg': '#117733', 'zr': '#CC3344', 'zi': '#1c1309'}
 FILTERS = tuple(FILTER_COLORS)
+FILTERS_ORDER = {
+    'zg': 1,
+    'zr': 2,
+    'zi': 3,
+}
 
 
 default_dr = 'dr3'

--- a/viewer.py
+++ b/viewer.py
@@ -1,5 +1,6 @@
 import pathlib
 from functools import lru_cache, partial
+from itertools import chain
 from urllib.parse import urlencode
 
 import dash_core_components as dcc
@@ -481,7 +482,7 @@ def get_summary(oid, dr, different_filter, different_field, radius_ids, radius_v
     other_oids = neighbour_oids(different_filter, different_field)
     lcs = get_plot_data(oid, dr, other_oids=other_oids)
     mags = {}
-    for obs in lcs:
+    for obs in chain.from_iterable(lcs.values()):
         mags.setdefault(obs['filter'], []).append(obs['mag'])
     mean_mag = {fltr: np.mean(m) for fltr, m in mags.items()}
     elements['Average mag (including neighbourhood)'] = [f'{fltr} {mean_mag[fltr]: .2f}'
@@ -547,6 +548,7 @@ def neighbour_oids(different_filter, different_field):
 def set_figure(cur_oid, dr, different_filter, different_field, min_mjd, max_mjd):
     other_oids = neighbour_oids(different_filter, different_field)
     lcs = get_plot_data(cur_oid, dr, other_oids=other_oids, min_mjd=min_mjd, max_mjd=max_mjd)
+    lcs = list(chain.from_iterable(lcs.values()))
     mag_min = min(obs['mag'] - obs['magerr'] for obs in lcs)
     mag_max = max(obs['mag'] + obs['magerr'] for obs in lcs)
     mag_ampl = mag_max - mag_min


### PR DESCRIPTION
- Prettier marker style: alpha, marker border, ticks
- Monospace font is used for OIDs in PDF version

- Legend location is set to upper right
- `data.get_plot_data()` returns `{oid: lc}` dict instead plain observation list

![PNG example](https://user-images.githubusercontent.com/1784493/96867277-c5a6d280-146c-11eb-9302-392722ea42bb.png)
[PDF example](https://github.com/snad-space/ztf-viewer/files/5422430/680113300005170-9.pdf)


Fix #20