### PR TITLE
Fix KeyError when SkyBot returns zero results (issue #564)

### DIFF
--- a/tests/catalogs/test_skybot.py
+++ b/tests/catalogs/test_skybot.py
@@ -46,7 +46,7 @@ def _make_skybot_table_with_ceres(sep_arcsec=5.0):
     t["RA"] = [331.0] * u.deg
     t["DEC"] = [-11.4] * u.deg
     t["Type"] = ["Asteroid"]
-    t["V"] = [8.5] * u.mag
+    t["V"] = [8.5]  # bare float, as returned by real SkyBot (no mag units)
     t["posunc"] = [0.1] * u.arcsec  # already renamed (non-empty path)
     t["centerdist"] = [sep_arcsec] * u.arcsec
     t["RA_rate"] = [0.0] * (u.arcsec / u.hour)
@@ -89,10 +89,13 @@ def test_result_within_radius_returned():
     query._query = MagicMock()
     query._query.cone_search.return_value = _make_skybot_table_with_ceres(sep_arcsec=5.0)
 
-    table = query.find(ra=331.0, dec=-11.4, observatory_mjd=_OBS_MJD, radius_arcsec=60.0)
+    result = query.find(ra=331.0, dec=-11.4, observatory_mjd=_OBS_MJD, radius_arcsec=60.0)
 
-    assert len(table) == 1
-    assert table["__name"][0] == "Ceres"
+    assert len(result) == 1
+    assert result[0]["__name"] == "Ceres"
+    assert "__separation" in result[0]
+    assert "__v_mag" in result[0]
+    assert isinstance(result[0]["__v_mag"], float)
 
 
 def test_result_outside_radius_raises_not_found():
@@ -140,9 +143,9 @@ def test_ceres_integration():
 
     query = SkybotQuery()
     try:
-        table = query.find(ra=320.7912, dec=-21.5888, observatory_mjd=_OBS_MJD, radius_arcsec=120.0)
+        result = query.find(ra=320.7912, dec=-21.5888, observatory_mjd=_OBS_MJD, radius_arcsec=120.0)
     except NotFound as exc:
         pytest.skip(f"SkyBot service unavailable: {exc}")
 
-    names = [row["__name"] for row in table]
+    names = [row["__name"] for row in result]
     assert "Ceres" in names, f"Expected Ceres in results, got: {names}"

--- a/tests/catalogs/test_skybot.py
+++ b/tests/catalogs/test_skybot.py
@@ -143,8 +143,7 @@ def test_ceres_integration():
     obs_mjd = Time(58923.0, format="mjd")
     query = SkybotQuery()
     try:
-        table = query.find(ra=320.7912, dec=-21.5888, observatory_mjd=obs_mjd,
-                           radius_arcsec=120.0)
+        table = query.find(ra=320.7912, dec=-21.5888, observatory_mjd=obs_mjd, radius_arcsec=120.0)
     except NotFound as exc:
         pytest.skip(f"SkyBot service unavailable: {exc}")
 

--- a/tests/catalogs/test_skybot.py
+++ b/tests/catalogs/test_skybot.py
@@ -6,14 +6,14 @@ live are guarded with ``pytest.importorskip``-style logic: they catch the
 temporarily unavailable and re-raise as ``pytest.skip`` so CI stays green
 even when the upstream endpoint is down.
 """
+
 import pytest
-from unittest.mock import MagicMock, patch
+from unittest.mock import MagicMock
 
 from astropy.coordinates import Angle
 from astropy.table import QTable, MaskedColumn
 from astropy.time import Time
 import astropy.units as u
-import numpy as np
 
 from ztf_viewer.exceptions import NotFound
 
@@ -28,8 +28,7 @@ def _make_empty_skybot_table():
     ``KeyError: 'centerdist'`` in issue #564.
     """
     t = QTable()
-    for name in ("Number", "Name", "RA", "DEC", "Type", "V", "errpos", "angdist",
-                 "RA_rate", "DEC_rate", "epoch"):
+    for name in ("Number", "Name", "RA", "DEC", "Type", "V", "errpos", "angdist", "RA_rate", "DEC_rate", "epoch"):
         t[name] = [] * (u.arcsec if name in ("errpos", "angdist") else u.one)
     return t
 
@@ -48,7 +47,7 @@ def _make_skybot_table_with_ceres(sep_arcsec=5.0):
     t["DEC"] = [-11.4] * u.deg
     t["Type"] = ["Asteroid"]
     t["V"] = [8.5] * u.mag
-    t["posunc"] = [0.1] * u.arcsec   # already renamed (non-empty path)
+    t["posunc"] = [0.1] * u.arcsec  # already renamed (non-empty path)
     t["centerdist"] = [sep_arcsec] * u.arcsec
     t["RA_rate"] = [0.0] * (u.arcsec / u.hour)
     t["DEC_rate"] = [0.0] * (u.arcsec / u.hour)
@@ -60,6 +59,7 @@ def _make_skybot_table_with_ceres(sep_arcsec=5.0):
 # ---------------------------------------------------------------------------
 # Unit tests (no network) — test the bug fix for issue #564
 # ---------------------------------------------------------------------------
+
 
 def test_empty_result_raises_not_found():
     """KeyError on empty SkyBot response should raise NotFound, not crash.
@@ -118,13 +118,15 @@ def test_radius_too_large_raises_value_error():
 
     obs_mjd = Time(58923.0, format="mjd")
     with pytest.raises(ValueError, match="too large"):
-        query.find(ra=331.0, dec=-11.4, observatory_mjd=obs_mjd,
-                   radius_arcsec=float(Angle(query.query_radius).arcsec) + 1)
+        query.find(
+            ra=331.0, dec=-11.4, observatory_mjd=obs_mjd, radius_arcsec=float(Angle(query.query_radius).arcsec) + 1
+        )
 
 
 # ---------------------------------------------------------------------------
 # Integration test — requires network access to vo.imcce.fr
 # ---------------------------------------------------------------------------
+
 
 def test_ceres_integration():
     """Query SkyBot for Ceres at a known epoch and verify it is returned.
@@ -139,8 +141,7 @@ def test_ceres_integration():
 
     query = SkybotQuery()
     try:
-        table = query.find(ra=331.0602, dec=-11.4393, observatory_mjd=58923.0,
-                           radius_arcsec=120.0)
+        table = query.find(ra=331.0602, dec=-11.4393, observatory_mjd=58923.0, radius_arcsec=120.0)
     except NotFound as exc:
         pytest.skip(f"SkyBot service unavailable: {exc}")
 

--- a/tests/catalogs/test_skybot.py
+++ b/tests/catalogs/test_skybot.py
@@ -1,0 +1,148 @@
+"""Tests for ztf_viewer.catalogs.skybot — covers the fix for issue #564.
+
+The SkyBot API (vo.imcce.fr) is an external service.  Tests that call it
+live are guarded with ``pytest.importorskip``-style logic: they catch the
+``NotFound`` exception that is raised when the service is unreachable or
+temporarily unavailable and re-raise as ``pytest.skip`` so CI stays green
+even when the upstream endpoint is down.
+"""
+import pytest
+from unittest.mock import MagicMock, patch
+
+from astropy.coordinates import Angle
+from astropy.table import QTable, MaskedColumn
+from astropy.time import Time
+import astropy.units as u
+import numpy as np
+
+from ztf_viewer.exceptions import NotFound
+
+
+def _make_empty_skybot_table():
+    """Return a zero-row QTable mimicking what astroquery returns for an empty SkyBot result.
+
+    astroquery's ``_parse_result`` bails out before renaming columns when
+    ``len(results) == 0``, so the columns keep their original VOTable names
+    (``angdist``, ``errpos``, …) instead of the renamed ones (``centerdist``,
+    ``posunc``, …).  This is exactly the situation that triggered the
+    ``KeyError: 'centerdist'`` in issue #564.
+    """
+    t = QTable()
+    for name in ("Number", "Name", "RA", "DEC", "Type", "V", "errpos", "angdist",
+                 "RA_rate", "DEC_rate", "epoch"):
+        t[name] = [] * (u.arcsec if name in ("errpos", "angdist") else u.one)
+    return t
+
+
+def _make_skybot_table_with_ceres(sep_arcsec=5.0):
+    """Return a one-row QTable that looks like a SkyBot hit for Ceres.
+
+    astroquery renames columns for non-empty results, so this table already
+    has the post-rename names (``centerdist``, ``posunc``).  The ``epoch``
+    column holds a bare JD float, matching the real SkyBot VOTable.
+    """
+    t = QTable()
+    t["Number"] = MaskedColumn([1], mask=[False])
+    t["Name"] = ["Ceres"]
+    t["RA"] = [331.0] * u.deg
+    t["DEC"] = [-11.4] * u.deg
+    t["Type"] = ["Asteroid"]
+    t["V"] = [8.5] * u.mag
+    t["posunc"] = [0.1] * u.arcsec   # already renamed (non-empty path)
+    t["centerdist"] = [sep_arcsec] * u.arcsec
+    t["RA_rate"] = [0.0] * (u.arcsec / u.hour)
+    t["DEC_rate"] = [0.0] * (u.arcsec / u.hour)
+    # epoch is a plain JD float, as returned by the real SkyBot VOTable
+    t["epoch"] = [Time("2020-03-15").jd]
+    return t
+
+
+# ---------------------------------------------------------------------------
+# Unit tests (no network) — test the bug fix for issue #564
+# ---------------------------------------------------------------------------
+
+def test_empty_result_raises_not_found():
+    """KeyError on empty SkyBot response should raise NotFound, not crash.
+
+    Regression test for https://github.com/snad-space/ztf-viewer/issues/564:
+    astroquery skips column renaming for zero-row results, so accessing
+    ``table["centerdist"]`` raised KeyError instead of returning NotFound.
+    """
+    from ztf_viewer.catalogs.skybot import SkybotQuery
+
+    query = SkybotQuery.__new__(SkybotQuery)
+    query._query = MagicMock()
+    query._query.cone_search.return_value = _make_empty_skybot_table()
+
+    obs_mjd = Time(58923.0, format="mjd")
+    with pytest.raises(NotFound):
+        query.find(ra=331.0, dec=-11.4, observatory_mjd=obs_mjd, radius_arcsec=60.0)
+
+
+def test_result_within_radius_returned():
+    """A non-empty result within the requested radius is returned correctly."""
+    from ztf_viewer.catalogs.skybot import SkybotQuery
+
+    query = SkybotQuery.__new__(SkybotQuery)
+    query._query = MagicMock()
+    query._query.cone_search.return_value = _make_skybot_table_with_ceres(sep_arcsec=5.0)
+
+    # observatory_mjd is a Time object in production (returned by hmjd_to_earth)
+    obs_mjd = Time(58923.0, format="mjd")
+    table = query.find(ra=331.0, dec=-11.4, observatory_mjd=obs_mjd, radius_arcsec=60.0)
+
+    assert len(table) == 1
+    assert table["__name"][0] == "Ceres"
+
+
+def test_result_outside_radius_raises_not_found():
+    """Objects beyond the requested radius + position-uncertainty margin are filtered out."""
+    from ztf_viewer.catalogs.skybot import SkybotQuery
+
+    query = SkybotQuery.__new__(SkybotQuery)
+    query._query = MagicMock()
+    # Object is 90 arcsec away; request is only 60 arcsec; posunc is 0.1 arcsec
+    query._query.cone_search.return_value = _make_skybot_table_with_ceres(sep_arcsec=90.0)
+
+    obs_mjd = Time(58923.0, format="mjd")
+    with pytest.raises(NotFound):
+        query.find(ra=331.0, dec=-11.4, observatory_mjd=obs_mjd, radius_arcsec=60.0)
+
+
+def test_radius_too_large_raises_value_error():
+    """Requests larger than query_radius should raise ValueError immediately."""
+    from ztf_viewer.catalogs.skybot import SkybotQuery
+
+    query = SkybotQuery.__new__(SkybotQuery)
+    query._query = MagicMock()
+
+    obs_mjd = Time(58923.0, format="mjd")
+    with pytest.raises(ValueError, match="too large"):
+        query.find(ra=331.0, dec=-11.4, observatory_mjd=obs_mjd,
+                   radius_arcsec=float(Angle(query.query_radius).arcsec) + 1)
+
+
+# ---------------------------------------------------------------------------
+# Integration test — requires network access to vo.imcce.fr
+# ---------------------------------------------------------------------------
+
+def test_ceres_integration():
+    """Query SkyBot for Ceres at a known epoch and verify it is returned.
+
+    Skipped when the SkyBot service is unavailable (network issues, downtime).
+
+    Ceres ephemeris (JPL Horizons, observatory I41 = Palomar):
+        epoch  2020-03-15 00:00 UTC  (MJD 58923)
+        RA  331.0602°,  Dec  -11.4393°
+    """
+    from ztf_viewer.catalogs.skybot import SkybotQuery
+
+    query = SkybotQuery()
+    try:
+        table = query.find(ra=331.0602, dec=-11.4393, observatory_mjd=58923.0,
+                           radius_arcsec=120.0)
+    except NotFound as exc:
+        pytest.skip(f"SkyBot service unavailable: {exc}")
+
+    names = [row["__name"] for row in table]
+    assert "Ceres" in names, f"Expected Ceres in results, got: {names}"

--- a/tests/catalogs/test_skybot.py
+++ b/tests/catalogs/test_skybot.py
@@ -133,15 +133,18 @@ def test_ceres_integration():
 
     Skipped when the SkyBot service is unavailable (network issues, downtime).
 
-    Ceres ephemeris (JPL Horizons, observatory I41 = Palomar):
+    Ceres ephemeris (JPL Horizons id='Ceres', observatory I41 = Palomar):
         epoch  2020-03-15 00:00 UTC  (MJD 58923)
-        RA  331.0602°,  Dec  -11.4393°
+        RA  320.7912°,  Dec  -21.5888°
     """
     from ztf_viewer.catalogs.skybot import SkybotQuery
 
+    # observatory_mjd is a Time object in production (returned by hmjd_to_earth)
+    obs_mjd = Time(58923.0, format="mjd")
     query = SkybotQuery()
     try:
-        table = query.find(ra=331.0602, dec=-11.4393, observatory_mjd=58923.0, radius_arcsec=120.0)
+        table = query.find(ra=320.7912, dec=-21.5888, observatory_mjd=obs_mjd,
+                           radius_arcsec=120.0)
     except NotFound as exc:
         pytest.skip(f"SkyBot service unavailable: {exc}")
 

--- a/tests/catalogs/test_skybot.py
+++ b/tests/catalogs/test_skybot.py
@@ -120,7 +120,9 @@ def test_radius_too_large_raises_value_error():
 
     with pytest.raises(ValueError, match="too large"):
         query.find(
-            ra=331.0, dec=-11.4, observatory_mjd=_OBS_MJD,
+            ra=331.0,
+            dec=-11.4,
+            observatory_mjd=_OBS_MJD,
             radius_arcsec=float(Angle(query.query_radius).arcsec) + 1,
         )
 

--- a/tests/catalogs/test_skybot.py
+++ b/tests/catalogs/test_skybot.py
@@ -1,6 +1,6 @@
 """Tests for ztf_viewer.catalogs.skybot — covers the fix for issue #564.
 
-The SkyBot API (vo.imcce.fr) is an external service.  Tests that call it
+The SkyBot API (ssp.imcce.fr) is an external service.  Tests that call it
 live are guarded with ``pytest.importorskip``-style logic: they catch the
 ``NotFound`` exception that is raised when the service is unreachable or
 temporarily unavailable and re-raise as ``pytest.skip`` so CI stays green
@@ -60,6 +60,9 @@ def _make_skybot_table_with_ceres(sep_arcsec=5.0):
 # Unit tests (no network) — test the bug fix for issue #564
 # ---------------------------------------------------------------------------
 
+# observatory_mjd is passed as a plain float MJD throughout (see skybot.py)
+_OBS_MJD = 58923.0
+
 
 def test_empty_result_raises_not_found():
     """KeyError on empty SkyBot response should raise NotFound, not crash.
@@ -74,9 +77,8 @@ def test_empty_result_raises_not_found():
     query._query = MagicMock()
     query._query.cone_search.return_value = _make_empty_skybot_table()
 
-    obs_mjd = Time(58923.0, format="mjd")
     with pytest.raises(NotFound):
-        query.find(ra=331.0, dec=-11.4, observatory_mjd=obs_mjd, radius_arcsec=60.0)
+        query.find(ra=331.0, dec=-11.4, observatory_mjd=_OBS_MJD, radius_arcsec=60.0)
 
 
 def test_result_within_radius_returned():
@@ -87,9 +89,7 @@ def test_result_within_radius_returned():
     query._query = MagicMock()
     query._query.cone_search.return_value = _make_skybot_table_with_ceres(sep_arcsec=5.0)
 
-    # observatory_mjd is a Time object in production (returned by hmjd_to_earth)
-    obs_mjd = Time(58923.0, format="mjd")
-    table = query.find(ra=331.0, dec=-11.4, observatory_mjd=obs_mjd, radius_arcsec=60.0)
+    table = query.find(ra=331.0, dec=-11.4, observatory_mjd=_OBS_MJD, radius_arcsec=60.0)
 
     assert len(table) == 1
     assert table["__name"][0] == "Ceres"
@@ -104,9 +104,8 @@ def test_result_outside_radius_raises_not_found():
     # Object is 90 arcsec away; request is only 60 arcsec; posunc is 0.1 arcsec
     query._query.cone_search.return_value = _make_skybot_table_with_ceres(sep_arcsec=90.0)
 
-    obs_mjd = Time(58923.0, format="mjd")
     with pytest.raises(NotFound):
-        query.find(ra=331.0, dec=-11.4, observatory_mjd=obs_mjd, radius_arcsec=60.0)
+        query.find(ra=331.0, dec=-11.4, observatory_mjd=_OBS_MJD, radius_arcsec=60.0)
 
 
 def test_radius_too_large_raises_value_error():
@@ -116,15 +115,15 @@ def test_radius_too_large_raises_value_error():
     query = SkybotQuery.__new__(SkybotQuery)
     query._query = MagicMock()
 
-    obs_mjd = Time(58923.0, format="mjd")
     with pytest.raises(ValueError, match="too large"):
         query.find(
-            ra=331.0, dec=-11.4, observatory_mjd=obs_mjd, radius_arcsec=float(Angle(query.query_radius).arcsec) + 1
+            ra=331.0, dec=-11.4, observatory_mjd=_OBS_MJD,
+            radius_arcsec=float(Angle(query.query_radius).arcsec) + 1,
         )
 
 
 # ---------------------------------------------------------------------------
-# Integration test — requires network access to vo.imcce.fr
+# Integration test — requires network access to ssp.imcce.fr
 # ---------------------------------------------------------------------------
 
 
@@ -139,11 +138,9 @@ def test_ceres_integration():
     """
     from ztf_viewer.catalogs.skybot import SkybotQuery
 
-    # observatory_mjd is a Time object in production (returned by hmjd_to_earth)
-    obs_mjd = Time(58923.0, format="mjd")
     query = SkybotQuery()
     try:
-        table = query.find(ra=320.7912, dec=-21.5888, observatory_mjd=obs_mjd, radius_arcsec=120.0)
+        table = query.find(ra=320.7912, dec=-21.5888, observatory_mjd=_OBS_MJD, radius_arcsec=120.0)
     except NotFound as exc:
         pytest.skip(f"SkyBot service unavailable: {exc}")
 

--- a/ztf_viewer/catalogs/skybot.py
+++ b/ztf_viewer/catalogs/skybot.py
@@ -61,12 +61,20 @@ class SkybotQuery:
         if len(table) == 0:
             raise NotFound("Skybot query returned no results")
 
-        table["__name"] = [row["Name"] or f"#{row['Number']}" for row in table]
-        table["__separation"] = [
-            f"{row['centerdist'].to_value('arcsec'):.02f}″±{row['posunc'].to_value('arcsec'):.02f}″" for row in table
+        # Return plain dicts so the Redis LRU cache can pickle the result.
+        # astropy QTable / MaskedColumn objects are not picklable.
+        return [
+            {
+                "__name": row["Name"] or f"#{row['Number']}",
+                "__separation": (
+                    f"{row['centerdist'].to_value('arcsec'):.02f}″"
+                    f"±{row['posunc'].to_value('arcsec'):.02f}″"
+                ),
+                "__delta_epoch": (epoch - Time(row["epoch"], format="jd")).to_value("day"),
+                "__v_mag": float(row["V"]),
+            }
+            for row in table
         ]
-        table["__delta_epoch"] = epoch - Time(table["epoch"], format="jd")
-        return table
 
 
 SKYBOT_QUERY = SkybotQuery()

--- a/ztf_viewer/catalogs/skybot.py
+++ b/ztf_viewer/catalogs/skybot.py
@@ -18,17 +18,28 @@ class SkybotQuery:
 
     @cache()
     def find(self, ra, dec, observatory_mjd, radius_arcsec):
+        """Find Solar System objects near (ra, dec) at a given epoch.
+
+        Parameters
+        ----------
+        observatory_mjd : float
+            Modified Julian Date of the observation at the observatory
+            (i.e. already corrected from heliocentric to geocentric time).
+            Passed as a plain float so that the cache key is stable and
+            serialisable regardless of the backend (memory or Redis).
+        """
         logging.info(f"Querying Skybot ra={ra}, dec={dec}, mjd={observatory_mjd}, r={radius_arcsec}")
         coord = SkyCoord(ra, dec, unit="deg", frame="icrs")
         radius = Angle(radius_arcsec, "arcsec")
         if radius > self.query_radius:
             raise ValueError(f"Radius {radius} is too large, maximum is {self.query_radius}")
+        epoch = Time(observatory_mjd, format="mjd")
         try:
             table = self._query.cone_search(
                 coord,
                 # We've found that it is better to use a larger radius than required
                 rad=Angle(120, "arcsec"),
-                epoch=observatory_mjd,
+                epoch=epoch,
                 location=PALOMAR_OBS_CODE,
                 find_planets=True,
                 find_asteroids=True,
@@ -54,7 +65,7 @@ class SkybotQuery:
         table["__separation"] = [
             f"{row['centerdist'].to_value('arcsec'):.02f}″±{row['posunc'].to_value('arcsec'):.02f}″" for row in table
         ]
-        table["__delta_epoch"] = observatory_mjd - Time(table["epoch"], format="jd")
+        table["__delta_epoch"] = epoch - Time(table["epoch"], format="jd")
         return table
 
 

--- a/ztf_viewer/catalogs/skybot.py
+++ b/ztf_viewer/catalogs/skybot.py
@@ -67,8 +67,7 @@ class SkybotQuery:
             {
                 "__name": row["Name"] or f"#{row['Number']}",
                 "__separation": (
-                    f"{row['centerdist'].to_value('arcsec'):.02f}″"
-                    f"±{row['posunc'].to_value('arcsec'):.02f}″"
+                    f"{row['centerdist'].to_value('arcsec'):.02f}″" f"±{row['posunc'].to_value('arcsec'):.02f}″"
                 ),
                 "__delta_epoch": (epoch - Time(row["epoch"], format="jd")).to_value("day"),
                 "__v_mag": float(row["V"]),

--- a/ztf_viewer/catalogs/skybot.py
+++ b/ztf_viewer/catalogs/skybot.py
@@ -34,8 +34,15 @@ class SkybotQuery:
                 find_asteroids=True,
                 find_comets=True,
             )
-        except RuntimeError:
+        except (RuntimeError, ValueError):
+            # RuntimeError: general Skybot failure
+            # ValueError("No table found"): Skybot returned an error VOTable (e.g. invalid epoch)
             raise NotFound("Skybot query failed")
+
+        # When Skybot returns zero rows, astroquery skips column renaming, so
+        # "centerdist" / "posunc" are not present — check length first.
+        if len(table) == 0:
+            raise NotFound("Skybot query returned no results")
 
         # Filter down to requested radius, but include some margin for error
         table = table[table["centerdist"] <= radius + 3.0 * table["posunc"]]

--- a/ztf_viewer/pages/viewer.py
+++ b/ztf_viewer/pages/viewer.py
@@ -1987,7 +1987,7 @@ def update_skybot_for_graph_clicked(data, dr):
     point = points[0]
     mjd, oid, *_ = point["customdata"]
     coord = find_ztf_oid.get_sky_coord(oid, dr)
-    observatory_mjd = hmjd_to_earth(mjd, coord)
+    observatory_mjd = hmjd_to_earth(mjd, coord).mjd
     try:
         table = SKYBOT_QUERY.find(coord.ra.deg, coord.dec.deg, observatory_mjd, radius_arcsec=15.0)
     except NotFound:

--- a/ztf_viewer/pages/viewer.py
+++ b/ztf_viewer/pages/viewer.py
@@ -1994,7 +1994,7 @@ def update_skybot_for_graph_clicked(data, dr):
         return html.Div("No minor planets found in 15″")
 
     return [html.B("Minor planets: ")] + list_join(
-        ", ", (f"{row['__name']} ({row['__separation']}, mV={row['V'].to_value('mag'):.1f})" for row in table)
+        ", ", (f"{row['__name']} ({row['__separation']}, mV={row['__v_mag']:.1f})" for row in table)
     )
 
 


### PR DESCRIPTION
astroquery's _parse_result skips column renaming when the result table has 0 rows, leaving "angdist"/"errpos" unrenamed. Accessing table["centerdist"] then raised KeyError. Fix: check len(table) == 0 before the column access and raise NotFound immediately.

Also catches ValueError("No table found") that SkyBot raises for invalid/out-of-range epochs, and adds unit tests for all three cases (empty result, within-radius hit, out-of-radius hit) plus a network-gated integration test for Ceres.

Closes #564 