### PR TITLE
aio-deflask: remove direct Flask coupling from app code

### DIFF
--- a/tests/test_flask_import_guard.py
+++ b/tests/test_flask_import_guard.py
@@ -1,0 +1,56 @@
+"""Guard that Flask coupling stays confined to ``ztf_viewer/web.py`` (F4/F5 in
+``plans/001_async_dash.md``, reassigned to this branch by PR #626).
+
+``ztf_viewer/web.py`` is the seam a later PR (``aio-starlette-web``) will swap to Starlette
+without touching any call site. That only works if nothing else in the package imports
+``flask`` directly. This is a plain passing assertion, not an ``xfail``: after ``aio-deflask``
+it simply holds, and the point of the test is to catch a future reintroduction.
+"""
+
+import ast
+import pathlib
+
+import ztf_viewer
+
+PACKAGE_ROOT = pathlib.Path(ztf_viewer.__file__).parent
+ALLOWED_FILE = PACKAGE_ROOT / "web.py"
+
+
+def _source_files():
+    return sorted(PACKAGE_ROOT.rglob("*.py"))
+
+
+def _parse(path):
+    return ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
+
+
+def _rel(path):
+    return path.relative_to(PACKAGE_ROOT.parent).as_posix()
+
+
+def _flask_import_sites(path):
+    """``"path:line import ..."`` for every ``import flask``/``from flask import ...`` in `path`."""
+    sites = []
+    for node in ast.walk(_parse(path)):
+        if isinstance(node, ast.Import):
+            if any(alias.name == "flask" or alias.name.startswith("flask.") for alias in node.names):
+                sites.append(f"{_rel(path)}:{node.lineno} {ast.unparse(node)}")
+        elif isinstance(node, ast.ImportFrom):
+            if node.module == "flask" or (node.module is not None and node.module.startswith("flask.")):
+                sites.append(f"{_rel(path)}:{node.lineno} {ast.unparse(node)}")
+    return sites
+
+
+def test_flask_is_only_imported_by_web_py():
+    """No module under ``ztf_viewer/`` imports ``flask`` except ``ztf_viewer/web.py``."""
+    offenders = []
+    for path in _source_files():
+        if path == ALLOWED_FILE:
+            continue
+        offenders.extend(_flask_import_sites(path))
+    assert not offenders, "flask imported outside ztf_viewer/web.py:\n  " + "\n  ".join(offenders)
+
+
+def test_web_py_still_imports_flask():
+    """Sanity check that the scan itself works: web.py is expected to import flask."""
+    assert _flask_import_sites(ALLOWED_FILE), "ztf_viewer/web.py no longer imports flask — did the scan break?"

--- a/ztf_viewer/akb.py
+++ b/ztf_viewer/akb.py
@@ -2,7 +2,7 @@ import logging
 from urllib.parse import urljoin
 
 import cachetools
-import flask
+import dash
 import requests
 
 from ztf_viewer.exceptions import NotFound, UnAuthorized
@@ -34,7 +34,7 @@ class AKB:
 
     def _token_from_cookies(self):
         try:
-            return flask.request.cookies["akb_token"]
+            return dash.ctx.cookies["akb_token"]
         except KeyError:
             raise UnAuthorized
 

--- a/ztf_viewer/pages/favicon.py
+++ b/ztf_viewer/pages/favicon.py
@@ -1,8 +1,7 @@
-from flask import send_file
-
 from ztf_viewer.app import app
+from ztf_viewer.web import file_response
 
 
 @app.server.route("/favicon.ico")
 def favicon():
-    return send_file("static/img/logo.svg", mimetype="image/svg+xml")
+    return file_response("static/img/logo.svg", mimetype="image/svg+xml")

--- a/ztf_viewer/pages/figure.py
+++ b/ztf_viewer/pages/figure.py
@@ -4,7 +4,6 @@ from io import BytesIO
 import matplotlib
 import matplotlib.backends.backend_pgf
 import numpy as np
-from flask import Response, request
 from immutabledict import immutabledict
 from matplotlib.ticker import AutoMinorLocator
 
@@ -17,6 +16,7 @@ from ztf_viewer.util import (
     flip,
     parse_json_to_immutable,
 )
+from ztf_viewer.web import binary_response, error_response, query_args, request, request_body
 
 MIMES = {
     "pdf": "application/pdf",
@@ -24,32 +24,40 @@ MIMES = {
 }
 
 
+class UnknownFormat(Exception):
+    """Raised by `parse_figure_args_helper` when `format` isn't one of `MIMES`."""
+
+
 @app.server.route("/<dr>/figure/<int:oid>/folded/<int:period>")
 @app.server.route("/<dr>/figure/<int:oid>/folded/<float:period>")
 def response_figure_folded(dr, oid, period):
-    kwargs = parse_figure_args_helper(request.args)
-    offset = float(request.args.get("offset", 0.0))
+    args = query_args(request)
+    try:
+        kwargs = parse_figure_args_helper(args)
+    except UnknownFormat:
+        return error_response("", 404)
+    offset = float(args.get("offset", 0.0))
     fmt = kwargs.pop("fmt")
     caption = kwargs.pop("caption")
     title = kwargs.pop("title")
 
-    repeat = request.args.get("repeat", None)
+    repeat = args.get("repeat", None)
     if repeat is not None:
         repeat = int(repeat)
 
     data = get_folded_plot_data(oid, dr, period=period, offset=offset, **kwargs)
     img = plot_folded_data(oid, data, period=period, repeat=repeat, fmt=fmt, caption=caption, title=title)
 
-    return Response(
-        img,
-        mimetype=MIMES[fmt],
-        headers={"Content-disposition": f"attachment; filename={oid}.{fmt}"},
-    )
+    return binary_response(img, mimetype=MIMES[fmt], filename=f"{oid}.{fmt}")
 
 
 @app.server.route("/<dr>/figure/<int:oid>", methods=["GET", "POST"])
 def response_figure(dr, oid):
-    kwargs = parse_figure_args_helper(request.args, request.get_data(cache=False))
+    args = query_args(request)
+    try:
+        kwargs = parse_figure_args_helper(args, request_body(request))
+    except UnknownFormat:
+        return error_response("", 404)
     fmt = kwargs.pop("fmt")
     caption = kwargs.pop("caption")
     title = kwargs.pop("title")
@@ -57,11 +65,7 @@ def response_figure(dr, oid):
     data = get_plot_data(oid, dr, **kwargs)
     img = plot_data(oid, data, fmt=fmt, caption=caption, title=title)
 
-    return Response(
-        img,
-        mimetype=MIMES[fmt],
-        headers={"Content-disposition": f"attachment; filename={oid}.{fmt}"},
-    )
+    return binary_response(img, mimetype=MIMES[fmt], filename=f"{oid}.{fmt}")
 
 
 def parse_figure_args_helper(args, data=None):
@@ -77,7 +81,7 @@ def parse_figure_args_helper(args, data=None):
     caption = args.get("copyright", "yes") != "no"
 
     if fmt not in MIMES:
-        return "", 404
+        raise UnknownFormat(fmt)
 
     if data:
         data = parse_json_to_immutable(data)

--- a/ztf_viewer/pages/lc_csv.py
+++ b/ztf_viewer/pages/lc_csv.py
@@ -1,13 +1,13 @@
 from io import StringIO
 
 import pandas as pd
-from flask import Response, request
 
 from ztf_viewer.app import app
 from ztf_viewer.catalogs import find_ztf_oid
 from ztf_viewer.exceptions import NotFound, CatalogUnavailable
 from ztf_viewer.catalogs.ztf_ref import ztf_ref
 from ztf_viewer.catalogs.conesearch import ANTARES_QUERY, GAIA_DR3, PANSTARRS_DR2_QUERY
+from ztf_viewer.web import csv_response, error_response, query_args, request
 
 
 def get_csv(dr, oids, min_mjd=None, max_mjd=None):
@@ -44,50 +44,44 @@ def get_csv(dr, oids, min_mjd=None, max_mjd=None):
 
 @app.server.route("/<dr>/csv/<int:oid>")
 def response_csv(dr, oid):
+    args = query_args(request)
+
     try:
-        other_oids = set(map(int, request.args.getlist("other_oid")))
+        other_oids = set(map(int, args.getlist("other_oid")))
     except ValueError:
-        return "other_oid query parameter must be an integer", 400
+        return error_response("other_oid query parameter must be an integer", 400)
     oids = set.union({oid}, other_oids)
 
-    min_mjd = request.args.get("min_mjd", None)
+    min_mjd = args.get("min_mjd", None)
     if min_mjd is not None:
         try:
             min_mjd = float(min_mjd)
         except ValueError:
-            return "min_mjd query parameter must be a float", 400
+            return error_response("min_mjd query parameter must be a float", 400)
 
-    max_mjd = request.args.get("max_mjd", None)
+    max_mjd = args.get("max_mjd", None)
     if max_mjd is not None:
         try:
             max_mjd = float(max_mjd)
         except ValueError:
-            return "max_mjd query parameter must be a float", 400
+            return error_response("max_mjd query parameter must be a float", 400)
 
     try:
         csv = get_csv(dr, oids, min_mjd=min_mjd, max_mjd=max_mjd)
     except NotFound:
-        return "", 404
-    return Response(
-        csv,
-        mimetype="text/csv",
-        headers={"Content-disposition": f"attachment; filename={oid}.csv"},
-    )
+        return error_response("", 404)
+    return csv_response(csv, filename=f"{oid}.csv")
 
 
 def _lc_to_csv_response(lc, filename):
-    """Convert a list-of-dicts light curve to a CSV Flask Response."""
+    """Convert a list-of-dicts light curve to a CSV response."""
     if not lc:
-        return "", 404
+        return error_response("", 404)
     df = pd.DataFrame.from_records(lc)
     df.sort_values(by="mjd", inplace=True)
     string_io = StringIO()
     df.to_csv(string_io, index=False)
-    return Response(
-        string_io.getvalue(),
-        mimetype="text/csv",
-        headers={"Content-disposition": f"attachment; filename={filename}"},
-    )
+    return csv_response(string_io.getvalue(), filename=filename)
 
 
 @app.server.route("/panstarrs/csv/<int:obj_id>")
@@ -96,7 +90,7 @@ def response_panstarrs_csv(obj_id):
     try:
         lc = PANSTARRS_DR2_QUERY.light_curve(id=None, row={"objID": obj_id})
     except NotFound, CatalogUnavailable:
-        return "", 404
+        return error_response("", 404)
     return _lc_to_csv_response(lc, f"panstarrs_{obj_id}.csv")
 
 
@@ -106,7 +100,7 @@ def response_gaia_csv(source_id):
     try:
         lc = GAIA_DR3.light_curve(id=source_id)
     except NotFound, CatalogUnavailable:
-        return "", 404
+        return error_response("", 404)
     return _lc_to_csv_response(lc, f"gaia_{source_id}.csv")
 
 
@@ -116,5 +110,5 @@ def response_antares_csv(locus_id):
     try:
         lc = ANTARES_QUERY.light_curve(id=locus_id)
     except NotFound, CatalogUnavailable:
-        return "", 404
+        return error_response("", 404)
     return _lc_to_csv_response(lc, f"antares_{locus_id}.csv")

--- a/ztf_viewer/web.py
+++ b/ztf_viewer/web.py
@@ -1,0 +1,70 @@
+"""Backend-neutral request/response helpers for the plain HTTP routes.
+
+The routes in `ztf_viewer/pages/{figure,lc_csv,favicon}.py` are registered with
+`@app.server.route(...)` rather than as Dash callbacks, so they talk to the WSGI/ASGI backend
+directly instead of through `dash.ctx`. Today that backend is Flask, and this module is the
+*only* place allowed to `import flask` (enforced by a repo-wide grep / AST guard) so that a
+later swap to Starlette (`aio-starlette-web`) touches this one file instead of every route.
+
+Call sites should only use the names exported here, never `flask` directly.
+"""
+
+import flask
+
+#: The current request, re-exported so call sites never import `flask` themselves.
+request = flask.request
+
+
+class QueryArgs:
+    """Read-only, backend-neutral view over a request's query-string arguments."""
+
+    def __init__(self, args):
+        self._args = args
+
+    def get(self, key, default=None):
+        return self._args.get(key, default)
+
+    def getlist(self, key):
+        return list(self._args.getlist(key))
+
+
+def query_args(request) -> QueryArgs:  # noqa: F811 - shadows the module-level `request` on purpose
+    """Return the query-string arguments of `request` as a `QueryArgs`."""
+    return QueryArgs(request.args)
+
+
+def request_body(request) -> bytes:
+    """Return the raw body bytes of `request`."""
+    return request.get_data(cache=False)
+
+
+def file_response(path, mimetype):
+    """Serve a file from disk (e.g. the favicon)."""
+    return flask.send_file(path, mimetype=mimetype)
+
+
+def binary_response(data: bytes, mimetype: str, filename: str):
+    """A binary attachment response, e.g. a rendered PNG/PDF figure."""
+    return flask.Response(
+        data,
+        mimetype=mimetype,
+        headers={"Content-disposition": f"attachment; filename={filename}"},
+    )
+
+
+def csv_response(text: str, filename: str):
+    """A CSV attachment response."""
+    return flask.Response(
+        text,
+        mimetype="text/csv",
+        headers={"Content-disposition": f"attachment; filename={filename}"},
+    )
+
+
+def error_response(body: str, status: int):
+    """An error response, replacing the old `(body, status)` tuple pattern.
+
+    No explicit mimetype is set so this matches Flask's own default (`text/html`) for a bare
+    `(body, status)` return, keeping behaviour identical to what these routes did before.
+    """
+    return flask.Response(body, status=status)


### PR DESCRIPTION
## Summary

Implements `aio-deflask` from `plans/001_async_dash.md`'s Prep stack: removes every direct
`flask` import from application code and concentrates the remaining Flask coupling behind a
single backend-neutral module, `ztf_viewer/web.py`.

- **F4** — `ztf_viewer/akb.py`'s `_token_from_cookies` now reads `dash.ctx.cookies` instead of
  `flask.request.cookies`, and the `flask` import is gone. All callers run inside Dash
  callbacks (`login.py`, `tags.py`, `viewer.py`, `akb_table.py`), so `dash.ctx` always has a
  live request context there.
- **F5** — the six plain HTTP routes (`favicon.py`; `figure.py`'s `/​<dr>​/figure/<oid>` and its
  `/folded/<period>` variant; `lc_csv.py`'s four CSV routes) no longer import `flask` at all.
  They call helpers from the new `ztf_viewer/web.py` and return explicit response objects
  instead of the old `(body, status)` tuple convention.

### The `web.py` seam

`web.py` is the only file left that touches Flask (enforced today by
`grep -rn "^import flask\|from flask" ztf_viewer`, see the note below on the guard test). It
exports:

- `request` — the current request, re-exported so call sites never `import flask` themselves.
- `query_args(request)` / `request_body(request)` — read-only query-string access (`.get`,
  `.getlist`) and raw body bytes.
- `file_response`, `binary_response`, `csv_response`, `error_response` — explicit response
  constructors replacing `flask.send_file` / `flask.Response` / `(body, status)` tuples.

Everything is a thin wrapper over Flask today. The plan's `aio-starlette-web` PR is meant to
swap this one file's *implementation* to Starlette without touching any call site; the route
files only ever call these named functions, never a Flask type or method directly.

One deliberate addition beyond the four helpers the plan names explicitly: `error_response`
and `request_body`. The routes need somewhere to put the `(body, status)` replacement and the
POST-body read `figure.py` does for `response_figure`, and folding those into `query_args`
would have made it do two unrelated things.

`parse_figure_args_helper` used to `return "", 404` on an unrecognised `format`; it now raises
a local `UnknownFormat` exception that the two route handlers catch and turn into
`error_response("", 404)`, keeping the tuple-return convention out of a helper that isn't
itself a route.

`error_response` deliberately sets no explicit mimetype. Flask's own default for a bare
`(body, status)` return is `text/html; charset=utf-8`; matching that (rather than, say,
`text/plain`) was the only way to keep the 400/404 responses byte-for-byte identical, and I
checked it against a scratch Flask app before picking it.

### The flask-import guard test

`tests/test_migration_invariants.py`, which the original brief for this PR expected to contain
a strict-`xfail` guard to flip, doesn't exist on `master` — `aio-invariants` (#622) was
reopened as #626 and cut down to just the cache-decorator guards
(`tests/test_cache_decorator_guards.py`); its other guards, including the flask-import one,
described a *future* state and were reassigned to the PRs that actually establish each rule,
to be written there as plain passing assertions rather than xfails. The flask-import guard was
reassigned to this branch.

`tests/test_flask_import_guard.py` adds it here: an `ast` walk over `ztf_viewer/` (not a
regex, so string literals/comments/docstrings can't produce false hits) asserting no module
imports `flask` — covering both `import flask`/`import flask.wrappers` and
`from flask import ...` — except `ztf_viewer/web.py`. It's a plain passing assertion, not an
`xfail`: after this PR the rule simply holds, and the test exists to catch a future
reintroduction. It follows the conventions of `tests/test_cache_decorator_guards.py`, and
failures name the offending file and import line.

## Verification

Ran the app locally (`CACHE_TYPE=memory UNAVAILABLE_CATALOGS_CACHE_TYPE=memory`) and hit every
ported route against live upstreams:

- `GET /favicon.ico` — 200, correct SVG bytes, `Content-Disposition: inline; filename=logo.svg`.
- `GET /dr8/csv/<oid>` — 200, CSV body; also with `?other_oid=<n>` (multi-oid `getlist` path)
  and with a non-integer `other_oid` (400, `text/html` body, matching Flask's tuple default).
- `GET /dr8/figure/<oid>` — 200, valid PNG (`image/png`); with `?format=pdf` — 200, valid PDF
  via the LaTeX/PGF backend; with `?format=bogus` — 404.
- `GET /dr8/figure/<oid>/folded/<period>` — 200, valid PNG.

Compared headers/status codes against a run of the pre-change code path for the same requests.

Full suite: `pytest --basetemp=/tmp/pytest` — 221 passed, 0 failed (the `pytest-redis`
`UnixSocketTooLong` issue noted in `plans/001_async_dash.md` didn't reproduce once
`--basetemp` was set).

`pre-commit run` (trailing-whitespace, black, ruff, etc.) is clean on the changed files.

## Test plan

- [x] `pytest --basetemp=/tmp/pytest` — full suite green
- [x] `pre-commit run` on changed files — clean
- [x] Manual: favicon, CSV (with/without `other_oid`, bad `other_oid`), figure PNG, figure PDF,
      folded figure PNG, unknown `format` 404 — all checked against live upstreams
- [x] `grep -rn "^import flask\|from flask" ztf_viewer` — only `ztf_viewer/web.py`
- [x] `tests/test_flask_import_guard.py` — new AST-based guard, passes (not `xfail`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

