### PR TITLE
Bump dependencies

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -50,7 +50,7 @@ comm==0.2.3
     # via ipywidgets
 contourpy==1.3.3
     # via matplotlib
-cryptography==46.0.3
+cryptography==46.0.7
     # via secretstorage
 cycler==0.12.1
     # via matplotlib
@@ -76,7 +76,7 @@ flask==3.0.3
     # via
     #   ztf-viewer (pyproject.toml)
     #   dash
-fonttools==4.60.1
+fonttools==4.61.0
     # via matplotlib
 h5py==3.15.1
     # via dustmaps
@@ -94,7 +94,7 @@ ipython==9.6.0
     # via ipywidgets
 ipython-pygments-lexers==1.1.1
     # via ipython
-ipywidgets==8.1.7
+ipywidgets==8.1.8
     # via
     #   ztf-viewer (pyproject.toml)
     #   anywidget
@@ -126,7 +126,7 @@ markupsafe==3.0.3
     # via
     #   jinja2
     #   werkzeug
-marshmallow==3.26.1
+marshmallow==3.26.2
     # via
     #   antares-client
     #   marshmallow-jsonapi
@@ -144,7 +144,7 @@ more-itertools==10.8.0
     # via
     #   jaraco-classes
     #   jaraco-functools
-narwhals==2.10.0
+narwhals==2.10.1
     # via plotly
 nest-asyncio==1.6.0
     # via dash
@@ -167,7 +167,7 @@ numpy==2.3.4
     #   plotly
     #   pyerfa
     #   scipy
-orjson==3.11.4
+orjson==3.11.6
     # via ztf-viewer (pyproject.toml)
 packaging==25.0
     # via
@@ -184,7 +184,7 @@ parso==0.8.5
     # via jedi
 pexpect==4.9.0
     # via ipython
-pillow==12.0.0
+pillow==12.2.0
     # via matplotlib
 plotly==6.3.1
     # via
@@ -205,7 +205,7 @@ pycparser==2.23
     # via cffi
 pyerfa==2.0.1.5
     # via astropy
-pygments==2.19.2
+pygments==2.20.0
     # via
     #   ipython
     #   ipython-pygments-lexers
@@ -230,7 +230,7 @@ redis==7.0.1
     #   redis-lru
 redis-lru==0.1.2
     # via ztf-viewer (pyproject.toml)
-requests==2.32.5
+requests==2.33.0
     # via
     #   ztf-viewer (pyproject.toml)
     #   alerce
@@ -275,7 +275,7 @@ typing-extensions==4.15.0
     #   python-utils
 tzdata==2025.2
     # via pandas
-urllib3==2.5.0
+urllib3==2.6.3
     # via requests
 wcwidth==0.2.14
     # via prompt-toolkit


### PR DESCRIPTION
cryptography  46.0.3  → 46.0.7  (CVE-2026-39892, CVE-2026-34073)
pillow        12.0.0  → 12.2.0
pygments      2.19.2  → 2.20.0
requests      2.32.5  → 2.33.0
orjson        3.11.4  → 3.11.6
urllib3       2.5.0   → 2.6.3
marshmallow   3.26.1  → 3.26.2  (patch; marshmallow 4.x skipped — breaking)
fonttools     4.60.1  → 4.61.0
ipywidgets    8.1.7   → 8.1.8
narwhals      2.10.0  → 2.10.1

flask/werkzeug bumps skipped: dash==2.18.2 requires werkzeug<3.1, and flask 3.1+ requires werkzeug>=3.1.

Validated: 29 unit tests pass, local dev server renders correctly.
