### PR TITLE
Skip upstream tests instead of failing when a service is down

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,3 +1,77 @@
+"""Shared test configuration.
+
+The catalog tests query real services. That is deliberate — they exercise our
+parsing against what the upstreams really return, which is the part worth
+testing — but it means a test can fail for reasons that have nothing to do with
+this repository: a read timeout, a dropped connection, an upstream 500, or a
+service that is simply down.
+
+Those failures are noise. They are not actionable, they land on whoever happens
+to open the next pull request, and after a few of them people stop reading CI.
+So a test marked ``upstream`` that fails with a transport-level error is turned
+into a **skip with a warning** rather than a failure: the run stays green, and
+the reason is printed in the summary (``-ra`` is on by default in addopts).
+
+What is deliberately *not* converted:
+
+* assertion failures — if the service answered and we parsed it wrong, that is
+  our bug and it must fail;
+* :class:`~ztf_viewer.exceptions.NotFound` — a real answer about the data;
+* anything in a test not marked ``upstream``.
+
+The marker is applied automatically to everything under ``tests/catalogs/``;
+add it by hand elsewhere with ``@pytest.mark.upstream``.
+"""
+
+import http.client
+import socket
+import urllib.error
+import warnings
+
+import pytest
+
+UPSTREAM_MARKER = "upstream"
+
+#: Errors that mean "the service did not answer properly", never "our code is wrong".
+#: ``OSError`` is the base of ``ConnectionError``, ``socket.timeout`` and
+#: ``http.client.RemoteDisconnected``, so it covers the transport layer broadly — which is
+#: safe here only because this conversion is opt-in per marker.
+UPSTREAM_ERRORS: tuple[type[BaseException], ...] = (
+    OSError,
+    socket.timeout,
+    urllib.error.URLError,
+    http.client.HTTPException,
+)
+
+
+def _extra_upstream_errors() -> tuple[type[BaseException], ...]:
+    """Third-party transport exceptions, imported lazily so conftest never hard-depends on them."""
+    extra: list[type[BaseException]] = []
+    try:
+        from requests import RequestException
+
+        extra.append(RequestException)
+    except ImportError:
+        pass
+    try:
+        from ztf_viewer.exceptions import CatalogUnavailable
+
+        extra.append(CatalogUnavailable)
+    except ImportError:
+        pass
+    return tuple(extra)
+
+
+def _is_upstream_error(exc: BaseException) -> bool:
+    if isinstance(exc, AssertionError):
+        return False
+    if isinstance(exc, UPSTREAM_ERRORS + _extra_upstream_errors()):
+        return True
+    # astroquery and friends wrap transport errors; walk the __cause__/__context__ chain.
+    cause = exc.__cause__ or exc.__context__
+    return cause is not None and _is_upstream_error(cause)
+
+
 def setup_config(item):
     from ztf_viewer import config
 
@@ -11,6 +85,43 @@ def setup_cache(item):
     cache.cache = cache._get_cache()
 
 
+def pytest_configure(config):
+    config.addinivalue_line(
+        "markers",
+        f"{UPSTREAM_MARKER}: test queries a real upstream service; transport failures "
+        "become skips instead of failures",
+    )
+
+
+def pytest_collection_modifyitems(items):
+    """Mark every catalog test as ``upstream`` — they all talk to real services."""
+    for item in items:
+        if "tests/catalogs/" in item.nodeid or item.nodeid.startswith("catalogs/"):
+            item.add_marker(UPSTREAM_MARKER)
+
+
 def pytest_runtest_setup(item):
     setup_config(item)
     setup_cache(item)
+
+
+@pytest.hookimpl(wrapper=True)
+def pytest_runtest_makereport(item, call):
+    report = yield
+
+    if report.outcome != "failed" or call.excinfo is None:
+        return report
+    if item.get_closest_marker(UPSTREAM_MARKER) is None:
+        return report
+    if not _is_upstream_error(call.excinfo.value):
+        return report
+
+    reason = f"upstream unavailable ({type(call.excinfo.value).__name__}: {call.excinfo.value})"
+    warnings.warn(f"{item.nodeid}: {reason}", UpstreamUnavailableWarning, stacklevel=1)
+    report.outcome = "skipped"
+    report.longrepr = (item.location[0], item.location[1], reason)
+    return report
+
+
+class UpstreamUnavailableWarning(UserWarning):
+    """An upstream service failed to answer, so a test was skipped instead of failed."""


### PR DESCRIPTION
Makes the catalog tests robust to upstream trouble without giving up on testing against real services. Replaces #631, which recorded and replayed upstream responses — closed as not worth its cost.

## The problem

`tests/catalogs/` queries real services. That is the right call: those tests check **our parsing** against what the upstreams actually return — column names, masked-vs-`"None"` values, coordinate ranges on the parsed astropy `Table`. Testing that against a canned blob mostly re-tests the blob.

But it means a test can fail for reasons that have nothing to do with this repository — a read timeout, a dropped connection, an upstream 500. Those failures are noise: not actionable, and they land on whoever happens to open the next PR. After a few of them people stop reading CI, which costs more than the tests are worth.

## What this does

A test marked `upstream` that fails with a **transport-level** error becomes a **skip with a warning** instead of a failure. The run stays green and the reason prints in the summary (`-ra` is already in addopts).

Implemented as a `pytest_runtest_makereport` wrapper rather than a `try/except` in each test, for two reasons: it needs no edits to existing tests, and it catches failures in **fixtures** as well as test bodies — `test_panstarrs.py`'s `stack_table` is module-scoped, so a network error there is a collection ERROR that a per-test `try/except` would never see.

## What still fails

Deliberately not converted:

- **assertion failures** — the service answered and we parsed it wrong; that is our bug
- **`NotFound`** — a real answer about the data, not a transport problem
- anything not marked `upstream`

Verified with a probe suite covering each path:

| case | result |
| --- | --- |
| transport error raised in a **fixture** | SKIPPED + warning |
| transport error raised in the **test body** | SKIPPED + warning |
| transport error **wrapped** by a `raise ... from` (astroquery style) | SKIPPED + warning |
| `assert 1 == 2` | **FAILED** |
| `NotFound` | **FAILED** |

The wrapped case matters: astroquery does not let transport errors through unchanged, so the check walks the `__cause__`/`__context__` chain.

## Scope

The marker is applied automatically to everything under `tests/catalogs/` — **28 tests**. The other **40** (`test_util`, the three `ttl_set` suites) are untouched, so a broken Redis fixture still fails loudly rather than being quietly skipped. `OSError` is treated as a transport error, which is broad; that is only safe because the conversion is opt-in per marker.

## Known gap, not addressed here

The **first-party SNAD APIs have no tests at all** — `ztf_dr`, `lc_features`, `model_fit`, `akb`. Those are exactly the modules the async migration rewrites from `requests` to `httpx` (`aio-snad-apis`), so they are where "tests that check our code against a real service" would buy the most. Worth adding before that port, in this same style.
