### PR TITLE
Reimplement the sync cache on the core, dropping redis_lru

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,7 +30,6 @@ dependencies = [
     "markupsafe",
     "requests",
     "redis",
-    "redis-lru",
     "matplotlib>=3.3",
     "cachetools",
     "scipy",

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -9,6 +9,10 @@ def setup_cache(item):
     from ztf_viewer import cache
 
     cache.cache = cache._get_cache()
+    # Rebinding `cache.cache` only affects functions decorated *after* this point, and all 19
+    # `@cache()` sites were decorated when their module was first imported.  Emptying the
+    # backends is what actually gives a test an empty cache.
+    cache.clear_memory_caches()
 
 
 def pytest_runtest_setup(item):

--- a/tests/test_cache_sync.py
+++ b/tests/test_cache_sync.py
@@ -1,0 +1,98 @@
+"""Decorator-level tests for the sync ``cache()`` (plan 001, ``aio-cache-sync``).
+
+``tests/test_cache_contract.py`` is the spec and covers hit/miss/TTL/value fidelity on both
+backends.  This file covers what the spec deliberately does not: the guards and the escape
+hatches that are properties of *this* implementation rather than of any cache.
+"""
+
+import pytest
+
+from ztf_viewer import cache as cache_module
+
+
+@pytest.fixture
+def cache(monkeypatch):
+    monkeypatch.setattr(cache_module, "CACHE_TYPE", "memory", raising=False)
+    from ztf_viewer import config
+
+    monkeypatch.setattr(config, "CACHE_TYPE", "memory", raising=False)
+    return cache_module._get_cache()
+
+
+def test_cache_rejects_a_coroutine_function(cache):
+    """Plan 001, F3: caching a coroutine object hands out an exhausted awaitable."""
+
+    async def coro():
+        return 1
+
+    with pytest.raises(TypeError):
+        cache()(coro)
+
+
+def test_cache_accepts_a_plain_function(cache):
+    @cache()
+    def plain():
+        return 1
+
+    assert plain() == 1
+
+
+def test_wrapper_keeps_the_wrapped_function_metadata(cache):
+    @cache()
+    def documented(a, b):
+        """Doc."""
+        return a + b
+
+    assert documented.__name__ == "documented"
+    assert documented.__doc__ == "Doc."
+    assert documented.__wrapped__.__name__ == "documented"
+
+
+def test_an_unencodable_argument_bypasses_the_cache_instead_of_raising(cache):
+    calls = []
+
+    @cache()
+    def counted(arg):
+        calls.append(arg)
+        return len(calls)
+
+    unencodable = lambda: None  # noqa: E731 - a lambda cannot be pickled
+
+    assert counted(unencodable) == 1
+    assert counted(unencodable) == 2, "an uncacheable argument must bypass, not poison, the cache"
+
+
+def test_an_unserializable_result_is_returned_but_not_cached(cache):
+    calls = []
+
+    @cache()
+    def counted():
+        calls.append(None)
+        return lambda: len(calls)  # a lambda cannot be pickled
+
+    assert counted()() == 1
+    assert counted()() == 2
+    assert len(calls) == 2
+
+
+def test_clear_memory_caches_empties_already_decorated_functions(cache):
+    calls = []
+
+    @cache()
+    def counted():
+        calls.append(None)
+        return len(calls)
+
+    assert counted() == 1
+    assert counted() == 1
+    cache_module.clear_memory_caches()
+    assert counted() == 2
+
+
+def test_unknown_cache_type_is_rejected(monkeypatch):
+    from ztf_viewer import config
+
+    monkeypatch.setattr(cache_module, "CACHE_TYPE", "nonesuch", raising=False)
+    monkeypatch.setattr(config, "CACHE_TYPE", "nonesuch", raising=False)
+    with pytest.raises(ValueError, match="CACHE_TYPE must be one of"):
+        cache_module._get_cache()

--- a/uv.lock
+++ b/uv.lock
@@ -1243,18 +1243,6 @@ wheels = [
 ]
 
 [[package]]
-name = "redis-lru"
-version = "0.1.2"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "redis" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/d0/d8/97d2a44501c1e527b03072abaa0c8a6462e92568da5fcf5078bdcb110b4b/redis-lru-0.1.2.tar.gz", hash = "sha256:01a648cb42d8efdb9472c5c42980da3dad4be4b6d45f2d9811ff6f69bcbfb164", size = 5182, upload-time = "2022-04-16T03:25:55.807Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/96/89/46e090f178697b93dc0d88043aa96cbe93aec5c2bd39ad2ad82eb0e8baec/redis_lru-0.1.2-py2.py3-none-any.whl", hash = "sha256:e6c2f56b43900b5a8f741d1db44bdcf423f228d6f3665f48a9ec6321c5579d0a", size = 5804, upload-time = "2022-04-16T03:25:53.789Z" },
-]
-
-[[package]]
 name = "requests"
 version = "2.34.2"
 source = { registry = "https://pypi.org/simple" }
@@ -1478,7 +1466,6 @@ dependencies = [
     { name = "plotly", extra = ["express"] },
     { name = "pydantic" },
     { name = "redis" },
-    { name = "redis-lru" },
     { name = "requests" },
     { name = "scipy" },
 ]
@@ -1516,7 +1503,6 @@ requires-dist = [
     { name = "plotly", extras = ["express"] },
     { name = "pydantic" },
     { name = "redis" },
-    { name = "redis-lru" },
     { name = "requests" },
     { name = "scipy" },
 ]

--- a/ztf_viewer/cache/__init__.py
+++ b/ztf_viewer/cache/__init__.py
@@ -1,39 +1,49 @@
-import functools
+"""The application cache: ``from ztf_viewer.cache import cache``, then ``@cache()``.
 
-from cachetools import TTLCache, cached
-from redis import StrictRedis
-from redis_lru import RedisLRU
+The pieces live next door — :mod:`~ztf_viewer.cache.core` (keys and value codec),
+:mod:`~ztf_viewer.cache.decorator` (the decorator), :mod:`~ztf_viewer.cache.memory` and
+:mod:`~ztf_viewer.cache.redis` (the two stores).  This module is only the configuration: which
+backend, how big, how long, and the ``cache`` every call site imports.
 
+Two backends, chosen by ``CACHE_TYPE``:
+
+* ``redis`` — a plain ``StrictRedis`` with a per-entry TTL (production).
+* ``memory`` — a process-local ``cachetools.TTLCache`` (development and tests).
+
+``CACHE_TYPE``, ``TTL`` and ``_get_cache()`` are the seam ``tests/conftest.py`` and
+``tests/test_cache_contract.py`` build a cache with; they must stay here, at module level.
+"""
+
+from ztf_viewer import config
+from ztf_viewer.cache.memory import clear_memory_caches, create_memory_cache
+from ztf_viewer.cache.redis import create_redis_cache
 from ztf_viewer.config import CACHE_TYPE
+
+__all__ = ["TTL", "cache", "clear_memory_caches"]
 
 TTL = 7 * 86400
 MAXSIZE = 1 << 16
 
-
-def _create_redis_cache():
-    from ztf_viewer.config import REDIS_HOSTNAME
-
-    redis_conn = StrictRedis(REDIS_HOSTNAME)
-    redis_lru = RedisLRU(redis_conn, default_ttl=TTL, max_size=MAXSIZE)
-    cache = functools.partial(redis_lru, ttl=TTL)
-    return cache
-
-
-def _crate_memory_cache():
-    ttl_cache = TTLCache(MAXSIZE, ttl=TTL)
-    cache = functools.partial(cached, cache=ttl_cache)
-    return cache
-
+# `CACHE_TYPE` above is bound at import, but `ztf_viewer.config.CACHE_TYPE` is assigned at
+# runtime by tests/conftest.py, and tests/test_cache_contract.py patches both.  Remembering the
+# import-time value lets `_get_cache()` honour whichever of the two was actually changed.
+_CACHE_TYPE_AT_IMPORT = CACHE_TYPE
 
 CACHE_CREATORS = {
-    "redis": _create_redis_cache,
-    "memory": _crate_memory_cache,
+    "redis": lambda: create_redis_cache(ttl=TTL),
+    "memory": lambda: create_memory_cache(MAXSIZE, ttl=TTL),
 }
+
+
+def _cache_type():
+    if CACHE_TYPE != _CACHE_TYPE_AT_IMPORT:
+        return CACHE_TYPE
+    return config.CACHE_TYPE
 
 
 def _get_cache():
     try:
-        return CACHE_CREATORS[CACHE_TYPE.lower().strip()]()
+        return CACHE_CREATORS[_cache_type().lower().strip()]()
     except KeyError as e:
         raise ValueError(f'CACHE_TYPE must be one of: {", ".join(CACHE_CREATORS)}') from e
 

--- a/ztf_viewer/cache/decorator.py
+++ b/ztf_viewer/cache/decorator.py
@@ -1,0 +1,61 @@
+"""The ``@cache()`` decorator itself, over any backend.
+
+Keying and serialization live in :mod:`ztf_viewer.cache.core`; the stores live in
+:mod:`ztf_viewer.cache.memory` and :mod:`ztf_viewer.cache.redis`.  A backend is anything with
+``get(key)`` and ``set(key, blob)`` over pickled bytes.
+
+This replaces ``redis_lru``/``cachetools.cached``, whose behaviour differed between backends in
+five ways (plan 001, F12); ``tests/test_cache_contract.py`` is the spec.
+"""
+
+import functools
+import inspect
+import logging
+
+from ztf_viewer.cache.core import (
+    UncacheableArgument,
+    UncacheableValue,
+    cache_key_for_call,
+    decode_value,
+    encode_value,
+)
+
+
+def make_cache(backend):
+    """Build the ``cache`` decorator factory over a backend."""
+
+    def cache():
+        def decorator(func):
+            if inspect.iscoroutinefunction(func):
+                raise TypeError(
+                    f"cache() cannot wrap the coroutine function {func.__qualname__}: it would cache the "
+                    "coroutine object, which is exhausted after the first await. Use acache() instead."
+                )
+
+            @functools.wraps(func)
+            def wrapper(*args, **kwargs):
+                try:
+                    key = cache_key_for_call(func, wrapper, args, kwargs)
+                except UncacheableArgument as e:
+                    # A cache must never turn a legal call into an error, so bypass it.
+                    logging.debug(f"not caching {func.__qualname__}: {e}")
+                    return func(*args, **kwargs)
+
+                blob = backend.get(key)
+                if blob is not None:
+                    return decode_value(blob)
+
+                value = func(*args, **kwargs)
+                try:
+                    encoded = encode_value(value)
+                except UncacheableValue as e:
+                    logging.warning(f"not caching the result of {func.__qualname__}: {e}")
+                    return value
+                backend.set(key, encoded)
+                return value
+
+            return wrapper
+
+        return decorator
+
+    return cache

--- a/ztf_viewer/cache/memory.py
+++ b/ztf_viewer/cache/memory.py
@@ -1,0 +1,53 @@
+"""The in-process cache backend: a ``cachetools.TTLCache`` behind a lock.
+
+Used in development and in tests.  Like every backend here it stores *serialized* values, so
+a cached value never aliases the one the caller holds and the two backends cannot disagree
+about what a cache round-trip does to a value.
+"""
+
+import threading
+import weakref
+
+from cachetools import TTLCache
+
+from ztf_viewer.cache.decorator import make_cache
+
+# Every live memory backend, so that `clear_memory_caches()` can reach the ones captured by
+# functions that were decorated at import time.
+_BACKENDS: weakref.WeakSet = weakref.WeakSet()
+
+
+class MemoryBackend:
+    """A process-local TTL store.  Locked because Dash serves callbacks from a thread pool."""
+
+    def __init__(self, maxsize, ttl):
+        self._cache = TTLCache(maxsize, ttl=ttl)
+        self._lock = threading.Lock()
+        _BACKENDS.add(self)
+
+    def clear(self):
+        with self._lock:
+            self._cache.clear()
+
+    def get(self, key):
+        with self._lock:
+            return self._cache.get(key)
+
+    def set(self, key, blob):
+        with self._lock:
+            self._cache[key] = blob
+
+
+def create_memory_cache(maxsize, ttl):
+    return make_cache(MemoryBackend(maxsize, ttl=ttl))
+
+
+def clear_memory_caches():
+    """Empty every in-process memory cache.
+
+    Rebinding ``ztf_viewer.cache.cache`` cannot un-cache anything: the 19 ``@cache()`` sites
+    captured a backend when their module was imported.  Tests need the entries gone between
+    tests, which is what this does.
+    """
+    for backend in list(_BACKENDS):
+        backend.clear()

--- a/ztf_viewer/cache/redis.py
+++ b/ztf_viewer/cache/redis.py
@@ -1,0 +1,31 @@
+"""The Redis cache backend: a plain ``StrictRedis`` with a per-entry TTL.
+
+This is the production backend.  Eviction under memory pressure is Redis' own ``allkeys-lru``
+(see ``docker-compose.yml``), so nothing here maintains an LRU of its own.
+
+Despite the module name, ``import redis`` below is the third-party client: Python 3 imports are
+absolute, so a submodule never shadows a top-level package for its siblings or for itself.  The
+client class is looked up on the module at call time rather than imported by name, which is also
+what lets a test point the backend at its own server.
+"""
+
+import redis
+
+from ztf_viewer import config
+from ztf_viewer.cache.decorator import make_cache
+
+
+class RedisBackend:
+    def __init__(self, client, ttl):
+        self._client = client
+        self._ttl = ttl
+
+    def get(self, key):
+        return self._client.get(key)
+
+    def set(self, key, blob):
+        self._client.set(key, blob, ex=self._ttl)
+
+
+def create_redis_cache(ttl):
+    return make_cache(RedisBackend(redis.StrictRedis(config.REDIS_HOSTNAME), ttl=ttl))

--- a/ztf_viewer/catalogs/conesearch/_base.py
+++ b/ztf_viewer/catalogs/conesearch/_base.py
@@ -132,6 +132,16 @@ class _BaseCatalogQuery:
     def normalized_query_name(self):
         return self._normalize_name(self.query_name)
 
+    def __cache_key__(self):
+        """How ``@cache()`` identifies this object in the key of a cached method.
+
+        ``ztf_viewer.cache.core.encode_self`` keys ``self`` on its class, which is what makes a
+        cached method entry outlive the process that computed it.  These instances are the one
+        place in the app where that is not enough: a subclass is constructed with a catalog
+        name, so two instances of one class would be two different catalogs.
+        """
+        return self.normalized_query_name
+
     @property
     def name_column(self):
         if self._name_column is not None:


### PR DESCRIPTION
Live: reimplements the sync `cache()` decorator on `cache-core`'s keying, and drops `redis_lru`. **This is the branch that turns the stack green** — every failing test below it passes here.

## What goes green

The 7 failures in `cache-contract-tests` (#627) and the 1 in `migration-invariants` (#626), with **zero edits to either test file**:

| test | backend | defect |
| --- | --- | --- |
| `test_distinct_functions_do_not_collide` | memory | keys omitted the function — all 19 `@cache()` sites shared one keyspace |
| `test_distinct_methods_of_same_class_do_not_collide` | memory | same |
| `test_different_kwarg_names_do_not_hit` | redis | `redis_lru` hashed only `kwargs.values()`, ignoring names |
| `test_hashable_value_holding_unhashable_parts_round_trips` | redis | `RedisLRU.set` hashed the value against its exclude set, raising instead of caching |
| `test_unhashable_argument_does_not_raise` | memory | `cachetools` hashed the argument tuple, so a list raised out of the wrapper |
| `test_method_key_is_independent_of_instance_identity` | both | the `self` decision — resolved in #628, not a defect |
| `test_sync_cache_rejects_a_coroutine_function` | — | `cache()` now raises `TypeError` on an `async def` (F3) |

Full suite at the top of this stack: **green**.

## Deliberate calls

- **Both backends store pickled bytes.** Memory and Redis can no longer disagree about what a round-trip does to a value, and the memory backend no longer hands every caller the same mutable object. Costs CPU in development only; production is Redis.
- **A value that will not pickle is returned with a `logging.warning` and simply not stored**, rather than raising out of the decorator as it does today.
- **`redis_lru` is dropped** from `pyproject.toml` and `uv.lock`. Its LRU bookkeeping is not replaced: `docker-compose.yml` already runs Redis with `--maxmemory 2048mb --maxmemory-policy allkeys-lru`, so eviction is Redis'. `MAXSIZE` now bounds only the memory backend.
- **Redis errors still propagate** rather than degrading to an uncached call. Unchanged from today, but worth revisiting separately — it is arguably wrong for a cache to take the site down.
- **Existing Redis entries become unreachable** on deploy. The plan already accepts this cold start. Per #628 it is also smaller than it sounds: method-site entries were already per-process and per-boot.

## Two live bugs found while doing this

Both pre-existing, neither introduced here:

1. **`tests/conftest.py`'s cache reset was a no-op.** It rebound `cache.cache = cache._get_cache()`, which only affects functions decorated *after* it runs — and all 19 sites are decorated at import. **Tests have been sharing one cache across the entire session.** Class-keying is what exposed it: `tests/catalogs/test_skybot.py::test_result_outside_radius_raises_not_found` builds a fresh `SkybotQuery` and calls `find` with arguments identical to the previous test's, and hit that test's entry. Fixed properly with `cache.clear_memory_caches()` (a `WeakSet` of live backends) called from `pytest_runtest_setup`, rather than by perturbing the skybot test.
2. **`SdssQuasarsQuery.find` is `@cache()`-decorated and calls `super().find()`**, which is also `@cache()`-decorated, with identical arguments. Under today's memory backend those two collapse into one entry — the shared-keyspace defect in live code, not just in tests.

## Verification

Full suite green at this branch. App smoke-run under `python -m ztf_viewer` with both cache types set to `memory`: `/health` 200, `/` 200, `/view/dr23/633207400004353` 200, no errors logged.
