### PR TITLE
Fix Alerce classifier error

### DIFF
--- a/tests/catalogs/conesearch/test_alerce.py
+++ b/tests/catalogs/conesearch/test_alerce.py
@@ -1,0 +1,53 @@
+"""Tests for AlerceQuery — covers the fix for issue #574.
+
+ALeRCE sometimes returns non-PEP-440 classifier_version values (e.g. 'beta').
+The fix makes __parse_classifier_version fall back to Version('0.0.0') instead
+of raising packaging.version.InvalidVersion.
+"""
+
+import packaging.version
+import pytest
+
+
+def _parse(s):
+    from ztf_viewer.catalogs.conesearch.alerce import AlerceQuery
+
+    return AlerceQuery._AlerceQuery__parse_classifier_version(s)
+
+
+def _agg(versions):
+    from ztf_viewer.catalogs.conesearch.alerce import AlerceQuery
+
+    return AlerceQuery._AlerceQuery__aggregate_max_classifier_version(versions)
+
+
+@pytest.mark.parametrize(
+    "version_string, expected",
+    [
+        # Normal case: well-formed version suffix
+        ("stamp_classifier_1.0.4", packaging.version.Version("1.0.4")),
+        ("lc_classifier_2.1.0", packaging.version.Version("2.1.0")),
+        # Non-PEP-440 suffix (issue #574): must not raise, returns 0.0.0
+        ("lc_classifier_beta", packaging.version.Version("0.0.0")),
+        ("some_classifier_dev", packaging.version.Version("0.0.0")),
+        # No underscore: treated as unknown, returns 0.0.0
+        ("beta", packaging.version.Version("0.0.0")),
+        ("1.0.4", packaging.version.Version("0.0.0")),
+    ],
+)
+def test_parse_classifier_version(version_string, expected):
+    assert _parse(version_string) == expected
+
+
+def test_aggregate_max_prefers_higher_version():
+    """__aggregate_max_classifier_version picks the numerically highest version."""
+    versions = ["stamp_classifier_1.0.4", "stamp_classifier_1.0.2", "stamp_classifier_beta"]
+    assert _agg(versions) == "stamp_classifier_1.0.4"
+
+
+def test_aggregate_max_all_invalid():
+    """When all versions are non-PEP-440, any element is returned (all map to 0.0.0)."""
+    versions = ["classifier_beta", "classifier_alpha"]
+    # Should not raise; result is one of the elements
+    result = _agg(versions)
+    assert result in versions

--- a/ztf_viewer/catalogs/conesearch/alerce.py
+++ b/ztf_viewer/catalogs/conesearch/alerce.py
@@ -38,11 +38,15 @@ class AlerceQuery(_BaseCatalogApiQuery):
 
     @staticmethod
     def __parse_classifier_version(s):
-        # s is like 'stamp_classifier_1.0.4'
+        # s is like 'stamp_classifier_1.0.4'; the trailing segment may be a
+        # non-PEP-440 string such as 'beta', so fall back to 0.0.0 on parse error.
         if "_" not in s:
             return packaging.version.Version("0.0.0")
         _, s = s.rsplit("_", 1)
-        return packaging.version.parse(s)
+        try:
+            return packaging.version.Version(s)
+        except packaging.version.InvalidVersion:
+            return packaging.version.Version("0.0.0")
 
     @staticmethod
     def __aggregate_max_classifier_version(column):


### PR DESCRIPTION
ALeRCE now returns classifier_version values like 'beta' which packaging.version.Version rejects with InvalidVersion.  Catch the exception in __parse_classifier_version and fall back to Version('0.0.0') so the classifier is still considered but ranked lowest.

Fixes #574