### PR TITLE
Update Fink API URL

### DIFF
--- a/ztf_viewer/brokers.py
+++ b/ztf_viewer/brokers.py
@@ -41,7 +41,7 @@ def antares_tag(ra, dec, radius_arcsec=DEFAULT_SEARCH_RADIUS_ARCSEC, *, oid):
 
 
 def fink_conesearch_url(ra, dec, radius_arcsec=DEFAULT_SEARCH_RADIUS_ARCSEC):
-    return f"https://fink-portal.org/?query_type=Conesearch&ra={ra}&dec={dec}&radius={radius_arcsec}"
+    return f"https://fink-portal.org/?action=conesearch&ra={ra}&dec={dec}&radius={radius_arcsec}"
 
 
 def fink_tag(ra, dec, radius_arcsec=DEFAULT_SEARCH_RADIUS_ARCSEC):

--- a/ztf_viewer/catalogs/conesearch/fink.py
+++ b/ztf_viewer/catalogs/conesearch/fink.py
@@ -37,8 +37,8 @@ class FinkQuery(_BaseCatalogApiQuery):
     }
     _prob_class_columns = {k: f"{v}_classifications" for k, v in _classifiers.items()}
 
-    _base_url = "https://fink-portal.org/"
-    _api_url = urljoin(_base_url, "/api/v1/explorer")
+    _base_url = "https://api.fink-portal.org/"
+    _api_url = urljoin(_base_url, "/api/v1/conesearch")
 
     def _api_query_region(self, ra, dec, radius_arcsec):
         params = {"ra": ra, "dec": dec, "radius": radius_arcsec}


### PR DESCRIPTION
Hello,

As part of the transition to a new system for Rubin, the URL to access the Fink API has changed:
- old: https://fink-portal.org/api/v1/<endpoint\>
- new: https://api.fink-portal.org/api/v1/<endpoint\>

Also, the `/explorer` endpoint has been renamed `/conesearch` for better clarity.

Finally, the query URL syntax has been changed to `URL?action=conesearch&ra=...`

In this transition period, in case of trouble do not hesitate to check https://fink-broker.readthedocs.io/en/latest/migration