### PR TITLE
Update Dash to v4.4.1

### DIFF
--- a/.ci/docker-compose.yml.tmpl
+++ b/.ci/docker-compose.yml.tmpl
@@ -9,6 +9,11 @@ services:
   ztf-web-viewer-app:
     build: .
     entrypoint: ["gunicorn", "-w2", "-t300", "--keep-alive=75", "-b0.0.0.0:80", "ztf_viewer.__main__:app"]
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:80/health"]
+      interval: 30s
+      timeout: 5s
+      retries: 3
     environment:
       - VIRTUAL_HOST=${SUBDOMAIN}.ztf.snad.space
       - DYNDNS_HOST=${SUBDOMAIN}.ztf.snad.space

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,12 +6,17 @@ Version schema is `year.month.num_release`
 
 ## [Unreleased]
 
+### Added
+
+- `/health` endpoint for container/orchestration health checks
+
 ### Changed
 
 - Download the Bayestar19 dust map from our own mirror, the Harvard Dataverse
   blocks scripted downloads now https://github.com/gregreen/dustmaps/issues/54
 - Update Dash to v3.4.0 https://github.com/snad-space/ztf-viewer/issues/518
 - Run gunicorn directly against the Dash app instance instead of the underlying Flask server, now that Dash 3.1+ is WSGI-compliant on its own
+- Update Dash to v4.4.1
 
 ### Removed
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -65,4 +65,6 @@ RUN uv sync --project /app --locked --group deploy
 
 ENV PATH="/app/.venv/bin:$PATH"
 
+HEALTHCHECK CMD curl -f http://localhost:80/health || exit 1
+
 ENTRYPOINT ["gunicorn", "-w2", "--threads=8", "-t70", "--keep-alive=75", "-b0.0.0.0:80", "ztf_viewer.__main__:app"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,7 +16,7 @@ license = {text = "MIT"}
 keywords = ["science", "astrophysics"]
 requires-python = ">=3.12"
 dependencies = [
-    "dash>=3.4.0,<4.0",
+    "dash>=4.4.1,<5.0",
     "dash_defer_js_import",
     "ipywidgets>=7.0.0", # needed by plotly
     "orjson",

--- a/uv.lock
+++ b/uv.lock
@@ -370,22 +370,25 @@ wheels = [
 
 [[package]]
 name = "dash"
-version = "3.4.0"
+version = "4.4.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
+    { name = "comm" },
     { name = "flask" },
     { name = "importlib-metadata" },
+    { name = "janus" },
     { name = "nest-asyncio" },
     { name = "plotly" },
+    { name = "pydantic" },
     { name = "requests" },
     { name = "retrying" },
     { name = "setuptools" },
     { name = "typing-extensions" },
     { name = "werkzeug" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/7a/3a/322a583ca3479ad2dc6a8bfbaf7f8e4d01e16cc5030d8e7b45445bc22502/dash-3.4.0.tar.gz", hash = "sha256:3944beb32000ee8b22cd7fbb33545a0a43e25916c63aa41ba59ee5611997815e", size = 7581177, upload-time = "2026-01-20T20:46:47.43Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/5a/67/d5cea6dedfbfde4165436fb58154480ea6358a9e71a739d3366575b5b724/dash-4.4.1.tar.gz", hash = "sha256:9356ca7856bc496c12c5b6de5978aaf783e090d07450ee395ade1c0c2cbdf816", size = 8536482, upload-time = "2026-07-21T18:58:19.72Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/87/2e/8fa7d095f7ab28649ece149118ccbde8286be52037b02ab02fbe52c34601/dash-3.4.0-py3-none-any.whl", hash = "sha256:62b1c2eca3cfbe05f5e6ed8666e2c9a204aa08e2ceef89f01ce9bcccb3c18e95", size = 7921864, upload-time = "2026-01-20T20:46:36.088Z" },
+    { url = "https://files.pythonhosted.org/packages/9a/29/498125538103a11eab9cfbbde41bacf93e14ab3ac92ae9fb4ac0ac4dd61b/dash-4.4.1-py3-none-any.whl", hash = "sha256:72120a91b10ee4d73f9446efd5d6a4ec218086feed7b1b479d2259844d1f658f", size = 8945027, upload-time = "2026-07-21T18:58:11.405Z" },
 ]
 
 [[package]]
@@ -649,6 +652,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/9c/cb/8ac0172223afbccb63986cc25049b154ecfb5e85932587206f42317be31d/itsdangerous-2.2.0.tar.gz", hash = "sha256:e0050c0b7da1eea53ffaf149c0cfbb5c6e2e2b69c4bef22c81fa6eb73e5f6173", size = 54410, upload-time = "2024-04-16T21:28:15.614Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/04/96/92447566d16df59b2a776c0fb82dbc4d9e07cd95062562af01e408583fc4/itsdangerous-2.2.0-py3-none-any.whl", hash = "sha256:c6242fc49e35958c8b15141343aa660db5fc54d4f13a1db01a3f5891b98700ef", size = 16234, upload-time = "2024-04-16T21:28:14.499Z" },
+]
+
+[[package]]
+name = "janus"
+version = "2.0.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d8/7f/69884b6618be4baf6ebcacc716ee8680a842428a19f403db6d1c0bb990aa/janus-2.0.0.tar.gz", hash = "sha256:0970f38e0e725400496c834a368a67ee551dc3b5ad0a257e132f5b46f2e77770", size = 22910, upload-time = "2024-12-13T12:59:08.622Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/68/34/65604740edcb20e1bda6a890348ed7d282e7dd23aa00401cbe36fd0edbd9/janus-2.0.0-py3-none-any.whl", hash = "sha256:7e6449d34eab04cd016befbd7d8c0d8acaaaab67cb59e076a69149f9031745f9", size = 12161, upload-time = "2024-12-13T12:59:06.106Z" },
 ]
 
 [[package]]
@@ -1714,7 +1726,7 @@ requires-dist = [
     { name = "astropy" },
     { name = "astroquery" },
     { name = "cachetools" },
-    { name = "dash", specifier = ">=3.4.0,<4.0" },
+    { name = "dash", specifier = ">=4.4.1,<5.0" },
     { name = "dash-defer-js-import" },
     { name = "dustmaps", specifier = ">=1.0.10" },
     { name = "flask" },

--- a/ztf_viewer/app.py
+++ b/ztf_viewer/app.py
@@ -17,5 +17,6 @@ app = dash.Dash(
     __name__,
     external_stylesheets=js9_css,
     external_scripts=js9_js,
+    health_endpoint="/health",
 )
 app.config.suppress_callback_exceptions = True

--- a/ztf_viewer/assets/style.css
+++ b/ztf_viewer/assets/style.css
@@ -88,26 +88,40 @@ select:focus {
 }
 
 /* Dash 4 wraps dcc.Input(type="number") in a styled container div (its own
-   border/background/padding) with +/- stepper buttons. Strip the wrapper's
-   own box so the input's existing border/height are the only ones visible,
-   restoring the pre-4.x compact, unstyled appearance.
+   border/background/padding) with +/- stepper buttons. Any component that
+   sets its own style={"width": ...} in Python has that style redirected
+   onto this same wrapper by Dash 4, and the input is deliberately made to
+   fill it (Dash's own CSS: .dash-input-element { flex: 1 1 0 }) - correct
+   and wanted there (min-mjd, ref-mag-input, etc.), so just strip the
+   wrapper's own box for those, leaving the fill behavior intact.
 
-   Dash also sets the inner input to width:100% of the wrapper. Previously,
-   inputs with no explicit width style relied on the browser's natural
-   ~201px default; now that same 100%-width input inside an unconstrained
-   inline-flex wrapper resolves to the full width of the surrounding row
-   instead. Give the wrapper that natural 201px width back as a default -
-   any component that sets its own style={"width": ...} already applies
-   that as an inline style on this same wrapper (Dash 4 redirects the
-   style prop there), which overrides this default via normal CSS cascade
-   rules, so explicitly-sized inputs are unaffected. */
+   Components with no explicit width (the majority - every per-catalog
+   search-radius field, for instance) previously relied on the browser's
+   own intrinsic input sizing, which naturally shrinks or grows with
+   whatever space its actual layout context provides. Dash's own CSS
+   forces two things that defeat that: .dash-input-container has
+   `container-type: inline-size`, a CSS containment mode that requires an
+   explicitly-resolvable width (auto/content-based sizing collapses to 0
+   under it); and .dash-input-element has `flex: 1 1 0`, which discards
+   the input's intrinsic size in favor of always filling its wrapper.
+   Undo both only for the no-width case, which lets the browser's normal
+   intrinsic/shrink-to-fit sizing take over again - this reproduces each
+   field's own pre-4.x width (they differ per layout context) without
+   hardcoding any of them or special-casing individual fields. */
 .dash-input-container.dash-input {
   display: inline-flex;
   border: none;
   background: none;
   padding: 0;
   height: auto;
-  width: 201px;
+}
+.dash-input-container.dash-input:not([style*="width"]) {
+  width: auto;
+  container-type: normal;
+}
+.dash-input-container.dash-input:not([style*="width"]) > .dash-input-element {
+  flex: none;
+  width: auto;
 }
 .dash-input-stepper {
   display: none;

--- a/ztf_viewer/assets/style.css
+++ b/ztf_viewer/assets/style.css
@@ -90,13 +90,24 @@ select:focus {
 /* Dash 4 wraps dcc.Input(type="number") in a styled container div (its own
    border/background/padding) with +/- stepper buttons. Strip the wrapper's
    own box so the input's existing border/height are the only ones visible,
-   restoring the pre-4.x compact, unstyled appearance. */
+   restoring the pre-4.x compact, unstyled appearance.
+
+   Dash also sets the inner input to width:100% of the wrapper. Previously,
+   inputs with no explicit width style relied on the browser's natural
+   ~201px default; now that same 100%-width input inside an unconstrained
+   inline-flex wrapper resolves to the full width of the surrounding row
+   instead. Give the wrapper that natural 201px width back as a default -
+   any component that sets its own style={"width": ...} already applies
+   that as an inline style on this same wrapper (Dash 4 redirects the
+   style prop there), which overrides this default via normal CSS cascade
+   rules, so explicitly-sized inputs are unaffected. */
 .dash-input-container.dash-input {
   display: inline-flex;
   border: none;
   background: none;
   padding: 0;
   height: auto;
+  width: 201px;
 }
 .dash-input-stepper {
   display: none;

--- a/ztf_viewer/assets/style.css
+++ b/ztf_viewer/assets/style.css
@@ -127,6 +127,30 @@ select:focus {
   display: none;
 }
 
+/* Dash 4's redesigned form controls (radio dots, checkboxes, the slider
+   handle, dropdown focus rings) all key off this custom property for their
+   "selected/interactive" color. Left at Dash's own default it's a plain
+   purple with no relation to the SNAD palette; point it at the same indigo
+   already used for links, buttons, and focus borders across this file. */
+:root {
+  --Dash-Fill-Interactive-Strong: #22114C;
+}
+
+/* Dash 4's input text now inherits color from the page (a dark gray) instead
+   of its own default black. Restore black, matching every other text field
+   style on this page (see the :focus rule above). */
+.dash-input-element {
+  color: #000;
+}
+
+/* Dash 4's dropdown renders its selected value in uppercase, semi-bold text
+   by default. Restore plain-case, regular-weight text to match every other
+   label on the page. */
+.dash-dropdown {
+  text-transform: none;
+  font-weight: 400;
+}
+
 #header-logo {
     height: 1.7320508076em;  /* sqrt(3) */
     width: auto;

--- a/ztf_viewer/assets/style.css
+++ b/ztf_viewer/assets/style.css
@@ -87,6 +87,21 @@ select:focus {
   border: 1px solid #22114C;
 }
 
+/* Dash 4 wraps dcc.Input(type="number") in a styled container div (its own
+   border/background/padding) with +/- stepper buttons. Strip the wrapper's
+   own box so the input's existing border/height are the only ones visible,
+   restoring the pre-4.x compact, unstyled appearance. */
+.dash-input-container.dash-input {
+  display: inline-flex;
+  border: none;
+  background: none;
+  padding: 0;
+  height: auto;
+}
+.dash-input-stepper {
+  display: none;
+}
+
 #header-logo {
     height: 1.7320508076em;  /* sqrt(3) */
     width: auto;

--- a/ztf_viewer/assets/style.css
+++ b/ztf_viewer/assets/style.css
@@ -151,6 +151,15 @@ select:focus {
   font-weight: 400;
 }
 
+/* Dash 4's dropdown trigger is a real <button>, so it also picks up this
+   file's generic button:hover/:focus rule below (gold text, meant for
+   actual action buttons like "GO") any time it's hovered or open. Opt it
+   back out to its normal resting text color. */
+.dash-dropdown:hover,
+.dash-dropdown:focus {
+  color: inherit;
+}
+
 #header-logo {
     height: 1.7320508076em;  /* sqrt(3) */
     width: auto;

--- a/ztf_viewer/pages/viewer.py
+++ b/ztf_viewer/pages/viewer.py
@@ -1313,7 +1313,7 @@ def show_ref_mag_or_magerr(oid, dr, different_filter, different_field):
                             type="number",
                             maxLength=6,
                             step=0.01,
-                            style={"width": "6em", "display": "inline"},
+                            style={"width": "6em", "display": "inline-block"},
                         ),
                         html.Div(
                             "  err ",
@@ -1327,7 +1327,7 @@ def show_ref_mag_or_magerr(oid, dr, different_filter, different_field):
                             maxLength=5,
                             min=0,
                             step=0.01,
-                            style={"width": "5em", "display": "inline"},
+                            style={"width": "5em", "display": "inline-block"},
                         ),
                     ],
                 )

--- a/ztf_viewer/pages/viewer.py
+++ b/ztf_viewer/pages/viewer.py
@@ -244,7 +244,7 @@ def get_layout(pathname, search):
                                     {"label": "Folded light curve", "value": "folded"},
                                 ],
                                 value="full",
-                                labelStyle={"display": "inline-block", "margin-right": "2em"},
+                                inline=True,
                                 id="light-curve-type",
                             ),
                             html.Div(
@@ -298,8 +298,7 @@ def get_layout(pathname, search):
                                     {"label": "Closest Gaia object, apparent", "value": "gaia", "disabled": False},
                                 ],
                                 value=[],
-                                labelStyle={"display": "inline-block", "margin-right": "2em"},
-                                style={"display": "block"},
+                                inline=True,
                             ),
                             dcc.RadioItems(
                                 options=[
@@ -309,7 +308,7 @@ def get_layout(pathname, search):
                                     {"label": "diff Flux", "value": "diffflux"},
                                 ],
                                 value="mag",
-                                labelStyle={"display": "inline-block", "margin-right": "2em"},
+                                inline=True,
                                 id="light-curve-brightness",
                             ),
                             html.Div(


### PR DESCRIPTION
## Summary
- Bump Dash `3.4.0` → `4.4.1` (`pyproject.toml`/`uv.lock`)
- Fix Dash 4's `dcc.Input(type="number")` redesign: the new wrapper div ships its own border/background/padding plus +/- stepper buttons, which double-boxed every numeric input in the app. CSS restores the pre-4.x compact, unstyled appearance across all ~40 call sites.
- Add the new `health_endpoint` API (Dash 3.3+): `/health` now returns `200 OK`, wired into the Dockerfile `HEALTHCHECK` and `.ci/docker-compose.yml.tmpl` `healthcheck:` block, neither of which existed before.

`dash_defer_js_import` (JS9/Aladin helper script loading) and `dash.dash_table.DataTable` both continue to work unchanged on 4.4.1 — verified directly, no replacement needed.

## Test plan
- [x] `uv lock` / `uv sync` — clean resolution
- [x] `uv run pytest` — only the pre-existing, unrelated 24 `pytest_redis.exception.UnixSocketTooLong` errors (macOS temp-dir path length issue)
- [x] Manually verified in a browser against the local dev server: search, object viewer (light curve, JS9, Aladin, ~40 numeric inputs across MJD range/ref-mag/model-fit panels), login, tags, and AKB/anomalies `DataTable` pages all load without new console errors
- [x] `curl http://localhost:8050/health` → `200 OK`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WS2nmiKURTUukkESXUEEWj