### PR TITLE
Refuse uncacheable callables at decoration time (F14)

### DIFF
--- a/plans/001_async_dash.md
+++ b/plans/001_async_dash.md
@@ -367,6 +367,22 @@ to its original content — latent today because both backends behave identicall
 rebuilds these mappings per callback, but a hazard if `aio-cache-core` starts keying on content
 instead of `hash()`.
 
+**F14 — the cache key cannot identify every callable, and failed unsafely in two ways.**
+*(Found while reviewing `aio-cache-async`; both defects predate it, in `cache_core`'s
+`function_id`.)* The key is `module.qualname` plus the encoded arguments, and `function_id` read
+that as `getattr(func, "__qualname__", func.__name__)`. Python evaluates the default eagerly, so
+`__name__` was required even when `__qualname__` was present — a callable carrying one but not
+the other raised `AttributeError` from inside the wrapper, on the first *call*, which is exactly
+what the decorator's `UncacheableArgument` bypass exists to prevent. Worse, a `functools.partial`
+labelled with both attributes passed the check and then keyed on the wrapped function alone: its
+bound arguments live in `partial.args`, which key derivation never sees, so two partials of one
+function shared a single entry and returned each other's values. **Decision: refuse both at
+decoration time** — partials by type (labelled or not), anything else by missing attribute — so a
+bad `@cache()` site fails when its module is imported. Supporting partials by unwrapping them was
+rejected: it fixes the name and leaves the wrong-value defect standing. No call site is affected
+today; the risk grows as `aio-shim` introduces partial wrapping and the async-I/O stack converts
+cached methods.
+
 **F13 — `web.py` is backend-neutral except for one name: `request`.** *(Found reviewing what
 `aio-deflask` actually landed, #633.)* The helpers came out as specified plus three more —
 `request_body`, `error_response` and a `QueryArgs` view — and all of them take the request as an

--- a/tests/test_cache_name_guard.py
+++ b/tests/test_cache_name_guard.py
@@ -1,0 +1,117 @@
+"""Decoration-time guard against callables ``function_id`` cannot key.
+
+``function_id`` used to evaluate ``func.__name__`` eagerly even when ``__qualname__`` was
+present, raising ``AttributeError`` on first call for anything missing it (defect 1); and a
+``functools.partial`` labelled with both attributes passed silently but keyed on the wrapped
+function only, dropping the bound arguments from the key and returning another partial's cached
+value (defect 2). Both are now refused at decoration time with a ``TypeError``.
+"""
+
+import functools
+
+import pytest
+
+from ztf_viewer import cache as cache_module
+from ztf_viewer.cache.core import function_id
+
+
+@pytest.fixture
+def cache(monkeypatch):
+    monkeypatch.setattr(cache_module, "CACHE_TYPE", "memory", raising=False)
+    from ztf_viewer import config
+
+    monkeypatch.setattr(config, "CACHE_TYPE", "memory", raising=False)
+    return cache_module._get_cache()
+
+
+def body(a, b):
+    return a + b
+
+
+def test_bare_partial_is_refused_at_decoration_time(cache):
+    p = functools.partial(body, 1)
+    with pytest.raises(TypeError, match="partial"):
+        cache()(p)
+
+
+def test_labelled_partial_is_still_refused(cache):
+    """Defect 2: labelled, a partial passes the attribute check but would still collide —
+    the key never sees the bound argument, so two partials of the same function would share
+    one cache entry and return each other's value."""
+    p1 = functools.partial(body, 1)
+    p2 = functools.partial(body, 100)
+    for p in (p1, p2):
+        p.__name__ = p.__qualname__ = "body"
+
+    with pytest.raises(TypeError, match="partial"):
+        cache()(p1)
+    with pytest.raises(TypeError, match="partial"):
+        cache()(p2)
+
+
+def test_qualname_without_name_is_refused(cache):
+    """Defect 1: today this raises AttributeError from inside the wrapper on first call."""
+
+    class Fake:
+        __qualname__ = "Fake"
+        __module__ = "tests.test_cache_name_guard"
+
+        def __call__(self, *a, **k):
+            return None
+
+    fake = Fake()
+    assert not hasattr(fake, "__name__")
+
+    with pytest.raises(TypeError):
+        function_id(fake)
+    with pytest.raises(TypeError):
+        cache()(fake)
+
+
+def test_ordinary_function_is_accepted_and_caches(cache):
+    calls = []
+
+    @cache()
+    def plain(x):
+        calls.append(x)
+        return x * 2
+
+    assert plain(3) == 6
+    assert plain(3) == 6
+    assert calls == [3]
+
+
+def test_method_is_accepted_and_caches(cache):
+    calls = []
+
+    class Thing:
+        @cache()
+        def method(self, x):
+            calls.append(x)
+            return x * 2
+
+    t = Thing()
+    assert t.method(3) == 6
+    assert t.method(3) == 6
+    assert calls == [3]
+
+
+def test_functools_wraps_decorated_function_is_accepted(cache):
+    def outer(func):
+        @functools.wraps(func)
+        def inner(*args, **kwargs):
+            return func(*args, **kwargs)
+
+        return inner
+
+    calls = []
+
+    @cache()
+    @outer
+    def wrapped(x):
+        calls.append(x)
+        return x * 2
+
+    assert wrapped(3) == 6
+    assert wrapped(3) == 6
+    assert calls == [3]

--- a/ztf_viewer/cache/core.py
+++ b/ztf_viewer/cache/core.py
@@ -24,6 +24,7 @@ never read each other's entries.
 ``self`` is deliberately encoded by neither content nor identity — see ``encode_self``.
 """
 
+import functools
 import pickle
 from collections.abc import Mapping, Set
 from hashlib import blake2b
@@ -162,8 +163,25 @@ def encode_arguments(args=(), kwargs=None, *, method_class: type | None = None) 
 
 
 def function_id(func) -> str:
-    """``module.qualname`` — the identity of a ``@cache()`` site."""
-    return f"{getattr(func, '__module__', None)}.{getattr(func, '__qualname__', func.__name__)}"
+    """``module.qualname`` — the identity of a ``@cache()`` site.
+
+    Raises ``TypeError`` for anything it cannot identify that way.
+    """
+    if isinstance(func, functools.partial):
+        raise TypeError(
+            f"cache() cannot key {func!r}: a functools.partial's bound arguments are invisible "
+            "to key derivation, so two partials of the same function would share one cache "
+            "entry. Decorate the underlying function instead and pass those arguments at the "
+            "call site."
+        )
+    module = getattr(func, "__module__", None)
+    name = getattr(func, "__qualname__", None)
+    if name is None or not hasattr(func, "__name__"):
+        raise TypeError(
+            f"cache() cannot key {func!r}: the key is derived from module.qualname, which "
+            "requires both __name__ and __qualname__, and this callable is missing one."
+        )
+    return f"{module}.{name}"
 
 
 def self_class(func, wrapper, args) -> type | None:

--- a/ztf_viewer/cache/decorator.py
+++ b/ztf_viewer/cache/decorator.py
@@ -18,6 +18,7 @@ from ztf_viewer.cache.core import (
     cache_key_for_call,
     decode_value,
     encode_value,
+    function_id,
 )
 
 
@@ -26,6 +27,9 @@ def make_cache(backend):
 
     def cache():
         def decorator(func):
+            # Fail at import time, not on first call.
+            function_id(func)
+
             if inspect.iscoroutinefunction(func):
                 raise TypeError(
                     f"cache() cannot wrap the coroutine function {func.__qualname__}: it would cache the "


### PR DESCRIPTION
Not part of stack #639 — this fixes `ztf_viewer/cache/core.py`, merged in #628, and shouldn't
ride inside a PR about something else. Found while reviewing #637.

## Two defects, both predating the async work

**1. The eager default.** `function_id()` read

```python
getattr(func, "__qualname__", func.__name__)
```

Python evaluates arguments before the call, so `__name__` was required *even when
`__qualname__` was present*. A callable carrying one but not the other raised `AttributeError`
— and since `cache_key_for_call` runs inside the wrapper, it surfaced on the first **call**, as
an error escaping the cache. That is exactly what the decorator's `UncacheableArgument` bypass
exists to prevent: a cache must never turn a legal call into an error.

**2. Silent wrong values.** Label a `functools.partial` to get past defect 1 and the cache
returns another partial's value:

```python
p1 = functools.partial(body, 1)      # body(1, b)
p2 = functools.partial(body, 100)    # body(100, b)
for p in (p1, p2):
    p.__name__ = p.__qualname__ = "body"

w1, w2 = cache()(p1), cache()(p2)
w1(5)   # 6    correct
w2(5)   # 6    WRONG — should be 105; the body ran only once
```

The key is `module.qualname` plus the arguments the *wrapper* receives — `(5,)`. The bound `1`
and `100` live in `partial.args`, which key derivation never sees, so both partials are one
entry. Same family as F12.2 (kwarg names ignored), via a path the original audit didn't cover.

## The fix: refuse, at decoration time

`function_id()` now raises `TypeError`, and `make_cache`'s `decorator()` calls it immediately, so
a bad `@cache()` site fails when its module is imported rather than on a first cache miss.

- **`functools.partial` is refused by type, checked before the attribute check** — a *labelled*
  partial passes the attribute test and is precisely defect 2. The message says why and points at
  decorating the underlying function instead.
- Anything else missing `__name__` or `__qualname__` is refused with a message naming the
  requirement.

**Supporting partials by unwrapping them was considered and rejected**: it fixes the name and
leaves defect 2 standing, since the bound arguments still wouldn't reach the key. Making them
work properly would mean folding `partial.args`/`keywords` into the encoded arguments — worth
doing the day something needs it, not on spec.

## Coverage

`tests/test_cache_name_guard.py` — bare partial refused; **labelled** partial refused (defect 2,
with a comment on what it would otherwise return); `__qualname__`-without-`__name__` refused,
tested both through `function_id()` and through `cache()` (this one raises `AttributeError`
today, so it proves the fix); and plain functions, methods and `functools.wraps`-decorated
functions still accepted and still caching.

None of the existing `@cache()` sites fails the new check.

Plan 001 records this as **F14**, alongside the other cache findings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)