### PR TITLE
Update Dash to v3.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ Version schema is `year.month.num_release`
 
 - Download the Bayestar19 dust map from our own mirror, the Harvard Dataverse
   blocks scripted downloads now https://github.com/gregreen/dustmaps/issues/54
+- Update Dash to v3.4.0 https://github.com/snad-space/ztf-viewer/issues/518
 
 ### Removed
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,8 +16,7 @@ license = {text = "MIT"}
 keywords = ["science", "astrophysics"]
 requires-python = ">=3.12"
 dependencies = [
-    # We should test version 3 before upgrade
-    "dash>=2.3.1,<3.0",
+    "dash>=3.4.0,<4.0",
     "dash_defer_js_import",
     "ipywidgets>=7.0.0", # needed by plotly
     "orjson",

--- a/uv.lock
+++ b/uv.lock
@@ -370,12 +370,9 @@ wheels = [
 
 [[package]]
 name = "dash"
-version = "2.18.2"
+version = "3.4.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "dash-core-components" },
-    { name = "dash-html-components" },
-    { name = "dash-table" },
     { name = "flask" },
     { name = "importlib-metadata" },
     { name = "nest-asyncio" },
@@ -386,18 +383,9 @@ dependencies = [
     { name = "typing-extensions" },
     { name = "werkzeug" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/cf/ae/dfd8c42c83cad1b903e4e3e7be7042074d5d7d16be97eaede6656b8ead95/dash-2.18.2.tar.gz", hash = "sha256:20e8404f73d0fe88ce2eae33c25bbc513cbe52f30d23a401fa5f24dbb44296c8", size = 7457235, upload-time = "2024-11-04T21:13:04.69Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/7a/3a/322a583ca3479ad2dc6a8bfbaf7f8e4d01e16cc5030d8e7b45445bc22502/dash-3.4.0.tar.gz", hash = "sha256:3944beb32000ee8b22cd7fbb33545a0a43e25916c63aa41ba59ee5611997815e", size = 7581177, upload-time = "2026-01-20T20:46:47.43Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/72/ef/d46131f4817f18b329e4fb7c53ba1d31774239d91266a74bccdc932708cc/dash-2.18.2-py3-none-any.whl", hash = "sha256:0ce0479d1bc958e934630e2de7023b8a4558f23ce1f9f5a4b34b65eb3903a869", size = 7792658, upload-time = "2024-11-04T21:12:56.592Z" },
-]
-
-[[package]]
-name = "dash-core-components"
-version = "2.0.0"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/41/55/ad4a2cf9b7d4134779bd8d3a7e5b5f8cc757f421809e07c3e73bb374fdd7/dash_core_components-2.0.0.tar.gz", hash = "sha256:c6733874af975e552f95a1398a16c2ee7df14ce43fa60bb3718a3c6e0b63ffee", size = 3427, upload-time = "2021-09-03T17:11:19.342Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/00/9e/a29f726e84e531a36d56cff187e61d8c96d2cc253c5bcef9a7695acb7e6a/dash_core_components-2.0.0-py3-none-any.whl", hash = "sha256:52b8e8cce13b18d0802ee3acbc5e888cb1248a04968f962d63d070400af2e346", size = 3822, upload-time = "2022-03-02T16:50:30.899Z" },
+    { url = "https://files.pythonhosted.org/packages/87/2e/8fa7d095f7ab28649ece149118ccbde8286be52037b02ab02fbe52c34601/dash-3.4.0-py3-none-any.whl", hash = "sha256:62b1c2eca3cfbe05f5e6ed8666e2c9a204aa08e2ceef89f01ce9bcccb3c18e95", size = 7921864, upload-time = "2026-01-20T20:46:36.088Z" },
 ]
 
 [[package]]
@@ -405,24 +393,6 @@ name = "dash-defer-js-import"
 version = "0.0.2"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/01/55/00cb28fbfa48c14815cef2c3754fab9c9dad93cbe4b8a8492e0e5aa516ea/dash_defer_js_import-0.0.2.tar.gz", hash = "sha256:403fef93d46535ed3ad4d5df0749136cfd1439d6956ff877b40dc47021df1e4a", size = 36947, upload-time = "2019-07-11T22:10:42.659Z" }
-
-[[package]]
-name = "dash-html-components"
-version = "2.0.0"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/14/c6/957d5e83b620473eb3c8557a253fb01c6a817b10ca43d3ff9d31796f32a6/dash_html_components-2.0.0.tar.gz", hash = "sha256:8703a601080f02619a6390998e0b3da4a5daabe97a1fd7a9cebc09d015f26e50", size = 3840, upload-time = "2021-09-03T17:15:28.871Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/75/65/1b16b853844ef59b2742a7de74a598f376ac0ab581f0dcc34db294e5c90e/dash_html_components-2.0.0-py3-none-any.whl", hash = "sha256:b42cc903713c9706af03b3f2548bda4be7307a7cf89b7d6eae3da872717d1b63", size = 4092, upload-time = "2022-03-02T16:56:07.734Z" },
-]
-
-[[package]]
-name = "dash-table"
-version = "5.0.0"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/3a/81/34983fa0c67125d7fff9d55e5d1a065127bde7ca49ca32d04dedd55f9f35/dash_table-5.0.0.tar.gz", hash = "sha256:18624d693d4c8ef2ddec99a6f167593437a7ea0bf153aa20f318c170c5bc7308", size = 3391, upload-time = "2021-09-03T17:22:17.114Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/da/ce/43f77dc8e7bbad02a9f88d07bf794eaf68359df756a28bb9f2f78e255bb1/dash_table-5.0.0-py3-none-any.whl", hash = "sha256:19036fa352bb1c11baf38068ec62d172f0515f73ca3276c79dee49b95ddc16c9", size = 3912, upload-time = "2022-03-02T17:10:41.401Z" },
-]
 
 [[package]]
 name = "dustmaps"
@@ -1743,7 +1713,7 @@ requires-dist = [
     { name = "astropy" },
     { name = "astroquery" },
     { name = "cachetools" },
-    { name = "dash", specifier = ">=2.3.1,<3.0" },
+    { name = "dash", specifier = ">=3.4.0,<4.0" },
     { name = "dash-defer-js-import" },
     { name = "dustmaps", specifier = ">=1.0.10" },
     { name = "flask" },

--- a/ztf_viewer/__main__.py
+++ b/ztf_viewer/__main__.py
@@ -582,4 +582,4 @@ def parse_args(args):
 
 if __name__ == "__main__":
     args = parse_args(None)
-    app.run_server(host=args.host, debug=True)
+    app.run(host=args.host, debug=True)

--- a/ztf_viewer/pages/login.py
+++ b/ztf_viewer/pages/login.py
@@ -1,5 +1,4 @@
-import dash
-from dash import Input, Output, State, dcc, html
+from dash import Input, Output, State, ctx, dcc, html
 
 from ztf_viewer.akb import akb
 from ztf_viewer.app import app
@@ -33,7 +32,5 @@ def do_login(n_submit, token):
     except UnAuthorized:
         return "Login failed: wrong token"
     if token:
-        dash.callback_context.response.set_cookie(
-            "akb_token", token, secure=True, samesite="Strict", max_age=31 * 86400
-        )
+        ctx.response.set_cookie("akb_token", token, secure=True, samesite="Strict", max_age=31 * 86400)
     return ["You are authorised as ", html.B(username)]


### PR DESCRIPTION
## Summary
- Bumps `dash` from 2.18.2 to 3.4.0 (`dash>=3.4.0,<4.0`)
- Fixes `app.run_server(...)` → `app.run(...)` in `ztf_viewer/__main__.py` — `run_server` was removed in Dash 3.0, which is why the previous dependabot bump (#517) had to be closed with "the simple version bump doesn't work"
- Modernizes `dash.callback_context` → `dash.ctx` in `ztf_viewer/pages/login.py` (same object, just the current top-level alias)
- Regenerated `uv.lock`; Dash 3 no longer pulls in the `dash-core-components`/`dash-html-components`/`dash-table` stub packages as transitive deps

Closes #518.

## Test plan
- [x] `uv run pytest` — 44 non-Redis tests pass (24 Redis-fixture errors are a pre-existing local macOS temp-path-length issue, unrelated to this change)
- [x] Ran the app locally (`CACHE_TYPE=memory uv run python -m ztf_viewer`) and drove it in a browser:
  - Homepage renders, including `dcc.Markdown`-rendered welcome text
  - Viewer page: light curve renders, Aladin panel initializes with real tile content, pattern-matching (`MATCH`) callbacks work
  - Login page: `ctx.response` is confirmed to be the same object as the old `dash.callback_context.response`
  - Tags page and Anomalies (`DataTable`) page render correctly
  - No new console errors beyond pre-existing ones (JS9 static assets are only built in Docker, as expected; a few pre-existing hyphenated-CSS-key React warnings)