### PR TITLE
Aladin FOV

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ Version schema is `year.month.num_release`
 ### Fixed
 
 - 500 error when downloading some PDF figures with a large number of points
+- Change Aladin field of view from 4.35' to 7.27' to make it close to ZTF FITS one https://github.com/snad-space/ztf-viewer/pull/199 
 
 ## [2022.7.3] 2022 July 25
 

--- a/ztf_viewer/static/js/aladin_helper.js
+++ b/ztf_viewer/static/js/aladin_helper.js
@@ -5,7 +5,7 @@ var aladin_dec = parseFloat(document.getElementById('aladin-dec').innerText);
 
 var aladin = A.aladin(
     '#aladin-lite-div',
-    {survey: 'P/PanSTARRS/DR1/color/z/zg/g', fov: 2.0 / 60.0, target: aladin_coord}
+    {survey: 'P/PanSTARRS/DR1/color/z/zg/g', fov: 7.27 / 60.0, target: aladin_coord}
 );
 var marker = A.marker(
     aladin_ra,


### PR DESCRIPTION
This PR resolves issue #147

I checked manually and it looks for me that FITS images in JS9 viewer has a fov equals to 7.25:

We have physical coordinates in JS9 so we can find out (I did it manually) that images' width is 435 px (except when we observe the edges of the frame). As soon as we know that pixel scale in ZTF is 1''/pixel we can conclude that fov is 435 / 60 = 7.25'. I ran server locally and it looks like this value works quite good.

Still I can't get why Aladin shows the value different from the original (for this reason I put 7.27 instead of 7.25).