### PR TITLE
Update plan 001: prep-stack order and F13

### DIFF
--- a/plans/001_async_dash.md
+++ b/plans/001_async_dash.md
@@ -29,8 +29,8 @@ merged by its author, and "ready for review" is a reviewer's signal, not the aut
       Replaced by #632 `robust-upstream-tests`, which keeps the tests live but turns
       transport-level failures on `upstream`-marked tests into skips, so CI stops going red
       because Simbad is down. See the revised foundations section.
-- [ ] `aio-golden-http` — **re-scoped:** goldens over *our* outputs only, no upstream replay;
-      partial coverage is fine
+- [x] `aio-golden-http` — **re-scoped:** goldens over *our* outputs only, no upstream replay;
+      partial coverage is fine — #634 `golden-http`
 - [ ] `aio-golden-callbacks` — **re-scoped** the same way; likely a thin subset
 - [x] `aio-cache-spec` — cache contract tests (keys, TTL, pickle round-trip) — **found five defects in
       today's cache, see F12** — #627 `cache-contract-tests`
@@ -45,13 +45,13 @@ merged by its author, and "ready for review" is a reviewer's signal, not the aut
       - `@acache()` guards → `aio-cache-async`
 
 **Prep** — backend-neutral, on Flask
-- [ ] `aio-deflask` — `ctx.cookies` instead of `flask.request`; routes go through `web.py` — *in progress*
+- [x] `aio-deflask` — `ctx.cookies` instead of `flask.request`; routes go through `web.py` — #633 `deflask`
 - [x] `aio-cache-core` — key derivation + value codec, no backend — #628 `cache-core`
 - [x] `aio-cache-sync` — reimplement sync `cache()`, drop `redis_lru` — #629 `cache-sync`
+- [ ] `aio-pytest-asyncio` — async test support — **moved ahead of `aio-cache-async`**, see below
 - [ ] `aio-cache-async` — add `acache()`, key-compatible with the sync one
 - [ ] `aio-cache-flight` — single-flight dedupe
 - [ ] `aio-ttlset` — async `unavailable_catalogs`
-- [ ] `aio-pytest-asyncio` — async test support
 
 **Async shell** — last stack on Flask
 - [ ] `aio-shim` — every callback becomes a coroutine (registration-layer wrap); adds the
@@ -403,10 +403,10 @@ master
       └─ aio-deflask          drop direct flask coupling
          └─ aio-cache-core     keying + codec, no backend
             └─ aio-cache-sync    reimplement sync cache, drop redis_lru
-               └─ aio-cache-async   add acache()
-                  └─ aio-cache-flight  single-flight
-                     └─ aio-ttlset        async unavailable_catalogs
-                        └─ aio-pytest-asyncio
+               └─ aio-pytest-asyncio  async test support (moved up: acache() needs it)
+                  └─ aio-cache-async   add acache()
+                     └─ aio-cache-flight  single-flight
+                        └─ aio-ttlset        async unavailable_catalogs
                            └─ aio-shim          all callbacks become coroutines
                               └─ aio-loop-registry  per-loop resources
                                  ├─ aio-pilots ⇢ native async pilots (optional)
@@ -822,6 +822,25 @@ the shell/flip stack stays small enough to review.
   produce false hits. This is the PR that makes the rule true, so it is the PR that owns the
   guard (see the no-tests-in-advance rule).
 
+### `aio-pytest-asyncio` — Async test support *(moved up: it is a prerequisite, not a follow-up)*
+Originally listed last in this stack. That was an ordering mistake: `aio-cache-async` is the
+first PR in the plan that adds a coroutine, so it is also the first that cannot be tested
+without async test support. Nothing here depends on the cache work, so moving it to the front
+of the remaining prep chain costs nothing and stops `aio-cache-async` from having to carry
+test-infrastructure changes alongside a cache rewrite.
+Route coverage lives in `aio-golden-http`; this PR only adds what async tests need.
+- Add `pytest-asyncio` to the `tests` dependency group; `asyncio_mode = "auto"`.
+- The `httpx.MockTransport` adapter this PR originally carried is dropped with the replay layer.
+  What replaces it is smaller: make sure #632's skip-on-transport-error path also fires for
+  async `upstream`-marked tests (the `pytest_runtest_makereport` hook is transport-agnostic, but
+  `httpx` raises a different exception hierarchy than `requests`, so the classifier needs the
+  `httpx` exceptions added — do it here, before any async upstream test exists). `httpx` is not
+  a dependency until `aio-fastapi-app`, which is fine: `tests/conftest.py` already imports
+  third-party transport exceptions lazily and skips the ones that are not installed.
+- **Accept:** an async test and a sync test asserting identical results against the same
+  upstream; an injected `httpx` transport error on an `upstream`-marked async test skips rather
+  than fails.
+
 ### the cache sub-stack — Async-capable cache layer *(its own stack of four PRs)*
 The cache sits under all 19 `@cache()` sites and under every catalog query; it is the one
 piece of shared infrastructure the whole migration rests on, so it gets its own reviewable
@@ -882,18 +901,6 @@ sounds: method-site entries are already per-process and per-boot today.
   (`AsyncRedisTTLStringSet`), keep `LocalTTLSet` usable from async (it's pure in-memory).
 - `ztf_viewer/catalogs/unavailable_catalogs.py` gains an async accessor.
 - **Accept:** mirrored versions of the three existing `test_ttl_set_*` suites.
-
-### `aio-pytest-asyncio` — Async test support
-Route coverage now lives in `aio-golden-http`; this PR only adds what async tests need.
-- Add `pytest-asyncio` to the `tests` dependency group; `asyncio_mode = "auto"`.
-- The `httpx.MockTransport` adapter this PR originally carried is dropped with the replay layer.
-  What replaces it is smaller: make sure #632's skip-on-transport-error path also fires for
-  async `upstream`-marked tests (the `pytest_runtest_makereport` hook is transport-agnostic, but
-  `httpx` raises a different exception hierarchy than `requests`, so the classifier needs the
-  `httpx` exceptions added — do it here, before any async upstream test exists).
-- **Accept:** an async test and a sync test asserting identical results against the same
-  upstream; an injected `httpx` transport error on an `upstream`-marked async test skips rather
-  than fails.
 
 ---
 

--- a/plans/001_async_dash.md
+++ b/plans/001_async_dash.md
@@ -1,7 +1,7 @@
 # 001 — Porting the ZTF Viewer to async (Dash 4 FastAPI backend)
 
-Status: in progress · foundations landed, prep started
-Baseline: `master` after `782bc7a`
+Status: in progress · foundations landed except the two optional test items, prep half-landed
+Baseline: `master` after `994874e`
 Now running: Flask backend, Python 3.14
 
 Note on names: branches and PRs drop the `aio-` prefix the plan uses (`aio-py314` shipped as
@@ -366,6 +366,17 @@ Both are now covered by the spec. Separately, `immutabledefaultdict` caches its 
 to its original content — latent today because both backends behave identically and the app
 rebuilds these mappings per callback, but a hazard if `aio-cache-core` starts keying on content
 instead of `hash()`.
+
+**F13 — `web.py` is backend-neutral except for one name: `request`.** *(Found reviewing what
+`aio-deflask` actually landed, #633.)* The helpers came out as specified plus three more —
+`request_body`, `error_response` and a `QueryArgs` view — and all of them take the request as an
+argument, so they really do swap in one file. `ztf_viewer/web.py:15` also re-exports
+`request = flask.request`, and `figure.py:34,56,58` and `lc_csv.py:47` use it **ambiently**, as a
+module-level import. Starlette has no ambient request: the handler receives it. So the claim in
+`aio-starlette-web` that `figure.py`/`lc_csv.py` need no edits holds for every helper *except*
+this one. Those four call sites must take `request` as a parameter — cheap, but it must happen
+in the same atomic sub-stack, and it is most naturally done in `aio-routes`, which is already
+rewriting those handler signatures for path parameters.
 
 ---
 
@@ -809,6 +820,9 @@ Everything here is behaviour-preserving and independently valuable. Ship it firs
 the shell/flip stack stays small enough to review.
 
 ### `aio-deflask` — Remove direct Flask coupling from app code
+*(Landed — #633, branch `deflask`. `web.py` also grew `request_body`, `error_response` and a
+`QueryArgs` view; the one thing that did not come out backend-neutral is the ambient `request`
+re-export, see F13.)*
 - `ztf_viewer/akb.py:37`: `flask.request.cookies` → `dash.ctx.cookies` (F4); drop the
   `flask` import.
 - Introduce `ztf_viewer/web.py` with backend-neutral helpers used by the routes:
@@ -953,7 +967,7 @@ This is the PR that dissolves the F1 constraint.
   it: that `inspect.iscoroutinefunction` sees through nested `functools.partial`, and an
   anti-vacuity check that `callback_map` is populated at all. Exclude clientside callbacks
   explicitly or the guard `KeyError`s instead of failing cleanly. Also: no `RuntimeWarning` from `dash/_callback.py:944`;
-  `aio-pytest-asyncio` smoke tests green; site behaves identically on Flask.
+  `aio-golden-http` green; site behaves identically on Flask.
 - **Note:** on Flask this is a small *pessimization* (a per-request event loop plus a thread
   hop, versus just a thread). It is deliberately temporary and unmeasurable at our traffic;
   if it shows up, shorten the gap between `aio-shim` and `aio-uvicorn`.
@@ -994,7 +1008,9 @@ rollback is a one-line revert.
 
 ### `aio-starlette-web` — `web.py` → Starlette
 - Swap `ztf_viewer/web.py` internals (built in `aio-deflask`) to Starlette `Response` / `FileResponse` /
-  `PlainTextResponse`, so `figure.py` / `lc_csv.py` / `favicon.py` need no edits here.
+  `PlainTextResponse`. Every helper takes its request as an argument, so `figure.py` /
+  `lc_csv.py` / `favicon.py` need no edits here — **except for the ambient `request` re-export
+  (F13)**, which has no Starlette equivalent and is dealt with in `aio-routes`.
 - **Accept:** unit tests on the helpers; this is the PR that makes the stack atomic — Flask
   is broken from here until `aio-uvicorn`.
 
@@ -1005,10 +1021,13 @@ rollback is a one-line revert.
   route pair (`ztf_viewer/pages/figure.py:27-28`) collapses to a single `float` route — keep
   an int-first route only if a client depends on the distinction.
 - `request.args.getlist("other_oid")` → `request.query_params.getlist(...)` (or
-  `list[str] = Query(...)`).
+  `list[str] = Query(...)`), inside `web.py`'s `QueryArgs`.
+- **Take `request` as a handler parameter** at `figure.py:34,56,58` and `lc_csv.py:47`, dropping
+  the ambient `from ztf_viewer.web import request` (F13). Four call sites.
 - Keep these handlers **sync** `def` — FastAPI threadpools them (F5). Making them async is
   the process-pool stack's job, after the CPU work moves off-loop.
-- **Accept:** `aio-pytest-asyncio` smoke tests pass unchanged; figure PNG/PDF and all four CSV endpoints
+- **Accept:** `aio-golden-http` passes unchanged — that is its stated acceptance criterion, so a
+  route port that changes a status, content type or disposition fails CI; figure PNG/PDF and all four CSV endpoints
   byte-compare against the Flask build for a fixed OID.
 
 ### `aio-uvicorn` — Entrypoint, deployment, and the default flip
@@ -1230,7 +1249,7 @@ Measure before moving; each may be cheaper to leave on a thread:
 | Golden snapshots recorded through a colliding memory cache, baking a wrong value in as the spec (F12.1) | Record `aio-golden-callbacks` snapshots with caching disabled, or after `aio-cache-sync` fixes the shared keyspace — not merely with the cache cleared between tests |
 | The cache rewrite silently preserves one of today's defects (F12) | The five defects are recorded as named `xfail`s in `aio-cache-spec`; `aio-cache-sync`'s accept criterion is that F12.1–F12.4 turn XPASS, so preserving a bug fails the criterion rather than passing quietly |
 | `aio-shim` misses the 19 loop-registered `set_table` callbacks (F1a′) | The invariant asserts over all 57 registrations, not the 39 source sites, so a missed loop fails CI |
-| Static assets 404 after the flip (F2) | `aio-pytest-asyncio` smoke tests assert `/static/js9/js9.min.js` and `/static/img/logo.svg` return 200 |
+| Static assets 404 after the flip (F2) | `aio-golden-http` asserts `/static/js9/js9.min.js` and `/static/img/logo.svg` return 200 — landed, #634 |
 | Duplicate 148 MiB dust-map allocation under the new concurrency (F9a) | Lock the lazy init and warm at startup (`aio-dustmaps`); test that concurrent first-callers allocate once |
 | Concurrent fan-out hammers upstreams that previously saw serialized traffic | Per-upstream `asyncio.Semaphore` (the offload pair) plus the existing `unavailable_catalogs` circuit breaker; keep an eye on Vizier/Simbad rate limits |
 | Cache stampede amplified by concurrency | Single-flight in the cache sub-stack — this becomes load-bearing, not a nicety |
@@ -1239,6 +1258,7 @@ Measure before moving; each may be cheaper to leave on a thread:
 | Process pool memory blowup | `aio-procpool` sizing; dustmaps explicitly excluded (F9); compare container RSS before/after |
 | Redis client split-brain (sync `StrictRedis` in `ttl_set.py`, async elsewhere) | `aio-ttlset` lands the async set before anything async touches it; one connection pool per worker |
 | Loop-affine client reused across Flask's per-request loops (F1c) | `aio-loop-registry`'s per-loop registry, with a test that runs two successive `asyncio.run` calls |
+| `aio-starlette-web` is assumed to be a one-file swap, but the ambient `request` re-export has no Starlette equivalent (F13) | The four call sites are named in `aio-routes`, inside the same atomic sub-stack; `aio-golden-http` fails if any of those routes changes shape |
 | Flip passes CI but breaks `master.ztf.snad.space` via the hardcoded entrypoint (F11) | `aio-uvicorn` changes `.ci/docker-compose.yml.tmpl` alongside the Dockerfile; verified on the PR preview before merge |
 | `aio-dustmaps` cannot be validated on dev (`NO_LOCAL_3D_DUST_MAP=1`, F11) | Cover the warm-up with tests rather than the dev server; get RSS numbers from a prod-like local run |
 | Async code developed on a different Python than it ships on (F10) | `aio-py314` upgrades production to 3.14 first, before any goldens are recorded or async is written |
@@ -1262,8 +1282,8 @@ Tick these off as they are answered.
    invariant holds it should be irrelevant — worth asserting.
 6. ~~**Does the foundations stack block the start, or run alongside?**~~ **Answered: it runs
    alongside.** The replay layer that was the long pole is gone, so nothing in foundations blocks
-   anything else. `aio-golden-http`, `aio-golden-callbacks` and `aio-bench` are now independent
-   and can land at any point; the prep stack started ahead of them.
+   anything else. `aio-golden-http` landed alongside the prep stack (#634); `aio-golden-callbacks`
+   and `aio-bench` are independent and can still land at any point.
 7. ~~**Python 3.14 upgrade — does the dependency set cooperate?**~~ **Answered: yes** — #625
    merged, production is on 3.14.
 8. ~~**Should the cache key on `self`?**~~ **Answered in `aio-cache-core` (#628): key on the


### PR DESCRIPTION
Two commits against `plans/001_async_dash.md` only — no code changes.

## 1. Reorder: async test support before `acache()`

`aio-cache-async` is the first PR in the plan that adds a coroutine, so it is also the first
that cannot be tested without `pytest-asyncio` — which the plan scheduled two PRs later, after
`aio-cache-flight` and `aio-ttlset`. The Progress list and the branch-structure diagram agreed
with each other, so this is a real ordering problem rather than a typo between the two.

Nothing in the async test support depends on the cache work, so `aio-pytest-asyncio` moves to
the front of the remaining prep chain. That also keeps a cache rewrite from having to carry
test-infrastructure changes.

Also marks #633 (`aio-deflask`) and #634 (`aio-golden-http`) merged in the Progress list.

## 2. Refresh against what has actually landed

**New finding F13 — `web.py` is backend-neutral except for one name.** The plan says
`aio-starlette-web` swaps `web.py`'s internals so that `figure.py` / `lc_csv.py` / `favicon.py`
need no edits. That holds for eight of the nine names `aio-deflask` landed, but
`ztf_viewer/web.py:15` re-exports `request = flask.request` — Flask's *ambient* request proxy —
and it is used as a module-level import at `figure.py:34,56,58` and `lc_csv.py:47`. Starlette
has no ambient request; the handler receives it. Those four call sites must take `request` as a
parameter, inside the same atomic flip sub-stack. Assigned to `aio-routes`, which is already
rewriting those handler signatures for path parameters. Risk-table row added.

Bookkeeping in the same commit:

- Three references to `aio-pytest-asyncio` carrying route/smoke coverage (in `aio-shim`,
  `aio-routes`, and the F2 risk row) now point at `aio-golden-http`, which owns that coverage
  since the re-scope and has merged. Verified against `tests/test_golden_http.py`, which does
  assert `/static/img/logo.svg` and `/static/js9/js9.min.js`.
- `aio-deflask` marked landed, noting the helpers it grew beyond the four the plan specified
  (`request_body`, `error_response`, the `QueryArgs` view).
- Status/baseline header moved from `782bc7a` to `994874e`.
- Open question 6 notes that `aio-golden-http` landed; `aio-golden-callbacks` and `aio-bench`
  are the two foundations items still open.

Bottom of the remaining prep stack: `aio-pytest-asyncio`, `aio-cache-async`, `aio-cache-flight`
and `aio-ttlset` follow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)