### PR TITLE
Add cache decorator guards

### DIFF
--- a/tests/test_cache_decorator_guards.py
+++ b/tests/test_cache_decorator_guards.py
@@ -1,0 +1,88 @@
+"""Guards on how the cache decorators are applied (F3 in ``plans/001_async_dash.md``).
+
+Both tests describe what is *supposed* to hold today, not a future state.
+
+``@cache()`` wraps a function and stores its return value.  Applied to an
+``async def`` it stores the **coroutine object** instead of the result, so the
+second hit returns a coroutine that has already been awaited — which raises
+rather than returning the cached value.  Nothing in the codebase does this yet,
+and the first test makes sure it stays that way; the second asserts that the
+decorator refuses outright, so the mistake cannot reach a review at all.
+
+``test_sync_cache_rejects_a_coroutine_function`` fails on today's
+``redis_lru``/``cachetools`` implementation, which accepts the coroutine
+silently.  That is a real defect, fixed by the ``cache-sync`` branch.
+"""
+
+import ast
+import pathlib
+
+import pytest
+
+import ztf_viewer
+
+PACKAGE_ROOT = pathlib.Path(ztf_viewer.__file__).parent
+
+
+def _source_files():
+    return sorted(PACKAGE_ROOT.rglob("*.py"))
+
+
+def _parse(path):
+    return ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
+
+
+def _rel(path):
+    return path.relative_to(PACKAGE_ROOT.parent).as_posix()
+
+
+def _decorator_name(node):
+    """``@cache()`` -> "cache", ``@foo.acache()`` -> "acache", anything else -> None."""
+    if isinstance(node, ast.Call):
+        node = node.func
+    if isinstance(node, ast.Attribute):
+        return node.attr
+    if isinstance(node, ast.Name):
+        return node.id
+    return None
+
+
+def _cache_decorated_definitions():
+    """``(decorator_name, is_async, "path:line function")`` for every @cache/@acache site."""
+    found = []
+    for path in _source_files():
+        for node in ast.walk(_parse(path)):
+            if not isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
+                continue
+            for decorator in node.decorator_list:
+                name = _decorator_name(decorator)
+                if name in ("cache", "acache"):
+                    found.append(
+                        (name, isinstance(node, ast.AsyncFunctionDef), f"{_rel(path)}:{node.lineno} {node.name}")
+                    )
+    return found
+
+
+def test_cache_decorators_are_applied_to_the_matching_function_kind():
+    """No ``@cache()`` on an ``async def`` anywhere in the package (and no ``@acache()`` on a ``def``)."""
+    sites = _cache_decorated_definitions()
+    assert sites, "no @cache()/@acache() sites found — did the scan break?"
+    wrong = [
+        f"@{name}() on {'async def' if is_async else 'def'} {where}"
+        for name, is_async, where in sites
+        if (name == "cache") == is_async
+    ]
+    assert not wrong, "cache decorator applied to the wrong kind of function:\n  " + "\n  ".join(wrong)
+
+
+# FAILS TODAY — fixed by `cache-sync`.  Today's cache() is cachetools/redis_lru and silently
+# caches the coroutine object, returning an already-awaited coroutine on the second hit.
+def test_sync_cache_rejects_a_coroutine_function():
+    """The decorator itself refuses, so the AST scan above is a backstop and not the only guard."""
+    from ztf_viewer.cache import cache
+
+    async def coro():
+        return 1
+
+    with pytest.raises(TypeError):
+        cache()(coro)


### PR DESCRIPTION
Two guards on how `@cache()` is applied. Rewritten from what this PR originally contained — see below.

`@cache()` stores a function's return value. Applied to an `async def` it stores the **coroutine object** instead, so the second hit returns a coroutine that has already been awaited, and raises rather than returning the cached value (F3).

- `test_cache_decorators_are_applied_to_the_matching_function_kind` — an AST scan over the package asserting no `@cache()` sits on an `async def` (and no `@acache()` on a plain `def`). Passes today; keeps it that way.
- `test_sync_cache_rejects_a_coroutine_function` — **fails today.** The decorator should refuse outright, so the mistake cannot reach review at all. Today's `redis_lru`/`cachetools` implementation accepts it silently. That is a real defect, fixed by the `cache-sync` branch.

## What changed from the original version of this PR

It began as `aio-invariants`: a checklist of rules the async migration will establish — every callback is a coroutine, flask confined to a `web.py` that does not exist yet, an `acache()` that does not exist yet. Those were `xfail`, then hard failures.

Both framings were wrong. **Those tests describe a future state, so they cannot fail usefully today — they just encode a plan in the test suite.** A test suite should say what is supposed to work now. They are dropped here and belong in the PRs that actually establish each rule (`aio-shim`, `aio-deflask`, `aio-cache-async`), where they can be written as plain passing assertions.

What survived is the pair that describes what should already hold today. The file is renamed `tests/test_cache_decorator_guards.py` to match.

## No longer stacked on Python 3.14

Originally based on `python-3.14` (#625). There was no reason for it: the plan stacks foundations on the interpreter bump because **goldens** are byte-exact CSVs from pandas/numpy, where recording on 3.12 and then switching produces churn indistinguishable from a regression. That argument applies to `aio-golden-http`/`aio-golden-callbacks`, which do not exist yet — not to pure-Python behavioural tests with no recorded artifacts. Now based on `master` and independently mergeable.

## Findings from the original investigation, preserved

The dropped callback-map test measured something worth keeping, since it corrects the plan and is now folded into `plans/001_async_dash.md` (merged in #624):

- The plan's **"39 callbacks" is a source-site count** (33 decorators + 6 bare calls). `app.callback_map` actually holds **59 entries: 57 server-side + 2 clientside**. The gap is `set_tables` (`ztf_viewer/pages/viewer.py:2048`), which registers one callback **per catalog** in a loop — 19 of them.
- **23 registrations are `functools.partial`-based, not 4.** F1a named only the hand-written `app.callback(...)(partial(...))` sites and missed the loop. This matters for `aio-shim`, whose diff is per-site but whose invariant is per-registration.
- **Clientside callbacks have no `"callback"` key at all**, so anything iterating `callback_map` must exclude them or it `KeyError`s.
- `inspect.iscoroutinefunction` **does** see through `functools.partial`, including nested (verified on 3.14) — F1a depends on this.
- F4's line number is off: `flask` is imported at `akb.py:5`; `:37` is the use site. Full list for `aio-deflask`: `akb.py:5`, `pages/favicon.py:1`, `pages/figure.py:7`, `pages/lc_csv.py:4`.

## Note

`pytest-redis` fails on macOS with `UnixSocketTooLong` due to the long default `TMPDIR` — run `pytest --basetemp=/tmp/pytest`. Pre-existing, affects the existing `test_ttl_set_redis_*` tests too; CI runs in Docker and is unaffected.
