### PR TITLE
Stop citing the migration plan from source and test code

### DIFF
--- a/tests/test_cache_contract.py
+++ b/tests/test_cache_contract.py
@@ -1,37 +1,16 @@
 """Contract tests for ``ztf_viewer.cache.cache()``.
 
-This file is the *spec* for the cache sub-stack rewrite (plan 001, ``aio-cache-spec``):
-it is written against today's implementation (``redis_lru`` / ``cachetools.cached``) and the
-rewrite (``aio-cache-core`` → ``aio-cache-sync`` → ``aio-cache-async`` → ``aio-cache-flight``)
-must keep it green **without editing a single line here**.
+Black-box spec through the public ``cache()`` decorator only: no test asserts a literal key
+string, only observable hit/miss behavior via call counts on the wrapped function. The only
+implementation seam relied on is ``ztf_viewer.cache._get_cache()`` plus the module-level
+``CACHE_TYPE`` / ``TTL`` names (also used by ``tests/conftest.py``); the Redis client
+constructor is stubbed to point at the ``pytest-redis`` server.
 
-Consequences for how these tests are written:
+The Redis half needs ``pytest-redis``; on macOS the default temp dir makes the fixture's
+unix socket path too long, so run pytest with ``--basetemp=/tmp/pytest``.
 
-* Everything is black-box, through the public ``cache()`` decorator.  Nothing here knows about
-  ``redis_lru``, about ``cachetools``, or about the key format.  In particular no test asserts a
-  literal key string: the key *scheme* changes at ``aio-cache-sync`` (existing Redis entries
-  become unreachable — an accepted cold start).  What is asserted instead are the observable
-  properties a key scheme must have: equal arguments hit, different arguments miss, different
-  functions do not collide.
-* "Hit" and "miss" are observed by counting calls of the wrapped function, never by inspecting
-  the backing store.
-* The only implementation seam this file relies on is the ability to build a decorator with a
-  chosen backend and TTL, via ``ztf_viewer.cache._get_cache()`` plus the module-level
-  ``CACHE_TYPE`` / ``TTL`` names (the same seam ``tests/conftest.py`` already uses).  The rewrite
-  must keep those three names working; everything else about the module is free to change.  For
-  the Redis backend the client constructor is stubbed out to point at the ``pytest-redis``
-  server, which is the one place a rewrite might need a different stub (never a different
-  assertion).
-* The Redis half needs ``pytest-redis``, as in ``tests/test_ttl_set_redis_ttl_set.py``.  On macOS
-  the default temporary directory makes the fixture's unix socket path too long, so run pytest
-  with ``--basetemp=/tmp/pytest`` locally (this is pre-existing, and applies to the ``ttl_set``
-  tests too).
-* Seven of these tests **fail on today's implementation**, each marked with a ``FAILS TODAY``
-  comment naming the branch that fixes it (``cache-sync``, except the ``self``-keying one, which
-  is ``cache-core``).  They are plain failures rather than ``xfail`` on purpose: a known defect
-  recorded as ``xfail`` never turns CI red, so nothing forces the fix except someone remembering
-  to look.  The consequence is that this file is red until the fix lands on top of it; it is
-  meant to be read as the bottom of that stack.
+Some tests are marked ``FAILS TODAY`` and are expected to fail against today's
+implementation — plain failures rather than ``xfail``, so they can't silently rot.
 """
 
 import time

--- a/tests/test_cache_core.py
+++ b/tests/test_cache_core.py
@@ -1,9 +1,8 @@
-"""Unit tests for the backend-independent cache core (plan 001, ``aio-cache-core``).
+"""Unit tests for the backend-independent cache core.
 
 ``tests/test_cache_contract.py`` is the black-box spec for the ``@cache()`` decorator and says
-nothing about key format; this file tests the pure functions underneath it directly — the
-properties the decorator relies on but cannot observe, above all that a key is a deterministic
-function of the call rather than of ``hash()``.
+nothing about key format; this file tests the key-building functions directly, above all that
+a key is a deterministic function of the call rather than of ``hash()``.
 """
 
 import os
@@ -65,7 +64,7 @@ def test_key_contains_the_function_id():
 
 
 def test_distinct_functions_get_distinct_keys():
-    """Plan 001, F12.1: the function is part of the key on every backend."""
+    """The function is part of the key on every backend."""
     assert cache_key(some_function, (1, "dr23")) != cache_key(another_function, (1, "dr23"))
 
 
@@ -119,7 +118,6 @@ def test_key_is_a_deterministic_function_of_the_arguments():
 
 
 def test_kwarg_names_are_part_of_the_key():
-    """Plan 001, F12.2."""
     assert key(min_mjd=58000.0) != key(max_mjd=58000.0)
 
 
@@ -199,7 +197,7 @@ def test_immutabledefaultdict_missing_key_lookup_does_not_change_the_key():
 
 
 def test_unhashable_arguments_are_keyed_rather_than_rejected():
-    """Plan 001, F12.4: neither backend may raise, and content is better than a bypass."""
+    """Neither backend may raise, and content is better than a bypass."""
     assert key([1, 2, 3]) == key([1, 2, 3])
     assert key([1, 2, 3]) != key([1, 2])
     assert key({"a": [1]}) == key({"a": [1]})
@@ -297,7 +295,7 @@ def test_self_class_ignores_a_staticmethod():
 
 
 def test_method_key_ignores_instance_identity_but_not_the_class():
-    """Plan 001, F12.5 decision: cached methods key on the class."""
+    """Cached methods key on the class."""
     first = Recorder(session=object())
     second = Recorder(session=object())
     other = OtherRecorder(session=object())

--- a/tests/test_cache_decorator_guards.py
+++ b/tests/test_cache_decorator_guards.py
@@ -1,17 +1,13 @@
-"""Guards on how the cache decorators are applied (F3 in ``plans/001_async_dash.md``).
+"""Guards on how the cache decorators are applied.
 
-Both tests describe what is *supposed* to hold today, not a future state.
+``@cache()`` applied to an ``async def`` stores the coroutine object instead of the result, so
+a second hit returns an already-awaited coroutine, which raises instead of returning the
+cached value. The first test asserts nothing in the codebase does this; the second asserts the
+decorator refuses it outright.
 
-``@cache()`` wraps a function and stores its return value.  Applied to an
-``async def`` it stores the **coroutine object** instead of the result, so the
-second hit returns a coroutine that has already been awaited — which raises
-rather than returning the cached value.  Nothing in the codebase does this yet,
-and the first test makes sure it stays that way; the second asserts that the
-decorator refuses outright, so the mistake cannot reach a review at all.
-
-``test_sync_cache_rejects_a_coroutine_function`` fails on today's
-``redis_lru``/``cachetools`` implementation, which accepts the coroutine
-silently.  That is a real defect, fixed by the ``cache-sync`` branch.
+``test_sync_cache_rejects_a_coroutine_function`` fails on today's ``redis_lru``/``cachetools``
+implementation, which accepts the coroutine silently — a real defect, fixed by the
+``cache-sync`` branch.
 """
 
 import ast

--- a/tests/test_cache_sync.py
+++ b/tests/test_cache_sync.py
@@ -1,8 +1,8 @@
-"""Decorator-level tests for the sync ``cache()`` (plan 001, ``aio-cache-sync``).
+"""Decorator-level tests for the sync ``cache()``.
 
 ``tests/test_cache_contract.py`` is the spec and covers hit/miss/TTL/value fidelity on both
-backends.  This file covers what the spec deliberately does not: the guards and the escape
-hatches that are properties of *this* implementation rather than of any cache.
+backends. This file covers what the spec deliberately does not: guards and escape hatches
+specific to this implementation rather than to any cache.
 """
 
 import pytest
@@ -20,7 +20,7 @@ def cache(monkeypatch):
 
 
 def test_cache_rejects_a_coroutine_function(cache):
-    """Plan 001, F3: caching a coroutine object hands out an exhausted awaitable."""
+    """Caching a coroutine object would hand out an exhausted awaitable."""
 
     async def coro():
         return 1

--- a/tests/test_flask_import_guard.py
+++ b/tests/test_flask_import_guard.py
@@ -1,10 +1,9 @@
-"""Guard that Flask coupling stays confined to ``ztf_viewer/web.py`` (F4/F5 in
-``plans/001_async_dash.md``, reassigned to this branch by PR #626).
+"""Guard that Flask coupling stays confined to ``ztf_viewer/web.py``.
 
-``ztf_viewer/web.py`` is the seam a later PR (``aio-starlette-web``) will swap to Starlette
-without touching any call site. That only works if nothing else in the package imports
-``flask`` directly. This is a plain passing assertion, not an ``xfail``: after ``aio-deflask``
-it simply holds, and the point of the test is to catch a future reintroduction.
+``ztf_viewer/web.py`` is the seam a later PR can swap to Starlette without touching any call
+site — that only works if nothing else in the package imports ``flask`` directly. This is a
+plain passing assertion, not an ``xfail``: it holds today, and the point of the test is to
+catch a future reintroduction.
 """
 
 import ast

--- a/tests/test_golden_http.py
+++ b/tests/test_golden_http.py
@@ -1,14 +1,9 @@
-"""Golden HTTP-surface tests (plan 001, ``aio-golden-http``).
+"""Golden HTTP-surface tests.
 
-These pin the parts of the route responses that the FastAPI/Starlette flip
-(``aio-fastapi-app`` through ``aio-uvicorn``) is likely to break, and that this repository
-actually controls. There is deliberately no HTTP replay/fixture layer here (the original plan
-sketched one; it was dropped) — so **only assertions about what we produce are in scope**:
-status codes, headers, content types, ``Content-Disposition``, CSV header rows and column sets,
-and file magic bytes. Anything whose expected value is really a third party's payload (exact CSV
-data rows, exact PNG/PDF bytes, the full Dash index HTML) is explicitly out of scope: it would go
-red for reasons outside this repo, which is exactly the noise ``tests/conftest.py``'s ``upstream``
-marker (see #632, ``robust-upstream-tests``) just finished eliminating everywhere else.
+Pin the parts of route responses this repository actually controls: status codes, headers,
+content types, ``Content-Disposition``, CSV header rows/column sets, and file magic bytes.
+Anything that is really a third party's payload (exact CSV data rows, exact PNG/PDF bytes,
+the full Dash index HTML) is out of scope — it would go red for reasons outside this repo.
 
 Split by what a test needs:
 
@@ -23,11 +18,9 @@ Left out entirely, and why:
 
 * Byte-exact CSV data rows and byte-exact PNG/PDF content — pure upstream/library payload, not
   ours to pin (matplotlib and LaTeX output is not reproducible across versions either).
-* The Pan-STARRS and Gaia CSV "friends" of ``/dr24/csv/<oid>``. They share the same
+* The Pan-STARRS and Gaia CSV "friends" of ``/dr24/csv/<oid>``: they share the same
   ``_lc_to_csv_response`` helper in ``ztf_viewer/pages/lc_csv.py`` as the Antares route exercised
-  below, which already covers that code path; finding a Pan-STARRS ``objID`` / Gaia ``source_id``
-  that is guaranteed to stay resolvable is exactly the kind of elaborate, fragile mechanism the
-  plan asks to avoid in favour of a thin, honest test.
+  below, which already covers that code path.
 * Full Dash index HTML snapshots for any page route — Dash's index is not a stable golden and
   would churn on every Dash upgrade for reasons with nothing to do with this repo's routing.
 """
@@ -78,12 +71,10 @@ def dash_app():
 def client(dash_app):
     """A WSGI/ASGI test client for the Dash server, independent of the backend.
 
-    Today ``app.server`` is a Flask app (``.test_client()``). After the FastAPI/Starlette flip
-    (``aio-fastapi-app`` onward) it becomes an ASGI app; Starlette's own
-    ``starlette.testclient.TestClient`` wraps *any* ASGI app behind a near-identical,
-    httpx-based interface (``client.get(path)``, ``response.status_code``, ``response.headers``).
-    Try the WSGI method first, since that is today's backend; fall back to the ASGI client so this
-    file needs no edits after the flip.
+    Today ``app.server`` is a Flask app (``.test_client()``). A future ASGI backend would work
+    via ``starlette.testclient.TestClient``, which wraps any ASGI app behind a near-identical,
+    httpx-based interface. Try WSGI first, since that is today's backend; fall back to ASGI so
+    this file needs no edits if that flip happens.
     """
     server = dash_app.server
     if hasattr(server, "test_client"):
@@ -103,8 +94,8 @@ def _content_type(response):
 
 
 # --------------------------------------------------------------------------------------------
-# 1. /static -- the single highest-value test: catches F2 (bare FastAPI() has no /static at all)
-#    and the Flask-vs-Starlette cache-header difference (the "/static design note").
+# 1. /static -- the single highest-value test: catches a bare app with no /static route at all,
+#    and the Flask-vs-Starlette cache-header difference.
 # --------------------------------------------------------------------------------------------
 
 
@@ -120,20 +111,14 @@ def test_static_logo_is_mounted(client):
 
 
 def test_static_js9_js9_min_js(client):
-    """JS9 is installed into `ztf_viewer/static/js9/` at image build time (Dockerfile:14-22,
-    merged into `/app/ztf_viewer/static/js9` *after* `COPY ztf_viewer /app/ztf_viewer/` since
-    Docker COPY merges directories rather than replacing them) -- so the file exists in CI's
-    Docker build but generally not in a local checkout. Skip locally with a clear reason; this
-    must genuinely run in CI (verified against the Dockerfile, not assumed).
+    """JS9 is installed into `ztf_viewer/static/js9/` at image build time, so the file exists in
+    CI's Docker build but generally not in a local checkout. Skip locally with a clear reason;
+    this must genuinely run in CI.
 
-    The header assertions are the actual regression net: F2 is "FastAPI() has no /static route at
-    all" (this request would 404 into the Dash catch-all instead of 200), and the design note's
-    concern is that Starlette's StaticFiles only sends ETag/Last-Modified while Flask sends a
-    Cache-Control. Measured against today's Flask 3.1: Flask's `send_file` already sends
-    `Cache-Control: no-cache` (not `max-age=...` as the design note assumed -- worth a plan
-    correction, Flask's default changed) *plus* ETag/Last-Modified, so the two backends are
-    already closer than the note expected. Pin what we see today so any regression -- losing the
-    route, or losing every header -- is caught.
+    The header assertions are the real regression net: a missing /static route would 404 into
+    the Dash catch-all instead of returning 200, and a future ASGI backend's StaticFiles sends
+    only ETag/Last-Modified where Flask 3.1's `send_file` sends `Cache-Control: no-cache` plus
+    ETag/Last-Modified. Pin what we see today so losing the route or losing headers is caught.
     """
     js9_path = _PACKAGE_ROOT / "static" / "js9" / "js9.min.js"
     if not js9_path.exists():

--- a/ztf_viewer/cache/core.py
+++ b/ztf_viewer/cache/core.py
@@ -116,7 +116,7 @@ def _normalize(obj):
 def encode_self(instance):
     """Normalize the ``self`` argument of a cached method.
 
-    **Decision (plan 001, F12.5 / open question 8): key on the class, not on the instance.**
+    **Decision: key on the class, not on the instance.**
     Every cached method in this app lives on a module-level singleton whose per-instance state
     is API sessions, client objects and timeout decorators — none of which change the result of
     a call.  Keying on ``id(self)`` (which is what both backends do today, directly or through
@@ -147,7 +147,7 @@ def encode_arguments(args=(), kwargs=None, *, method_class: type | None = None) 
             this = encode_self(args[0])
             args = args[1:]
         # Kwargs are sorted by name, and the *name* is part of the encoding: `f(min_mjd=x)` and
-        # `f(max_mjd=x)` are different calls (plan 001, F12.2).
+        # `f(max_mjd=x)` are different calls.
         keywords = [(name, _normalize(value)) for name, value in sorted(kwargs.items())]
         return _dumps((this, _normalize(tuple(args)), keywords))
     except RecursionError as e:  # only reachable for self-referential arguments

--- a/ztf_viewer/cache/decorator.py
+++ b/ztf_viewer/cache/decorator.py
@@ -5,7 +5,7 @@ Keying and serialization live in :mod:`ztf_viewer.cache.core`; the stores live i
 ``get(key)`` and ``set(key, blob)`` over pickled bytes.
 
 This replaces ``redis_lru``/``cachetools.cached``, whose behaviour differed between backends in
-five ways (plan 001, F12); ``tests/test_cache_contract.py`` is the spec.
+five ways; ``tests/test_cache_contract.py`` is the spec.
 """
 
 import functools

--- a/ztf_viewer/web.py
+++ b/ztf_viewer/web.py
@@ -4,7 +4,7 @@ The routes in `ztf_viewer/pages/{figure,lc_csv,favicon}.py` are registered with
 `@app.server.route(...)` rather than as Dash callbacks, so they talk to the WSGI/ASGI backend
 directly instead of through `dash.ctx`. Today that backend is Flask, and this module is the
 *only* place allowed to `import flask` (enforced by a repo-wide grep / AST guard) so that a
-later swap to Starlette (`aio-starlette-web`) touches this one file instead of every route.
+later swap to Starlette touches this one file instead of every route.
 
 Call sites should only use the names exported here, never `flask` directly.
 """


### PR DESCRIPTION
Standalone, off `master`. No behaviour change — comments and docstrings only.

The cache and test modules had grown citations of `plans/001_async_dash.md`: finding IDs
(`F12.2`, `F3`, `F1c`), plan branch names (`aio-cache-sync`, `aio-starlette-web`,
`aio-loop-registry`), and PR numbers used as explanations. The code outlives the plan; once the
migration is done and the document is archived, a pointer to "F12.2" tells a future reader
nothing, while the reason itself is what belongs next to the code.

So the citation goes and the content stays:

```diff
-        # `f(min_mjd=x)` and `f(max_mjd=x)` are different calls (plan 001, F12.2).
+        # `f(min_mjd=x)` and `f(max_mjd=x)` are different calls.

-    **Decision (plan 001, F12.5 / open question 8): key on the class, not on the instance.**
+    **Decision: key on the class, not on the instance.**

-later swap to Starlette (`aio-starlette-web`) touches this one file instead of every route.
+later swap to Starlette touches this one file instead of every route.
```

Where a line was *only* a citation it is deleted — `tests/test_cache_core.py`'s
`"""Plan 001, F12.2."""` carried nothing the test's own name didn't already say.

Several test module docstrings were also trimmed while in there: they had accumulated migration
narrative that belongs in the plan, not in the suite. `tests/test_golden_http.py`'s is about half
its old length and still states the scope rules that matter (what is hermetic, what is
`upstream`-marked, what is deliberately not asserted and why).

Plan and finding IDs stay where they belong: commit messages and PR descriptions, which are dated
records rather than living documentation.

232 passed, 1 skipped (the JS9 asset, present only in the build image); pre-commit clean.

The same cleanup is applied to the unmerged branches in their own commits — #640 and stack #639
(#636/#637/#638) — so nothing reintroduces it as those land.

🤖 Generated with [Claude Code](https://claude.com/claude-code)