### PR TITLE
Require Redis 6.2+ and pin the server image

### DIFF
--- a/.ci/docker-compose.yml.tmpl
+++ b/.ci/docker-compose.yml.tmpl
@@ -1,7 +1,7 @@
 version: '2'
 services:
   redis:
-    image: redis
+    image: redis:8-alpine
     networks:
       - app
     restart: always

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -13,3 +13,11 @@ updates:
     directory: "/"
     schedule:
       interval: "monthly"
+  - package-ecosystem: "docker"
+    directory: "/"
+    schedule:
+      interval: "monthly"
+  - package-ecosystem: "docker-compose"
+    directory: "/"
+    schedule:
+      interval: "monthly"

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Please use [the GitHub issue tracker](https://github.com/snad-space/ztf-viewer/i
 Environment variables to configure the server, see default values in `config.py`:
 - `CACHE_TYPE`: cache type, specify `redis` to use [redis](https://redis.io) server, or `memory` to use in-process cache
 - `UNAVAILABLE_CATALOGS_CACHE_TYPE`: unavailable catalog cache type, specify `redis` to use [redis](https://redis.io) server, or `memory` to use in-process cache
-- `REDIS_URL`: redis server address
+- `REDIS_URL`: redis server address (Redis 6.2+ required)
 - `LC_API_URL`: SNAD ZTF database API address
 - `AKB_API_URL`: knowledge database address
 - `FEATURES_API_URL`: feature extraction service address

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,6 @@
 services:
   redis:
-    image: redis
+    image: redis:8-alpine
     command: ["redis-server", "--maxmemory", "2048mb", "--maxmemory-policy", "allkeys-lru", "--save", "", "--appendonly", "no"]
     networks:
       - app

--- a/tests/test_ttl_set_redis_ttl_set.py
+++ b/tests/test_ttl_set_redis_ttl_set.py
@@ -1,8 +1,17 @@
 import time
 
+import packaging.version
 import pytest
 
 from ztf_viewer.ttl_set import RedisTTLSet
+
+# `remove()` uses GETDEL, so an older server would fail these tests obscurely.
+MIN_REDIS_VERSION = packaging.version.parse("6.2.0")
+
+
+def test_redis_server_is_new_enough(redisdb) -> None:
+    version = packaging.version.parse(redisdb.info()["redis_version"])
+    assert version >= MIN_REDIS_VERSION, f"tests need Redis >= {MIN_REDIS_VERSION}, this server is {version}"
 
 
 def test_clear(redisdb) -> None:

--- a/ztf_viewer/ttl_set.py
+++ b/ztf_viewer/ttl_set.py
@@ -3,7 +3,6 @@ from abc import ABC, abstractmethod
 from collections.abc import MutableSet
 from typing import Generic, Hashable, Iterator, TypeVar
 
-import packaging.version
 from cachetools import TTLCache
 from redis import StrictRedis
 
@@ -72,18 +71,6 @@ class RedisTTLSet(_BaseTTLSet[_T_Redis], Generic[_T_Redis]):
         if b"*" in self.prefix:
             raise ValueError('prefix must not contain "*"')
 
-        self.redis_version = self.__redis_version(client)
-        if self.redis_version < packaging.version.parse("6.2.0"):
-            self.remove = self.__remove_pre_6_2_0
-        else:
-            self.remove = self.__remove_6_2_0
-
-    @staticmethod
-    def __redis_version(client: StrictRedis) -> packaging.version.Version:
-        info = client.info()
-        version = packaging.version.parse(info["redis_version"])
-        return version
-
     def _encode(self, value: _T_Redis) -> bytes:
         serialized = pickle.dumps(value, protocol=pickle.HIGHEST_PROTOCOL)
         return self.prefix + serialized
@@ -96,16 +83,6 @@ class RedisTTLSet(_BaseTTLSet[_T_Redis], Generic[_T_Redis]):
         self.client.delete(key)
 
     def remove(self, value: _T_Redis) -> None:
-        # To be assigned in __init__ according to Redis version
-        raise NotImplementedError
-
-    def __remove_pre_6_2_0(self, value: _T_Redis) -> None:
-        key = self._encode(value)
-        if self.client.exists(key) == 0:
-            raise KeyError(f"{value} not found")
-        self.client.delete(key)
-
-    def __remove_6_2_0(self, value: _T_Redis) -> None:
         key = self._encode(value)
         if self.client.getdel(key) is None:
             raise KeyError(f"{value} not found")


### PR DESCRIPTION
`RedisTTLSet.__init__` called `client.info()` to choose between an atomic `GETDEL`-based
`remove()` (Redis >= 6.2) and a two-round-trip `exists`-then-`delete` fallback. That probe comes
from October 2022 ("Implement RedisTTLSet for redis<6.2") and has been carried ever since.

Nothing we run can take the fallback path:

| where | version |
| --- | --- |
| production / dev (`docker-compose.yml`, `.ci/docker-compose.yml.tmpl`) | `image: redis`, unpinned, currently 8.x |
| CI tests (`.ci/Dockerfile_test`) | Debian bookworm `redis-server`, 7.0.15 |

`remove()` is also dead code as far as the app is concerned — the only uses of
`unavailable_catalogs` are `add()` in `ztf_viewer/exceptions.py` and `in` in
`catalogs/conesearch/_base.py`. So the probe bought a fallback nothing reaches, for a method
nothing calls, at the price of a blocking network round trip on the **import** path:
`unavailable_catalogs` is constructed at module import, which makes this startup-path I/O.

So: `remove()` is `GETDEL` unconditionally, the version probe and the `packaging.version`
dependency are gone, and `__init__` no longer touches the network.

To make "Redis >= 6.2" a fact rather than a hope:

- **`image: redis:8-alpine`** in `docker-compose.yml` and `.ci/docker-compose.yml.tmpl`.
- **Dependabot** gains the `docker` and `docker-compose` ecosystems, so the pin gets update PRs
  instead of quietly rotting. Note `docker` also covers the `Dockerfile` base image, so expect
  Python base-image PRs too — say the word and I'll restrict it. One gap worth knowing:
  `.ci/docker-compose.yml.tmpl` is not a filename Dependabot recognises as a manifest, so its pin
  has to be kept in step with `docker-compose.yml` by hand.
- A **`test_redis_server_is_new_enough`** check in `tests/test_ttl_set_redis_ttl_set.py`. The
  test fixtures spawn a locally installed `redis-server` binary rather than the pinned image, so
  the pin alone doesn't cover them; this fails loudly instead of exercising a path production
  never takes.
- One line in the README, next to `REDIS_URL`.

Behaviour change worth naming explicitly: against a pre-6.2 server the app now breaks rather than
degrading. That is the intent — we are not going back below 6.2.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
