### PR TITLE
Make the TTL-prolongation tests deterministic

### DIFF
--- a/tests/test_ttl_set_local_ttl_set.py
+++ b/tests/test_ttl_set_local_ttl_set.py
@@ -1,6 +1,7 @@
 import time
 
 import pytest
+from cachetools import TTLCache
 
 from ztf_viewer.ttl_set import LocalTTLSet
 
@@ -81,12 +82,23 @@ def test_ttl() -> None:
 
 
 def test_ttl_prolongation() -> None:
-    ttl_set = LocalTTLSet(maxsize=2, ttl=2)
+    clock = 0.0
+
+    def fake_timer() -> float:
+        return clock
+
+    ttl = 2
+    ttl_set = LocalTTLSet(maxsize=2, ttl=ttl)
+    ttl_set.ttl_cache = TTLCache(maxsize=2, ttl=ttl, timer=fake_timer)
+
     ttl_set.add(1)
     assert len(ttl_set) == 1
-    time.sleep(1)
-    ttl_set.add(1)
-    time.sleep(1)
+
+    clock += 1.5  # most of the way to the original expiry
+    ttl_set.add(1)  # re-add resets the TTL
+
+    clock += 1  # past the original expiry, before the new one
     assert len(ttl_set) == 1
-    time.sleep(1)
+
+    clock += 1  # past the new expiry
     assert len(ttl_set) == 0

--- a/tests/test_ttl_set_redis_ttl_set.py
+++ b/tests/test_ttl_set_redis_ttl_set.py
@@ -81,12 +81,19 @@ def test_ttl(redisdb) -> None:
 
 
 def test_ttl_prolongation(redisdb) -> None:
-    ttl_set = RedisTTLSet(client=redisdb, ttl=2)
+    ttl = 10
+    ttl_set = RedisTTLSet(client=redisdb, ttl=ttl)
+    key = ttl_set._encode(1)
+
     ttl_set.add(1)
-    assert len(ttl_set) == 1
-    time.sleep(1)
+    pttl_before = redisdb.pttl(key)
+
+    time.sleep(0.3)
+    pttl_after_wait = redisdb.pttl(key)
+    assert pttl_after_wait < pttl_before
+
     ttl_set.add(1)
-    time.sleep(1)
-    assert len(ttl_set) == 1
-    time.sleep(2)
-    assert len(ttl_set) == 0
+    pttl_after_readd = redisdb.pttl(key)
+    # Re-adding resets the TTL back up close to the full value.
+    assert pttl_after_readd > pttl_after_wait
+    assert (ttl * 1000 - 2000) < pttl_after_readd <= ttl * 1000

--- a/tests/test_ttl_set_redis_ttl_string_set.py
+++ b/tests/test_ttl_set_redis_ttl_string_set.py
@@ -81,12 +81,19 @@ def test_ttl(redisdb) -> None:
 
 
 def test_ttl_prolongation(redisdb) -> None:
-    ttl_set = RedisTTLStringSet(client=redisdb, ttl=2)
+    ttl = 10
+    ttl_set = RedisTTLStringSet(client=redisdb, ttl=ttl)
+    key = ttl_set._encode("a")
+
     ttl_set.add("a")
-    assert len(ttl_set) == 1
-    time.sleep(1)
+    pttl_before = redisdb.pttl(key)
+
+    time.sleep(0.3)
+    pttl_after_wait = redisdb.pttl(key)
+    assert pttl_after_wait < pttl_before
+
     ttl_set.add("a")
-    time.sleep(1)
-    assert len(ttl_set) == 1
-    time.sleep(1)
-    assert len(ttl_set) == 0
+    pttl_after_readd = redisdb.pttl(key)
+    # Re-adding resets the TTL back up close to the full value.
+    assert pttl_after_readd > pttl_after_wait
+    assert (ttl * 1000 - 2000) < pttl_after_readd <= ttl * 1000


### PR DESCRIPTION
Standalone, off `master`. Test-only, unrelated to stack #639. This is the flake that failed CI on
#638 and, before that, on #636 — both times unrelated to the branch under review.

## What was wrong

`test_ttl_prolongation` asserts that re-adding an entry resets its TTL, and it checked that by
sleeping across the expiry boundary:

```
t=0  add          → expires at 2.0
t=1  add again    → expires at 3.0
t=2  assert alive → 1.0s of margin, fine
t=3  assert gone  → ~0s of margin ✗
```

Whether the last assertion passed came down to whether the runner's sleeps overshot by more than
the two `add` calls cost. Nothing about `ttl_set.py` is wrong — a re-run passes.

## What it does now

Assert the property directly instead of waiting for it.

**Redis** (`RedisTTLSet`, `RedisTTLStringSet`): ask the server for the remaining lifetime with
`PTTL` rather than sleeping past it. Add, observe the TTL falling, re-add, and assert it jumped
back to near the full value — one-directional inequalities plus a multi-second slack window, so a
slow runner cannot flake it. No sleep crosses an expiry boundary.

**Local** (`LocalTTLSet`): drive a fake clock. `cachetools.TTLCache` takes a `timer`, so the test
substitutes one it advances by hand — past the original expiry to prove the entry survived, then
past the new one to prove it expires. No wall clock at all, and no production code changed.

The plain `test_ttl` expiry tests are untouched; they are the end-to-end check that expiry happens
at all, and their margins were never tight.

## Result

`test_ttl_prolongation` drops from ~4s to ~0.3s per Redis module and under 5ms for the local one;
the three modules together go from ~16s to ~8s, with what remains being the untouched `test_ttl`
sleeps. Ran the three modules five times over — 5/5 — and the full suite is green.

An earlier version of this PR just widened the sleep. That made a flake less likely without making
it impossible, which is why it was replaced.

🤖 Generated with [Claude Code](https://claude.com/claude-code)