### PR TITLE
Increase latex memory

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to [ZTF SNAD Viewer](http://ztf.snad.space) will be document
 
 Version schema is `year.month.num_release`
 
+## [Unreleased]
+
+### Fixed
+
+- 500 error when downloading some PDF figures with a large number of points
+
 ## [2022.7.3] 2022 July 25
 
 ### Fixed

--- a/Dockerfile
+++ b/Dockerfile
@@ -24,7 +24,7 @@ RUN apt-get update \
     && rm -rf /var/lib/apt/lists/*
 
 # Increse latex maximum memory size - matplotlib wants it
-RUN echo "main_memory = 50000000" > /etc/texmf/texmf.d/10main_memory.cnf
+RUN echo "main_memory = 50000000" >> /etc/texmf/texmf.d/00debian.cnf
 
 # Install dependencies
 COPY requirements.txt /app/

--- a/Dockerfile
+++ b/Dockerfile
@@ -24,8 +24,8 @@ RUN apt-get update \
     && rm -rf /var/lib/apt/lists/*
 
 # Increse latex maximum memory size - matplotlib wants it
-RUN echo "main_memory = 50000000" >> /etc/texmf/texmf.d/10main_memory.cnf
-    && update-texmf
+RUN echo "main_memory = 50000000" >> /etc/texmf/texmf.d/10main_memory.cnf \
+    && update-texmf \
     && texhash
 
 # Install dependencies

--- a/Dockerfile
+++ b/Dockerfile
@@ -24,7 +24,9 @@ RUN apt-get update \
     && rm -rf /var/lib/apt/lists/*
 
 # Increse latex maximum memory size - matplotlib wants it
-RUN echo "main_memory = 50000000" >> /etc/texmf/texmf.d/00debian.cnf
+RUN echo "main_memory = 50000000" >> /etc/texmf/texmf.d/10main_memory.cnf
+    && update-texmf
+    && texhash
 
 # Install dependencies
 COPY requirements.txt /app/

--- a/Dockerfile
+++ b/Dockerfile
@@ -27,7 +27,7 @@ RUN apt-get update \
 RUN echo "main_memory = 50000000" > /etc/texmf/texmf.d/10main_memory.cnf \
     && update-texmf \
     && texhash \
-    && fmtutil-sys --all
+    && fmtutil-sys --all || test 1
 
 # Install dependencies
 COPY requirements.txt /app/

--- a/Dockerfile
+++ b/Dockerfile
@@ -23,6 +23,9 @@ RUN apt-get update \
     && apt-get install -y --no-install-recommends texlive-latex-extra cm-super-minimal dvipng texlive-xetex texlive-fonts-recommended \
     && rm -rf /var/lib/apt/lists/*
 
+# Increse latex maximum memory size - matplotlib wants it
+RUN echo "main_memory = 50000000" > /etc/texmf/texmf.d/10main_memory.cnf
+
 # Install dependencies
 COPY requirements.txt /app/
 RUN pip install -r /app/requirements.txt

--- a/Dockerfile
+++ b/Dockerfile
@@ -26,7 +26,8 @@ RUN apt-get update \
 # Increse latex maximum memory size - matplotlib wants it
 RUN echo "main_memory = 50000000" > /etc/texmf/texmf.d/10main_memory.cnf \
     && update-texmf \
-    && texhash
+    && texhash \
+    && fmtutil-sys --all
 
 # Install dependencies
 COPY requirements.txt /app/

--- a/Dockerfile
+++ b/Dockerfile
@@ -24,7 +24,7 @@ RUN apt-get update \
     && rm -rf /var/lib/apt/lists/*
 
 # Increse latex maximum memory size - matplotlib wants it
-RUN echo "main_memory = 50000000" >> /etc/texmf/texmf.d/10main_memory.cnf \
+RUN echo "main_memory = 50000000" > /etc/texmf/texmf.d/10main_memory.cnf \
     && update-texmf \
     && texhash
 


### PR DESCRIPTION
Low latex memory causes 500 error for some downloadable PDF plots. See folded plot for `791213400009257` as an example
https://pr196.ztf.snad.space/dr8/figure/791213400009257/folded/2.0078?other_oid=792316300013740&other_oid=791313400005610&other_oid=791113400002334&other_oid=792216300003876&other_oid=792116300002277&title=791213400009257&format=pdf&offset=-0.0