### PR TITLE
Add an async-capable unavailable_catalogs (aio-ttlset)

### DIFF
--- a/tests/test_ttl_set_async_local_ttl_set.py
+++ b/tests/test_ttl_set_async_local_ttl_set.py
@@ -1,0 +1,119 @@
+import asyncio
+
+import pytest
+from cachetools import TTLCache
+
+from ztf_viewer.ttl_set import AsyncLocalTTLSet
+
+
+async def test_clear() -> None:
+    ttl_set = AsyncLocalTTLSet(maxsize=2, ttl=86400)
+    await ttl_set.add(1)
+    await ttl_set.add(2)
+    await ttl_set.clear()
+    assert await ttl_set.size() == 0
+
+
+async def test_add() -> None:
+    ttl_set = AsyncLocalTTLSet(maxsize=1, ttl=86400)
+    await ttl_set.add(1)
+    assert await ttl_set.size() == 1
+
+
+async def test_remove() -> None:
+    ttl_set = AsyncLocalTTLSet(maxsize=1, ttl=86400)
+    await ttl_set.add(1)
+    await ttl_set.remove(1)
+    assert await ttl_set.size() == 0
+
+
+async def test_contains() -> None:
+    ttl_set = AsyncLocalTTLSet(maxsize=1, ttl=86400)
+    await ttl_set.add(1)
+    assert await ttl_set.contains(1)
+
+
+async def test_values() -> None:
+    ttl_set = AsyncLocalTTLSet(maxsize=1, ttl=86400)
+    await ttl_set.add(1)
+    assert set(await ttl_set.values()) == {1}
+
+
+async def test_size() -> None:
+    ttl_set = AsyncLocalTTLSet(maxsize=1, ttl=86400)
+    await ttl_set.add(1)
+    assert await ttl_set.size() == 1
+
+
+async def test_size_0() -> None:
+    ttl_set = AsyncLocalTTLSet(maxsize=1, ttl=86400)
+    assert await ttl_set.size() == 0
+
+
+async def test_multiple_add() -> None:
+    ttl_set = AsyncLocalTTLSet(maxsize=2, ttl=86400)
+    await ttl_set.add(1)
+    await ttl_set.add(1)
+    assert await ttl_set.size() == 1
+
+
+async def test_multiple_remove() -> None:
+    ttl_set = AsyncLocalTTLSet(maxsize=2, ttl=86400)
+    await ttl_set.add(1)
+    await ttl_set.remove(1)
+    with pytest.raises(KeyError):
+        await ttl_set.remove(1)
+    assert await ttl_set.size() == 0
+
+
+async def test_multiple_values() -> None:
+    ttl_set = AsyncLocalTTLSet(maxsize=2, ttl=86400)
+    await ttl_set.add(1)
+    await ttl_set.add(2)
+    assert set(await ttl_set.values()) == {1, 2}
+
+
+async def test_ttl() -> None:
+    ttl_set = AsyncLocalTTLSet(maxsize=2, ttl=1)
+    await ttl_set.add(1)
+    assert await ttl_set.size() == 1
+    await asyncio.sleep(2)
+    assert await ttl_set.size() == 0
+
+
+async def test_ttl_prolongation() -> None:
+    clock = 0.0
+
+    def fake_timer() -> float:
+        return clock
+
+    ttl = 2
+    ttl_set = AsyncLocalTTLSet(maxsize=2, ttl=ttl)
+    ttl_set._local.ttl_cache = TTLCache(maxsize=2, ttl=ttl, timer=fake_timer)
+
+    await ttl_set.add(1)
+    assert await ttl_set.size() == 1
+
+    clock += 1.5  # most of the way to the original expiry
+    await ttl_set.add(1)  # re-add resets the TTL
+
+    clock += 1  # past the original expiry, before the new one
+    assert await ttl_set.size() == 1
+
+    clock += 1  # past the new expiry
+    assert await ttl_set.size() == 0
+
+
+async def test_wraps_an_existing_local_ttl_set() -> None:
+    """The memory backend of `unavailable_catalogs` shares one `LocalTTLSet` between the sync
+    and async accessors, so an entry either adds is visible to both."""
+    from ztf_viewer.ttl_set import LocalTTLSet
+
+    local = LocalTTLSet(maxsize=2, ttl=86400)
+    ttl_set = AsyncLocalTTLSet(local=local)
+
+    await ttl_set.add(1)
+    assert 1 in local
+
+    local.add(2)
+    assert await ttl_set.contains(2)

--- a/tests/test_ttl_set_async_redis_ttl_set.py
+++ b/tests/test_ttl_set_async_redis_ttl_set.py
@@ -1,0 +1,144 @@
+import asyncio
+
+import pytest
+import redis.asyncio
+
+from ztf_viewer.ttl_set import AsyncRedisTTLSet
+
+
+def _async_client_factory(redisdb):
+    """A zero-arg factory building an async client pointed at the same `pytest-redis` server."""
+    kwargs = redisdb.connection_pool.connection_kwargs
+
+    def factory():
+        return redis.asyncio.Redis(unix_socket_path=kwargs.get("path"), db=kwargs.get("db", 0))
+
+    return factory
+
+
+@pytest.fixture
+def ttl_set_factory(redisdb):
+    def make(ttl):
+        return AsyncRedisTTLSet(ttl=ttl, client_factory=_async_client_factory(redisdb))
+
+    return make
+
+
+async def test_clear(ttl_set_factory) -> None:
+    ttl_set = ttl_set_factory(86400)
+    await ttl_set.add(1)
+    await ttl_set.add(2)
+    await ttl_set.clear()
+    assert await ttl_set.size() == 0
+
+
+async def test_add(ttl_set_factory) -> None:
+    ttl_set = ttl_set_factory(86400)
+    await ttl_set.add(1)
+    assert await ttl_set.size() == 1
+
+
+async def test_remove(ttl_set_factory) -> None:
+    ttl_set = ttl_set_factory(86400)
+    await ttl_set.add(1)
+    await ttl_set.remove(1)
+    assert await ttl_set.size() == 0
+
+
+async def test_contains(ttl_set_factory) -> None:
+    ttl_set = ttl_set_factory(86400)
+    await ttl_set.add(1)
+    assert await ttl_set.contains(1)
+
+
+async def test_values(ttl_set_factory) -> None:
+    ttl_set = ttl_set_factory(86400)
+    await ttl_set.add(1)
+    assert set(await ttl_set.values()) == {1}
+
+
+async def test_size(ttl_set_factory) -> None:
+    ttl_set = ttl_set_factory(86400)
+    await ttl_set.add(1)
+    assert await ttl_set.size() == 1
+
+
+async def test_size_0(ttl_set_factory) -> None:
+    ttl_set = ttl_set_factory(86400)
+    assert await ttl_set.size() == 0
+
+
+async def test_multiple_add(ttl_set_factory) -> None:
+    ttl_set = ttl_set_factory(86400)
+    await ttl_set.add(1)
+    await ttl_set.add(1)
+    assert await ttl_set.size() == 1
+
+
+async def test_multiple_remove(ttl_set_factory) -> None:
+    ttl_set = ttl_set_factory(86400)
+    await ttl_set.add(1)
+    await ttl_set.remove(1)
+    with pytest.raises(KeyError):
+        await ttl_set.remove(1)
+    assert await ttl_set.size() == 0
+
+
+async def test_multiple_values(ttl_set_factory) -> None:
+    ttl_set = ttl_set_factory(86400)
+    await ttl_set.add(1)
+    await ttl_set.add(2)
+    assert set(await ttl_set.values()) == {1, 2}
+
+
+async def test_ttl(ttl_set_factory) -> None:
+    ttl_set = ttl_set_factory(1)
+    await ttl_set.add(1)
+    assert await ttl_set.size() == 1
+    await asyncio.sleep(2)
+    assert await ttl_set.size() == 0
+
+
+async def test_ttl_prolongation(ttl_set_factory, redisdb) -> None:
+    ttl = 10
+    ttl_set = ttl_set_factory(ttl)
+    key = ttl_set._encode(1)
+
+    await ttl_set.add(1)
+    pttl_before = redisdb.pttl(key)
+
+    await asyncio.sleep(0.3)
+    pttl_after_wait = redisdb.pttl(key)
+    assert pttl_after_wait < pttl_before
+
+    await ttl_set.add(1)
+    pttl_after_readd = redisdb.pttl(key)
+    # Re-adding resets the TTL back up close to the full value.
+    assert pttl_after_readd > pttl_after_wait
+    assert (ttl * 1000 - 2000) < pttl_after_readd <= ttl * 1000
+
+
+async def test_no_io_at_construction(redisdb) -> None:
+    """Construction must not touch the network — building `client_factory` itself proves it was
+    never called."""
+    calls = []
+
+    def factory():
+        calls.append(1)
+        return redis.asyncio.Redis(unix_socket_path=redisdb.connection_pool.connection_kwargs.get("path"))
+
+    AsyncRedisTTLSet(ttl=1, client_factory=factory)
+    assert calls == []
+
+
+def test_two_successive_asyncio_run_calls_both_work(redisdb) -> None:
+    """Simulates Flask's per-request event loop: the client must be rebuilt for the second
+    loop rather than reused from the first, which would raise on a closed loop."""
+    ttl_set = AsyncRedisTTLSet(ttl=86400, client_factory=_async_client_factory(redisdb))
+
+    async def body():
+        await ttl_set.add(1)
+        return await ttl_set.contains(1)
+
+    assert asyncio.run(body()) is True
+    assert asyncio.run(body()) is True

--- a/tests/test_ttl_set_async_redis_ttl_string_set.py
+++ b/tests/test_ttl_set_async_redis_ttl_string_set.py
@@ -1,0 +1,118 @@
+import asyncio
+
+import pytest
+import redis.asyncio
+
+from ztf_viewer.ttl_set import AsyncRedisTTLStringSet
+
+
+def _async_client_factory(redisdb):
+    """A zero-arg factory building an async client pointed at the same `pytest-redis` server."""
+    kwargs = redisdb.connection_pool.connection_kwargs
+
+    def factory():
+        return redis.asyncio.Redis(unix_socket_path=kwargs.get("path"), db=kwargs.get("db", 0))
+
+    return factory
+
+
+@pytest.fixture
+def ttl_set_factory(redisdb):
+    def make(ttl):
+        return AsyncRedisTTLStringSet(ttl=ttl, client_factory=_async_client_factory(redisdb))
+
+    return make
+
+
+async def test_clear(ttl_set_factory) -> None:
+    ttl_set = ttl_set_factory(86400)
+    await ttl_set.add("a")
+    await ttl_set.add("b")
+    await ttl_set.clear()
+    assert await ttl_set.size() == 0
+
+
+async def test_add(ttl_set_factory) -> None:
+    ttl_set = ttl_set_factory(86400)
+    await ttl_set.add("")
+    assert await ttl_set.size() == 1
+
+
+async def test_remove(ttl_set_factory) -> None:
+    ttl_set = ttl_set_factory(86400)
+    await ttl_set.add("a")
+    await ttl_set.remove("a")
+    assert await ttl_set.size() == 0
+
+
+async def test_contains(ttl_set_factory) -> None:
+    ttl_set = ttl_set_factory(86400)
+    await ttl_set.add("")
+    assert await ttl_set.contains("")
+
+
+async def test_values(ttl_set_factory) -> None:
+    ttl_set = ttl_set_factory(86400)
+    await ttl_set.add("abc")
+    assert set(await ttl_set.values()) == {"abc"}
+
+
+async def test_size(ttl_set_factory) -> None:
+    ttl_set = ttl_set_factory(86400)
+    await ttl_set.add("X")
+    assert await ttl_set.size() == 1
+
+
+async def test_size_0(ttl_set_factory) -> None:
+    ttl_set = ttl_set_factory(86400)
+    assert await ttl_set.size() == 0
+
+
+async def test_multiple_add(ttl_set_factory) -> None:
+    ttl_set = ttl_set_factory(86400)
+    await ttl_set.add("α")
+    await ttl_set.add("α")
+    assert await ttl_set.size() == 1
+
+
+async def test_multiple_remove(ttl_set_factory) -> None:
+    ttl_set = ttl_set_factory(86400)
+    await ttl_set.add("Цирк")
+    await ttl_set.remove("Цирк")
+    with pytest.raises(KeyError):
+        await ttl_set.remove("Цирк")
+    assert await ttl_set.size() == 0
+
+
+async def test_multiple_values(ttl_set_factory) -> None:
+    ttl_set = ttl_set_factory(86400)
+    await ttl_set.add("abc")
+    await ttl_set.add("def")
+    assert set(await ttl_set.values()) == {"abc", "def"}
+
+
+async def test_ttl(ttl_set_factory) -> None:
+    ttl_set = ttl_set_factory(1)
+    await ttl_set.add("a")
+    assert await ttl_set.size() == 1
+    await asyncio.sleep(2)
+    assert await ttl_set.size() == 0
+
+
+async def test_ttl_prolongation(ttl_set_factory, redisdb) -> None:
+    ttl = 10
+    ttl_set = ttl_set_factory(ttl)
+    key = ttl_set._encode("a")
+
+    await ttl_set.add("a")
+    pttl_before = redisdb.pttl(key)
+
+    await asyncio.sleep(0.3)
+    pttl_after_wait = redisdb.pttl(key)
+    assert pttl_after_wait < pttl_before
+
+    await ttl_set.add("a")
+    pttl_after_readd = redisdb.pttl(key)
+    # Re-adding resets the TTL back up close to the full value.
+    assert pttl_after_readd > pttl_after_wait
+    assert (ttl * 1000 - 2000) < pttl_after_readd <= ttl * 1000

--- a/tests/test_unavailable_catalogs_async.py
+++ b/tests/test_unavailable_catalogs_async.py
@@ -1,0 +1,21 @@
+"""The async accessor added to `unavailable_catalogs.py`.
+
+Inert: nothing in the app calls `unavailable_catalogs_async` yet, so this only checks the
+accessor is wired up and, for the memory backend, that it shares state with the sync one.
+
+``ztf_viewer.catalogs.unavailable_catalogs`` connects to Redis eagerly at import time (see
+``tests/test_golden_http.py``'s ``dash_app`` fixture docstring for the same wart), so the module
+must not be imported until ``pytest_runtest_setup`` has forced ``UNAVAILABLE_CATALOGS_CACHE_TYPE``
+to ``"memory"`` — hence the import is inside the test rather than at module level.
+"""
+
+from ztf_viewer.ttl_set import AsyncLocalTTLSet
+
+
+async def test_memory_backend_shares_state_with_the_sync_accessor() -> None:
+    from ztf_viewer.catalogs.unavailable_catalogs import unavailable_catalogs, unavailable_catalogs_async
+
+    assert isinstance(unavailable_catalogs_async, AsyncLocalTTLSet), "test config forces the memory backend"
+    unavailable_catalogs.add("some-catalog")
+    assert await unavailable_catalogs_async.contains("some-catalog")
+    unavailable_catalogs.discard("some-catalog")

--- a/ztf_viewer/catalogs/unavailable_catalogs.py
+++ b/ztf_viewer/catalogs/unavailable_catalogs.py
@@ -1,7 +1,8 @@
+import redis.asyncio
 from redis import StrictRedis
 
 from ztf_viewer.config import REDIS_HOSTNAME, UNAVAILABLE_CATALOGS_CACHE_TYPE
-from ztf_viewer.ttl_set import LocalTTLSet, RedisTTLStringSet
+from ztf_viewer.ttl_set import AsyncLocalTTLSet, AsyncRedisTTLStringSet, LocalTTLSet, RedisTTLStringSet
 
 TTL = 5 * 60  # 5 minutes
 MAXSIZE = 1 << 10  # number of catalogs, we have much less
@@ -26,3 +27,26 @@ def _get_unavailable_catalogs():
 
 
 unavailable_catalogs = _get_unavailable_catalogs()
+
+
+def _create_async_redis():
+    # No client at construction time: AsyncRedisTTLStringSet builds one lazily, per running loop.
+    return AsyncRedisTTLStringSet(
+        TTL, client_factory=lambda: redis.asyncio.Redis(REDIS_HOSTNAME), prefix="unavailable_catalogs"
+    )
+
+
+ASYNC_CREATORS = {
+    "redis": _create_async_redis,
+    "memory": lambda: AsyncLocalTTLSet(local=unavailable_catalogs),
+}
+
+
+def _get_unavailable_catalogs_async():
+    try:
+        return ASYNC_CREATORS[UNAVAILABLE_CATALOGS_CACHE_TYPE.lower().strip()]()
+    except KeyError as e:
+        raise ValueError(f'UNAVAILABLE_CATALOGS_CACHE_TYPE must be one of: {", ".join(ASYNC_CREATORS)}') from e
+
+
+unavailable_catalogs_async = _get_unavailable_catalogs_async()

--- a/ztf_viewer/ttl_set.py
+++ b/ztf_viewer/ttl_set.py
@@ -1,8 +1,22 @@
+"""TTL-bounded sets: a local in-memory backend and a Redis-backed one, each with an async variant.
+
+The sync classes (`LocalTTLSet`, `RedisTTLSet`, `RedisTTLStringSet`) implement
+`collections.abc.MutableSet`. The async ones (`AsyncLocalTTLSet`, `AsyncRedisTTLSet`,
+`AsyncRedisTTLStringSet`) are deliberately not `MutableSet`s: `__contains__`, `__len__` and
+`__iter__` cannot be made awaitable, so there is no async counterpart to that interface. Instead
+they expose plain async methods with names chosen to read naturally with `await`: `add`,
+`discard`, `remove`, `clear`, `contains`, `size`, `values`.
+"""
+
+import asyncio
 import pickle
+import threading
+import weakref
 from abc import ABC, abstractmethod
 from collections.abc import MutableSet
-from typing import Generic, Hashable, Iterator, TypeVar
+from typing import Callable, Generic, Hashable, Iterator, TypeVar
 
+import redis.asyncio
 from cachetools import TTLCache
 from redis import StrictRedis
 
@@ -108,6 +122,127 @@ class RedisTTLSet(_BaseTTLSet[_T_Redis], Generic[_T_Redis]):
 
 
 class RedisTTLStringSet(RedisTTLSet[str]):
+    def _encode(self, value: str) -> bytes:
+        return self.prefix + value.encode()
+
+    def _decode(self, key: bytes) -> str:
+        return key.removeprefix(self.prefix).decode()
+
+
+_T_AsyncLocal = TypeVar("_T_AsyncLocal", bound=Hashable)
+
+
+class AsyncLocalTTLSet(Generic[_T_AsyncLocal]):
+    """Async facade over :class:`LocalTTLSet`.
+
+    `LocalTTLSet` is pure in-memory and never blocks, so there is nothing here to actually await
+    — this exists only so a caller can use the same awaitable method names regardless of which
+    backend `unavailable_catalogs` was configured with.
+    """
+
+    def __init__(self, local: "LocalTTLSet[_T_AsyncLocal] | None" = None, *, maxsize: int = 0, ttl: int = 0):
+        self._local = local if local is not None else LocalTTLSet(maxsize=maxsize, ttl=ttl)
+
+    async def add(self, value: _T_AsyncLocal) -> None:
+        self._local.add(value)
+
+    async def discard(self, value: _T_AsyncLocal) -> None:
+        self._local.discard(value)
+
+    async def remove(self, value: _T_AsyncLocal) -> None:
+        self._local.remove(value)
+
+    async def clear(self) -> None:
+        self._local.clear()
+
+    async def contains(self, value: _T_AsyncLocal) -> bool:
+        return value in self._local
+
+    async def size(self) -> int:
+        return len(self._local)
+
+    async def values(self) -> list[_T_AsyncLocal]:
+        return list(self._local)
+
+
+_T_AsyncRedis = TypeVar("_T_AsyncRedis")
+
+
+class AsyncRedisTTLSet(Generic[_T_AsyncRedis]):
+    """Async counterpart to :class:`RedisTTLSet`, on ``redis.asyncio``.
+
+    A connection pool is bound to the loop that created it, so the client is built lazily per
+    running loop rather than once in ``__init__`` — mirrors ``AsyncRedisBackend`` in
+    ``ztf_viewer/cache/redis.py``; keep the two in sync if that pattern changes.
+
+    Nothing here does I/O in ``__init__``.
+    """
+
+    def __init__(
+        self,
+        ttl: int,
+        client_factory: Callable[[], "redis.asyncio.Redis"],
+        prefix: str = "RedisTTLSet",
+    ):
+        self.ttl = ttl
+        self._client_factory = client_factory
+
+        self.prefix = prefix.encode()
+        if b"*" in self.prefix:
+            raise ValueError('prefix must not contain "*"')
+
+        self._clients: weakref.WeakKeyDictionary = weakref.WeakKeyDictionary()
+        self._registry_lock = threading.Lock()
+
+    def _client(self) -> "redis.asyncio.Redis":
+        loop = asyncio.get_running_loop()
+        # threading.Lock, not asyncio: the WeakKeyDictionary itself is shared across threads, one loop each.
+        with self._registry_lock:
+            client = self._clients.get(loop)
+            if client is None:
+                client = self._clients[loop] = self._client_factory()
+        return client
+
+    def _encode(self, value: _T_AsyncRedis) -> bytes:
+        serialized = pickle.dumps(value, protocol=pickle.HIGHEST_PROTOCOL)
+        return self.prefix + serialized
+
+    def _decode(self, key: bytes) -> _T_AsyncRedis:
+        return pickle.loads(key.removeprefix(self.prefix))
+
+    async def add(self, value: _T_AsyncRedis) -> None:
+        key = self._encode(value)
+        # `set(..., ex=)` rather than the deprecated `setex`, matching the cache's Redis backend.
+        await self._client().set(key, 0, ex=self.ttl)
+
+    async def discard(self, value: _T_AsyncRedis) -> None:
+        key = self._encode(value)
+        await self._client().delete(key)
+
+    async def remove(self, value: _T_AsyncRedis) -> None:
+        key = self._encode(value)
+        if await self._client().getdel(key) is None:
+            raise KeyError(f"{value} not found")
+
+    async def clear(self) -> None:
+        client = self._client()
+        for key in await client.keys(self.prefix + b"*"):
+            await client.delete(key)
+
+    async def contains(self, value: _T_AsyncRedis) -> bool:
+        key = self._encode(value)
+        return await self._client().exists(key) > 0
+
+    async def size(self) -> int:
+        client = self._client()
+        return len(await client.keys(self.prefix + b"*"))
+
+    async def values(self) -> list[_T_AsyncRedis]:
+        client = self._client()
+        return [self._decode(key) for key in await client.keys(self.prefix + b"*")]
+
+
+class AsyncRedisTTLStringSet(AsyncRedisTTLSet[str]):
     def _encode(self, value: str) -> bytes:
         return self.prefix + value.encode()
 


### PR DESCRIPTION
`aio-ttlset` from the async migration plan: an async-capable `unavailable_catalogs`. Inert —
nothing calls the new accessor yet, so nothing in the app behaves differently after this merges.

`ztf_viewer/ttl_set.py` gains three async classes alongside the existing sync ones:

- **`AsyncLocalTTLSet`** — a thin facade over `LocalTTLSet`. `LocalTTLSet` is pure in-memory and
  never blocks, so there's nothing to actually await; the facade exists only so a caller gets the
  same awaitable method names regardless of backend. It can wrap an *existing* `LocalTTLSet`
  instead of building its own, which is how `unavailable_catalogs.py` wires it up (below).
- **`AsyncRedisTTLSet`** / **`AsyncRedisTTLStringSet`** — on `redis.asyncio`, mirroring
  `RedisTTLSet`/`RedisTTLStringSet`. The client is built lazily, per running loop, in a
  `weakref.WeakKeyDictionary` guarded by a `threading.Lock` — the exact pattern
  `AsyncRedisBackend` in `ztf_viewer/cache/redis.py` already uses, so a connection pool never
  gets bound to a loop that later closes out from under it (Flask's per-request loop today,
  FastAPI's one long-lived loop later).

None of the three are `collections.abc.MutableSet`s. `__contains__`, `__len__`, `__iter__` can't
be made awaitable, so pretending to be a `MutableSet` would just mean silently-broken dunders.
Instead they expose plain async methods named to read naturally with `await`: `add`, `discard`,
`remove`, `clear`, `contains`, `size`, `values`. Said once in the module docstring rather than on
each class.

`ztf_viewer/catalogs/unavailable_catalogs.py` gains `unavailable_catalogs_async`, built the same
way as the existing `unavailable_catalogs` (a `CREATORS`-style dict keyed by
`UNAVAILABLE_CATALOGS_CACHE_TYPE`). For the memory backend it wraps the *same* `LocalTTLSet`
instance the sync accessor already built, so an entry either one adds is visible to the other —
same reasoning as `AsyncMemoryBackend` wrapping a shared `MemoryBackend` in the cache stack. For
the redis backend it points at the same server and key prefix, so the two are interchangeable
views of one store rather than a second one.

Stacked on the Redis-6.2 PR below it, which is what lets `AsyncRedisTTLSet.remove` be a plain
`GETDEL` with no version probe and no I/O in `__init__`.

## Tests

Three mirrored suites (`tests/test_ttl_set_async_local_ttl_set.py`,
`tests/test_ttl_set_async_redis_ttl_set.py`, `tests/test_ttl_set_async_redis_ttl_string_set.py`),
one per async class, same cases as their sync counterparts translated to `await`. Plus:

- a construction-time no-I/O check on `AsyncRedisTTLSet` (builds it with a `client_factory` that
  records whether it was ever called, asserts it wasn't);
- a two-successive-`asyncio.run()` test on `AsyncRedisTTLSet`, simulating Flask's per-request
  loop, the same shape as the existing `AsyncRedisBackend`/`AsyncMemoryBackend` coverage in
  `tests/test_cache_async.py`;
- `tests/test_unavailable_catalogs_async.py` checks the accessor is wired up and, for the memory
  backend, that it shares state with the sync one. It imports `ztf_viewer.catalogs` lazily inside
  the test body rather than at module level — that module still connects to Redis eagerly at
  import time (the same pre-existing wart called out above), so importing it before
  `pytest_runtest_setup` has forced the test config to `"memory"` would blow up at collection.

Full suite is green locally (`pytest --basetemp=/tmp/pytest`), one pre-existing skip
(`test_golden_http.py`'s JS9 asset, not built outside the Docker image).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
