### PR TITLE
Fix JS9 link

### DIFF
--- a/ztf_viewer/config.py
+++ b/ztf_viewer/config.py
@@ -11,5 +11,5 @@ MODEL_FIT_API_URL = os.environ.get("MODEL_FIT_API_URL", "https://fit.lc.snad.spa
 OGLE_III_API_URL = os.environ.get("OGLE_III_API_URL", "https://ogle3.snad.space")
 ZTF_PERIODIC_API_URL = os.environ.get("ZTF_PERIODIC_API_URL", "https://periodic.ztf.snad.space")
 TNS_API_URL = os.environ.get("TNS_API_URL", "https://tns.snad.space")
-JS9_URL = os.environ.get("JS9_URL", "https://js9.org")
+JS9_URL = os.environ.get("JS9_URL", "https://www.js9.org")
 NO_LOCAL_3D_DUST_MAP = os.environ.get("NO_LOCAL_3D_DUST_MAP", "").lower() in ("1", "true", "yes")

--- a/ztf_viewer/config.py
+++ b/ztf_viewer/config.py
@@ -11,5 +11,5 @@ MODEL_FIT_API_URL = os.environ.get("MODEL_FIT_API_URL", "https://fit.lc.snad.spa
 OGLE_III_API_URL = os.environ.get("OGLE_III_API_URL", "https://ogle3.snad.space")
 ZTF_PERIODIC_API_URL = os.environ.get("ZTF_PERIODIC_API_URL", "https://periodic.ztf.snad.space")
 TNS_API_URL = os.environ.get("TNS_API_URL", "https://tns.snad.space")
-JS9_URL = os.environ.get("JS9_URL", "https://www.js9.org")
+JS9_URL = os.environ.get("JS9_URL", "https://www.js9.org/js9.html")
 NO_LOCAL_3D_DUST_MAP = os.environ.get("NO_LOCAL_3D_DUST_MAP", "").lower() in ("1", "true", "yes")

--- a/ztf_viewer/config.py
+++ b/ztf_viewer/config.py
@@ -11,5 +11,5 @@ MODEL_FIT_API_URL = os.environ.get("MODEL_FIT_API_URL", "https://fit.lc.snad.spa
 OGLE_III_API_URL = os.environ.get("OGLE_III_API_URL", "https://ogle3.snad.space")
 ZTF_PERIODIC_API_URL = os.environ.get("ZTF_PERIODIC_API_URL", "https://periodic.ztf.snad.space")
 TNS_API_URL = os.environ.get("TNS_API_URL", "https://tns.snad.space")
-JS9_URL = os.environ.get("JS9_URL", "https://js9.si.edu/js9/js9.html")
+JS9_URL = os.environ.get("JS9_URL", "https://js9.org")
 NO_LOCAL_3D_DUST_MAP = os.environ.get("NO_LOCAL_3D_DUST_MAP", "").lower() in ("1", "true", "yes")


### PR DESCRIPTION
## Summary

Updates the default JS9 viewer URL from the unavailable `js9.si.edu` endpoint to `https://js9.org`, so the generated “Open in JS9” link points at the current JS9 site unless `JS9_URL` is overridden by the environment.

Closes #589.

## Verification

- `PYTHONPATH=. python3 - <<'PY' ...` confirmed `ztf_viewer.config.JS9_URL == "https://js9.org"`
- `python3 -m py_compile ztf_viewer/config.py`
- `git diff --check`
