### PR TITLE
Run gunicorn directly against the Dash app instance

### DIFF
--- a/.ci/docker-compose.yml.tmpl
+++ b/.ci/docker-compose.yml.tmpl
@@ -8,7 +8,7 @@ services:
 
   ztf-web-viewer-app:
     build: .
-    entrypoint: ["gunicorn", "-w2", "-t300", "--keep-alive=75", "-b0.0.0.0:80", "ztf_viewer.__main__:server()"]
+    entrypoint: ["gunicorn", "-w2", "-t300", "--keep-alive=75", "-b0.0.0.0:80", "ztf_viewer.__main__:app"]
     environment:
       - VIRTUAL_HOST=${SUBDOMAIN}.ztf.snad.space
       - DYNDNS_HOST=${SUBDOMAIN}.ztf.snad.space

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ Version schema is `year.month.num_release`
 - Download the Bayestar19 dust map from our own mirror, the Harvard Dataverse
   blocks scripted downloads now https://github.com/gregreen/dustmaps/issues/54
 - Update Dash to v3.4.0 https://github.com/snad-space/ztf-viewer/issues/518
+- Run gunicorn directly against the Dash app instance instead of the underlying Flask server, now that Dash 3.1+ is WSGI-compliant on its own
 
 ### Removed
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -65,4 +65,4 @@ RUN uv sync --project /app --locked --group deploy
 
 ENV PATH="/app/.venv/bin:$PATH"
 
-ENTRYPOINT ["gunicorn", "-w2", "--threads=8", "-t70", "--keep-alive=75", "-b0.0.0.0:80", "ztf_viewer.__main__:server()"]
+ENTRYPOINT ["gunicorn", "-w2", "--threads=8", "-t70", "--keep-alive=75", "-b0.0.0.0:80", "ztf_viewer.__main__:app"]

--- a/ztf_viewer/__main__.py
+++ b/ztf_viewer/__main__.py
@@ -569,11 +569,6 @@ archivePrefix = {arXiv},
     ]
 
 
-def server():
-    """Entrypoint for Gunicorn"""
-    return app.server
-
-
 def parse_args(args):
     parser = argparse.ArgumentParser()
     parser.add_argument("--host", default="127.0.0.1")


### PR DESCRIPTION
## Summary
Stacked on #615 — requires Dash 3.1+.

Dash 3.1 made `Dash` instances directly WSGI-compliant ([plotly/dash#3323](https://github.com/plotly/dash/pull/3323)), so gunicorn no longer needs the `app.server` (Flask) indirection.

- Drops the `server()` wrapper from `ztf_viewer/__main__.py`
- `Dockerfile` `ENTRYPOINT` and `.ci/docker-compose.yml.tmpl` `entrypoint`: `ztf_viewer.__main__:server()` → `ztf_viewer.__main__:app`

## Test plan
- [x] `gunicorn -w2 --threads=8 -t70 --keep-alive=75 -b127.0.0.1:8051 ztf_viewer.__main__:app` (the exact production command, different port) starts cleanly and serves the homepage with a 200 and correct `<title>`