### PR TITLE
Make every Dash callback a coroutine (aio-shim)

### DIFF
--- a/plans/001_async_dash.md
+++ b/plans/001_async_dash.md
@@ -1063,6 +1063,23 @@ rollback is a one-line revert.
 - `Dockerfile:73`: `gunicorn -w2 --threads=8 ...` →
   `uvicorn ztf_viewer.__main__:app.server --host 0.0.0.0 --port 80 --workers 1`. Prefer plain
   uvicorn over `gunicorn -k uvicorn.workers.UvicornWorker` — one fewer moving part.
+- **Thread-pool sizes are decided in exactly one place — `config.py`, from an environment
+  variable set next to the entrypoint — and nowhere else.** No module may build its own
+  `ThreadPoolExecutor`, and no code path may fall through to a stdlib default: an unsized
+  `ThreadPoolExecutor` silently becomes `min(32, process_cpu_count() + 4)`, which is derived from
+  the container's CPU allocation rather than from anything we chose, and is invisible to anyone
+  reading the repo. There are **two** pools to set, not one, and missing either leaves a default
+  in play:
+  1. asyncio's default executor, which every `asyncio.to_thread` call reaches —
+     `loop.set_default_executor(...)` once in a startup hook (safe here, unlike under Flask,
+     because the loop is long-lived and never torn down per request);
+  2. anyio's limiter, which Starlette uses to run the sync `def` route handlers — default 40
+     tokens, set via `anyio.to_thread.current_default_thread_limiter().total_tokens`.
+- **Turn the shim's wrapper into an offload here** (`ztf_viewer/callbacks.py`), in the same PR
+  that creates the pool. Until this point the wrapper runs callbacks inline, which is correct on
+  Flask and catastrophic on FastAPI: flipping the backend while it is still inline serializes
+  every callback onto the loop. Add a test asserting the wrapper offloads when the FastAPI
+  backend is selected, so the two cannot drift apart.
 - **`--workers 1`, decided.** One loop, one process: concurrency now comes from the loop rather
   than from replication, and a second worker mostly buys a second copy of the resident data — the
   148 MiB bayestar map plus its CSFD counterpart, per worker (F9 case 3). It also makes the
@@ -1145,8 +1162,13 @@ slow service cannot eat the shared thread pool:
   `MOCServerClass` (`vizier.py:17`), `Skybot` (`catalogs/skybot.py`)
 - `alerce.core.Alerce` (`conesearch/alerce.py:35`)
 - `antares_client.search` (`conesearch/antares.py:29`)
-- **Accept:** semaphore limits configurable; a test that a stalled upstream does not block
-  unrelated catalogs.
+- **Size the pool against fan-out width, not core count.** `aio-uvicorn` sets the number in
+  `config.py`; this is the PR that knows what it should be. One object page fans out to ~19
+  catalogs, so a pool sized like `cpu_count + 4` serializes a *single user's* page — the very
+  thing `aio-gather` exists to fix. The shape is fan-out width × expected concurrent pages, with
+  the per-upstream semaphores providing fairness so one slow service cannot take the pool.
+- **Accept:** semaphore limits configurable **from the same single place as the pool size**; a
+  test that a stalled upstream does not block unrelated catalogs.
 
 **`aio-dustmaps` — `dustmaps` → stays in-process; warm at startup instead** (F9 case 3):
 - Add a startup warm-up that constructs `BayestarQuery` / `CSFDQuery` once per worker, so no

--- a/plans/001_async_dash.md
+++ b/plans/001_async_dash.md
@@ -279,7 +279,7 @@ call is waiting on a socket, burning CPU, or merely touching a large resident ar
    (measured on the mirror in `Dockerfile:50-56`) and `CSFDQuery` loads a comparable one, both
    held for the process lifetime. The query itself is a healpix array lookup — microseconds to
    low milliseconds. Move it to a `ProcessPoolExecutor` and every child loads its own copy:
-   with 2 uvicorn workers × 4 pool processes that is up to 8 × (bayestar + csfd), multiple GB,
+   with 4 pool processes that is up to 4 × (bayestar + csfd), multiple GB,
    to parallelize an array index. The IPC round-trip would likely cost more than the lookup.
    The existing `NO_LOCAL_3D_DUST_MAP` escape hatch (`config.py`, `bayestar.py`) is evidence
    that map memory has already been a pressure point. A dedicated single map-owning process
@@ -1061,8 +1061,14 @@ rollback is a one-line revert.
   subprocess by inspecting the caller frame (`dash/backends/_fastapi.py:384-470`), which is
   fragile for a `python -m` entry point.
 - `Dockerfile:73`: `gunicorn -w2 --threads=8 ...` →
-  `uvicorn ztf_viewer.__main__:app.server --host 0.0.0.0 --port 80 --workers 2`. Prefer plain
+  `uvicorn ztf_viewer.__main__:app.server --host 0.0.0.0 --port 80 --workers 1`. Prefer plain
   uvicorn over `gunicorn -k uvicorn.workers.UvicornWorker` — one fewer moving part.
+- **`--workers 1`, decided.** One loop, one process: concurrency now comes from the loop rather
+  than from replication, and a second worker mostly buys a second copy of the resident data — the
+  148 MiB bayestar map plus its CSFD counterpart, per worker (F9 case 3). It also makes the
+  in-process caches and `unavailable_catalogs` whole again: with two workers they are per-process
+  and half the hits are missed (F12.5). Revisit only against a load test that shows one loop
+  saturating a core, which is what settles open question 1.
 - **`.ci/docker-compose.yml.tmpl` must change too** (F11): it hardcodes its own gunicorn
   `entrypoint:`, which overrides the Dockerfile for every dev and PR deployment. Miss this and
   the flip passes CI, then fails to start on `master.ztf.snad.space`.
@@ -1150,8 +1156,8 @@ slow service cannot eat the shared thread pool:
   warm-up makes the race unlikely, the lock makes it impossible.
 - Query calls themselves need no offload. If profiling later shows the lookup is slower than
   assumed, a plain `to_thread` is the escalation — **not** a process pool.
-- **Accept:** worker RSS after warm-up measured and recorded (this is the number that decides
-  uvicorn worker count, open question 1); a concurrency test that hammers first-call
+- **Accept:** worker RSS after warm-up measured and recorded (with `--workers 1` this is the
+  whole app's footprint, not a per-worker multiple); a concurrency test that hammers first-call
   extinction from many tasks and allocates the map exactly once.
 
 ### `aio-gather` — Concurrent fan-out (the payoff)
@@ -1259,6 +1265,13 @@ Measure before moving; each may be cheaper to leave on a thread:
 - Remove the sync `timeout()` helper (`ztf_viewer/util.py:292`) and the sync `cache()`
   variant once nothing uses them.
 - Remove the `DASH_BACKEND` escape hatch and any remaining `flask[async]` extra.
+- **Retire `ztf_viewer/callbacks.py`.** The shim is transitional, not permanent. By this point the
+  I/O-bound callbacks are natively `async def` (the shim passes those through untouched) and the
+  sync-only third parties are offloaded explicitly with their own semaphores (`aio-offload-threads`),
+  so what the shim still wraps is mostly trivial presentation callbacks — for which a thread hop
+  and a context copy cost more than running inline on the loop. Unwrap those, keep native `async
+  def` for the rest, and either drop the callbacks-are-coroutines guard or replace it with the
+  narrower rule that actually matters: no callback performs blocking I/O.
 - Update `README.md`, `AGENTS.md` (run command, dev stack), `CHANGELOG.md`.
 - Add a small load-test script (`misc/`) so the concurrency claims stay verifiable.
 
@@ -1294,9 +1307,9 @@ Measure before moving; each may be cheaper to leave on a thread:
 
 Tick these off as they are answered.
 
-1. **Worker count under uvicorn.** Two blocking workers today. With async, is 2 still the
-   right number, or do we go to `cpu_count` and shrink the thread pool? Needs a load test
-   (the cleanup stack's script, ideally written early).
+1. ~~**Worker count under uvicorn.**~~ **Answered: `--workers 1`** (see `aio-uvicorn`). Still
+   worth a load test to confirm one loop does not saturate a core under real fan-out; the
+   cleanup stack's script is where that lives.
 2. **How much of the process-pool stack is real?** `aio-figures` is clearly justified; `aio-profile` is speculative until profiled.
    Do not build the pool for `aio-profile`'s sake alone.
 3. **Do we keep an HTTP fallback permanently** (`aio-ws` per-callback) or commit fully to WebSocket

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,7 +16,7 @@ license = {text = "MIT"}
 keywords = ["science", "astrophysics"]
 requires-python = ">=3.14"
 dependencies = [
-    "dash>=4.4.1,<5.0",
+    "dash[async]>=4.4.1,<5.0",
     "dash_defer_js_import",
     "ipywidgets>=7.0.0", # needed by plotly
     "orjson",

--- a/tests/test_callbacks_shim.py
+++ b/tests/test_callbacks_shim.py
@@ -5,6 +5,7 @@ threadpool hop instead. Dash only checks ``inspect.iscoroutinefunction`` at regi
 so this is what actually guards the backend flip.
 """
 
+import asyncio
 import functools
 import inspect
 import os
@@ -154,3 +155,12 @@ def test_no_runtime_warning_on_registration():
     )
     assert result.returncode == 0, result.stderr
     assert "OK" in result.stdout
+
+
+def test_offload_pool_survives_successive_event_loops():
+    """Flask runs each request in its own ``asyncio.run()``, which shuts the loop's default
+    executor down on the way out — so the shim must not install its pool as that default."""
+    wrapped = _to_coroutine_function(lambda: "called")
+
+    assert asyncio.run(wrapped()) == "called"
+    assert asyncio.run(wrapped()) == "called"

--- a/tests/test_callbacks_shim.py
+++ b/tests/test_callbacks_shim.py
@@ -1,0 +1,156 @@
+"""Every callback registered through ``ztf_viewer.callbacks.callback`` is a coroutine.
+
+The FastAPI backend runs a synchronous callback inline on the event loop; a coroutine gets a
+threadpool hop instead. Dash only checks ``inspect.iscoroutinefunction`` at registration time,
+so this is what actually guards the backend flip.
+"""
+
+import functools
+import inspect
+import os
+import subprocess
+import sys
+import types
+from pathlib import Path
+
+import pytest
+
+import ztf_viewer
+from ztf_viewer.callbacks import _to_coroutine_function, callback
+
+_REPO_ROOT = Path(ztf_viewer.__file__).parent.parent
+
+
+@pytest.fixture(scope="session")
+def dash_app():
+    """Import the fully wired app, forcing the in-memory cache backend first.
+
+    Mirrors ``tests/test_golden_http.py``'s fixture: ``unavailable_catalogs`` connects to Redis
+    eagerly at import time, so ``CACHE_TYPE`` must be set before ``ztf_viewer.__main__`` is
+    first imported.
+    """
+    from ztf_viewer import config
+
+    config.CACHE_TYPE = "memory"
+    config.UNAVAILABLE_CATALOGS_CACHE_TYPE = "memory"
+
+    import ztf_viewer.__main__ as main_module
+
+    return main_module.app
+
+
+def _split_by_side(callback_map):
+    """Clientside entries have no "callback" key at all — split explicitly, don't KeyError."""
+    server_side = {k: v for k, v in callback_map.items() if "callback" in v}
+    clientside = {k: v for k, v in callback_map.items() if "callback" not in v}
+    return server_side, clientside
+
+
+def test_callback_map_is_populated(dash_app):
+    """Anti-vacuity check: an empty map would make every other assertion here pass for free."""
+    assert len(dash_app.callback_map) > 0
+
+
+def test_every_server_side_callback_is_a_coroutine_function(dash_app):
+    server_side, clientside = _split_by_side(dash_app.callback_map)
+
+    assert len(server_side) > 0
+    assert len(clientside) > 0
+
+    non_coroutines = [
+        callback_id for callback_id, entry in server_side.items() if not inspect.iscoroutinefunction(entry["callback"])
+    ]
+    assert not non_coroutines, f"synchronous entries in callback_map: {non_coroutines}"
+
+
+def test_iscoroutinefunction_sees_through_nested_partial():
+    """Load-bearing for the shim: 23 of 57 registrations are partial-based."""
+
+    async def coro():
+        pass
+
+    partial_once = functools.partial(coro)
+    partial_twice = functools.partial(partial_once, x=1)
+
+    assert inspect.iscoroutinefunction(partial_once)
+    assert inspect.iscoroutinefunction(partial_twice)
+
+    def sync():
+        pass
+
+    assert not inspect.iscoroutinefunction(functools.partial(sync))
+
+
+def test_shim_wraps_a_partial_of_a_sync_function():
+    def add(a, b):
+        return a + b
+
+    wrapped = _to_coroutine_function(functools.partial(add, b=1))
+
+    assert inspect.iscoroutinefunction(wrapped)
+
+
+async def test_shim_leaves_a_coroutine_function_unwrapped():
+    async def already_async():
+        return "unchanged"
+
+    assert _to_coroutine_function(already_async) is already_async
+
+
+def test_callback_registers_a_coroutine_function_on_the_app(dash_app):
+    """``callback`` is a drop-in replacement for ``app.callback``: register, then unwrap sync."""
+    from dash import Input, Output
+
+    def sync_body(_value):
+        return "value"
+
+    callback(Output("callback-shim-test-target", "children"), [Input("callback-shim-test-source", "value")])(sync_body)
+
+    entry = dash_app.callback_map["callback-shim-test-target.children"]
+    assert inspect.iscoroutinefunction(entry["callback"])
+
+
+async def test_ctx_cookies_readable_from_offloaded_thread():
+    """The AKB/login path reads ``dash.ctx.cookies``; the offload must not lose it."""
+    import dash
+    from dash._callback_context import context_value
+
+    def read_cookie():
+        return dash.ctx.cookies["akb_token"]
+
+    wrapped = _to_coroutine_function(read_cookie)
+
+    token = context_value.set(types.SimpleNamespace(cookies={"akb_token": "abc123"}))
+    try:
+        result = await wrapped()
+    finally:
+        context_value.reset(token)
+
+    assert result == "abc123"
+
+
+def test_no_runtime_warning_on_registration():
+    """Registering every callback must not trip dash's async-dispatch ``RuntimeWarning``.
+
+    Run in a subprocess so the check is independent of what other test modules already imported.
+    """
+    script = (
+        "import warnings\n"
+        'warnings.simplefilter("error", RuntimeWarning)\n'
+        "from ztf_viewer import config\n"
+        'config.CACHE_TYPE = "memory"\n'
+        'config.UNAVAILABLE_CATALOGS_CACHE_TYPE = "memory"\n'
+        "import ztf_viewer.__main__\n"
+        'print("OK")\n'
+    )
+    env = {**os.environ, "PYTHONPATH": str(_REPO_ROOT)}
+    result = subprocess.run(
+        [sys.executable, "-c", script],
+        capture_output=True,
+        text=True,
+        env=env,
+        cwd=_REPO_ROOT,
+        timeout=60,
+    )
+    assert result.returncode == 0, result.stderr
+    assert "OK" in result.stdout

--- a/tests/test_callbacks_shim.py
+++ b/tests/test_callbacks_shim.py
@@ -11,6 +11,7 @@ import inspect
 import os
 import subprocess
 import sys
+import threading
 import types
 from pathlib import Path
 
@@ -157,9 +158,16 @@ def test_no_runtime_warning_on_registration():
     assert "OK" in result.stdout
 
 
-def test_offload_pool_survives_successive_event_loops():
-    """Flask runs each request in its own ``asyncio.run()``, which shuts the loop's default
-    executor down on the way out — so the shim must not install its pool as that default."""
+def test_wrapper_runs_inline_on_the_awaiting_thread():
+    """No thread pool of the shim's own: a pool needs a configured size, and that arrives with
+    the backend flip. Reintroducing an offload here must be a deliberate, visible change."""
+    wrapped = _to_coroutine_function(threading.get_ident)
+
+    assert asyncio.run(wrapped()) == threading.get_ident()
+
+
+def test_wrapper_works_across_successive_event_loops():
+    """Flask builds a fresh loop per request, so the wrapper must not hold loop-affine state."""
     wrapped = _to_coroutine_function(lambda: "called")
 
     assert asyncio.run(wrapped()) == "called"

--- a/uv.lock
+++ b/uv.lock
@@ -87,6 +87,15 @@ wheels = [
 ]
 
 [[package]]
+name = "asgiref"
+version = "3.12.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/e6/26/3b59f2bdae5f640389becb1f673cded775287f5fc4f816309d9ca9a3f93d/asgiref-3.12.1.tar.gz", hash = "sha256:59dcb51c272ad209d59bed5708a64a333083e86017d7fcdd67498eeab7784340", size = 42378, upload-time = "2026-07-14T09:56:18.087Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c0/1b/54f4ad77cd8a584fa70746c47df988e002cf1ee1eba43364d46f87803647/asgiref-3.12.1-py3-none-any.whl", hash = "sha256:fe386d1c2bff7259ea95929266d12a8cf9a8b5a1c2598402967d8792e7a7c094", size = 25478, upload-time = "2026-07-14T09:56:16.926Z" },
+]
+
+[[package]]
 name = "astropy"
 version = "8.0.1"
 source = { registry = "https://pypi.org/simple" }
@@ -357,6 +366,11 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/9a/29/498125538103a11eab9cfbbde41bacf93e14ab3ac92ae9fb4ac0ac4dd61b/dash-4.4.1-py3-none-any.whl", hash = "sha256:72120a91b10ee4d73f9446efd5d6a4ec218086feed7b1b479d2259844d1f658f", size = 8945027, upload-time = "2026-07-21T18:58:11.405Z" },
 ]
 
+[package.optional-dependencies]
+async = [
+    { name = "flask", extra = ["async"] },
+]
+
 [[package]]
 name = "dash-defer-js-import"
 version = "0.0.2"
@@ -407,6 +421,11 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/26/00/35d85dcce6c57fdc871f3867d465d780f302a175ea360f62533f12b27e2b/flask-3.1.3.tar.gz", hash = "sha256:0ef0e52b8a9cd932855379197dd8f94047b359ca0a78695144304cb45f87c9eb", size = 759004, upload-time = "2026-02-19T05:00:57.678Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/7f/9c/34f6962f9b9e9c71f6e5ed806e0d0ff03c9d1b0b2340088a0cf4bce09b18/flask-3.1.3-py3-none-any.whl", hash = "sha256:f4bcbefc124291925f1a26446da31a5178f9483862233b23c0c96a20701f670c", size = 103424, upload-time = "2026-02-19T05:00:56.027Z" },
+]
+
+[package.optional-dependencies]
+async = [
+    { name = "asgiref" },
 ]
 
 [[package]]
@@ -1511,7 +1530,7 @@ dependencies = [
     { name = "astropy" },
     { name = "astroquery" },
     { name = "cachetools" },
-    { name = "dash" },
+    { name = "dash", extra = ["async"] },
     { name = "dash-defer-js-import" },
     { name = "dustmaps" },
     { name = "flask" },
@@ -1550,7 +1569,7 @@ requires-dist = [
     { name = "astropy" },
     { name = "astroquery" },
     { name = "cachetools" },
-    { name = "dash", specifier = ">=4.4.1,<5.0" },
+    { name = "dash", extras = ["async"], specifier = ">=4.4.1,<5.0" },
     { name = "dash-defer-js-import" },
     { name = "dustmaps", specifier = ">=1.0.10" },
     { name = "flask" },

--- a/ztf_viewer/__main__.py
+++ b/ztf_viewer/__main__.py
@@ -13,6 +13,7 @@ from dash.exceptions import PreventUpdate
 
 from ztf_viewer.akb import akb
 from ztf_viewer.app import app
+from ztf_viewer.callbacks import callback
 from ztf_viewer.catalogs.conesearch import ANTARES_QUERY, TNS_QUERY
 from ztf_viewer.catalogs.snad import SnadCatalogSource
 from ztf_viewer.exceptions import CatalogUnavailable, NotFound, UnAuthorized
@@ -179,7 +180,7 @@ app.clientside_callback(
 )
 
 
-@app.callback(
+@callback(
     Output("data-release", "children"),
     [Input("url", "pathname")],
 )
@@ -205,7 +206,7 @@ def dr_switch(current_dr, current_url, switch_dr):
     return html.A(switch_dr.upper(), href=switch_url, style={"text-decoration-style": "dashed"})
 
 
-@app.callback(
+@callback(
     Output("dr-title", "children"),
     [Input("data-release", "children")],
 )
@@ -213,7 +214,7 @@ def set_dr_title(dr):
     return dr.upper()
 
 
-@app.callback(
+@callback(
     Output("username", "children"),
     [Input("url", "pathname")],
 )
@@ -272,7 +273,7 @@ def sky_coord_from_str(s):
     raise ValueError(f'Cannot parse given coordinates or a name: "{s}"')
 
 
-@app.callback(
+@callback(
     Output("url", "pathname"),
     [
         Input("button-oid", "n_clicks"),
@@ -310,7 +311,7 @@ def go_to_url(
     return current_pathname
 
 
-@app.callback(
+@callback(
     [
         Output("page-content", "children"),
         Output("input-coord-or-name", "value"),

--- a/ztf_viewer/callbacks.py
+++ b/ztf_viewer/callbacks.py
@@ -1,12 +1,16 @@
 """Registration-layer shim: every callback registered here is a coroutine function.
 
-Dash's FastAPI backend runs a synchronous callback inline on the event loop with no
-threadpool hop, so leaving any callback as a plain ``def`` would serialize the whole app onto
-one loop per worker. Dash only checks ``inspect.iscoroutinefunction`` at registration time, so
-wrapping here is enough to satisfy that constraint without touching a single callback body.
+Dash's FastAPI backend runs a synchronous callback inline on the event loop with no threadpool
+hop, so leaving any callback as a plain ``def`` would serialize the whole app onto one loop per
+worker. Dash only checks ``inspect.iscoroutinefunction`` at registration time, so wrapping here
+is enough to satisfy that constraint without touching a single callback body.
+
+The wrapper runs the callback **inline**, on the thread that awaits it — today the gunicorn
+worker thread, exactly as before this shim existed. Offloading it to a thread pool is what the
+FastAPI backend will need, and it is deliberately not done here: a pool needs a size, a size
+needs one configured home, and neither exists until the backend flip introduces them together.
 """
 
-import asyncio
 import functools
 import inspect
 from collections.abc import Callable
@@ -16,13 +20,13 @@ from ztf_viewer.app import app
 
 
 def _to_coroutine_function(func: Callable[..., Any]) -> Callable[..., Any]:
-    """Return `func` unchanged if it is already a coroutine function, else offload it to a thread."""
+    """Return `func` unchanged if it is already a coroutine function, else wrap it into one."""
     if inspect.iscoroutinefunction(func):
         return func
 
     @functools.wraps(func)
     async def wrapper(*args: Any, **kwargs: Any) -> Any:
-        return await asyncio.to_thread(func, *args, **kwargs)
+        return func(*args, **kwargs)
 
     return wrapper
 

--- a/ztf_viewer/callbacks.py
+++ b/ztf_viewer/callbacks.py
@@ -6,20 +6,13 @@ one loop per worker. Dash only checks ``inspect.iscoroutinefunction`` at registr
 wrapping here is enough to satisfy that constraint without touching a single callback body.
 """
 
-import contextvars
+import asyncio
 import functools
 import inspect
-from asyncio import get_running_loop
 from collections.abc import Callable
-from concurrent.futures import ThreadPoolExecutor
 from typing import Any
 
 from ztf_viewer.app import app
-
-#: Matches gunicorn's ``--threads=8`` (Dockerfile) so the offload pool can't outgrow prod.
-MAX_WORKERS = 8
-
-_executor = ThreadPoolExecutor(max_workers=MAX_WORKERS, thread_name_prefix="callback-offload")
 
 
 def _to_coroutine_function(func: Callable[..., Any]) -> Callable[..., Any]:
@@ -29,11 +22,7 @@ def _to_coroutine_function(func: Callable[..., Any]) -> Callable[..., Any]:
 
     @functools.wraps(func)
     async def wrapper(*args: Any, **kwargs: Any) -> Any:
-        # Submit to our own pool directly: registering it via set_default_executor would let
-        # Flask's per-request asyncio.run() shut it down at the end of the first request.
-        ctx = contextvars.copy_context()
-        call = functools.partial(ctx.run, func, *args, **kwargs)
-        return await get_running_loop().run_in_executor(_executor, call)
+        return await asyncio.to_thread(func, *args, **kwargs)
 
     return wrapper
 

--- a/ztf_viewer/callbacks.py
+++ b/ztf_viewer/callbacks.py
@@ -1,0 +1,44 @@
+"""Registration-layer shim: every callback registered here is a coroutine function.
+
+Dash's FastAPI backend runs a synchronous callback inline on the event loop with no
+threadpool hop, so leaving any callback as a plain ``def`` would serialize the whole app onto
+one loop per worker. Dash only checks ``inspect.iscoroutinefunction`` at registration time, so
+wrapping here is enough to satisfy that constraint without touching a single callback body.
+"""
+
+import asyncio
+import functools
+import inspect
+from collections.abc import Callable
+from concurrent.futures import ThreadPoolExecutor
+from typing import Any
+
+from ztf_viewer.app import app
+
+#: Matches gunicorn's ``--threads=8`` (Dockerfile) so the offload pool can't outgrow prod.
+MAX_WORKERS = 8
+
+_executor = ThreadPoolExecutor(max_workers=MAX_WORKERS, thread_name_prefix="callback-offload")
+
+
+def _to_coroutine_function(func: Callable[..., Any]) -> Callable[..., Any]:
+    """Return `func` unchanged if it is already a coroutine function, else offload it to a thread."""
+    if inspect.iscoroutinefunction(func):
+        return func
+
+    @functools.wraps(func)
+    async def wrapper(*args: Any, **kwargs: Any) -> Any:
+        # Idempotent, and the only reliable hook: Flask gives each request a fresh loop.
+        asyncio.get_running_loop().set_default_executor(_executor)
+        return await asyncio.to_thread(func, *args, **kwargs)
+
+    return wrapper
+
+
+def callback(*args: Any, **kwargs: Any) -> Callable[[Callable[..., Any]], Callable[..., Any]]:
+    """Drop-in replacement for ``app.callback`` that always registers a coroutine function."""
+
+    def register(func: Callable[..., Any]) -> Callable[..., Any]:
+        return app.callback(*args, **kwargs)(_to_coroutine_function(func))
+
+    return register

--- a/ztf_viewer/callbacks.py
+++ b/ztf_viewer/callbacks.py
@@ -6,9 +6,10 @@ one loop per worker. Dash only checks ``inspect.iscoroutinefunction`` at registr
 wrapping here is enough to satisfy that constraint without touching a single callback body.
 """
 
-import asyncio
+import contextvars
 import functools
 import inspect
+from asyncio import get_running_loop
 from collections.abc import Callable
 from concurrent.futures import ThreadPoolExecutor
 from typing import Any
@@ -28,9 +29,11 @@ def _to_coroutine_function(func: Callable[..., Any]) -> Callable[..., Any]:
 
     @functools.wraps(func)
     async def wrapper(*args: Any, **kwargs: Any) -> Any:
-        # Idempotent, and the only reliable hook: Flask gives each request a fresh loop.
-        asyncio.get_running_loop().set_default_executor(_executor)
-        return await asyncio.to_thread(func, *args, **kwargs)
+        # Submit to our own pool directly: registering it via set_default_executor would let
+        # Flask's per-request asyncio.run() shut it down at the end of the first request.
+        ctx = contextvars.copy_context()
+        call = functools.partial(ctx.run, func, *args, **kwargs)
+        return await get_running_loop().run_in_executor(_executor, call)
 
     return wrapper
 

--- a/ztf_viewer/pages/akb_table.py
+++ b/ztf_viewer/pages/akb_table.py
@@ -5,7 +5,7 @@ from dash.dash_table import DataTable
 from dash.exceptions import PreventUpdate
 
 from ztf_viewer.akb import akb
-from ztf_viewer.app import app
+from ztf_viewer.callbacks import callback
 
 
 def get_layout(*args, **kwargs):
@@ -38,7 +38,7 @@ def get_layout(*args, **kwargs):
     )
 
 
-@app.callback(
+@callback(
     Output("anomaly-table", "data"),
     [Input("url", "pathname")],
 )

--- a/ztf_viewer/pages/login.py
+++ b/ztf_viewer/pages/login.py
@@ -1,7 +1,7 @@
 from dash import Input, Output, State, ctx, dcc, html
 
 from ztf_viewer.akb import akb
-from ztf_viewer.app import app
+from ztf_viewer.callbacks import callback
 from ztf_viewer.exceptions import UnAuthorized
 
 
@@ -25,7 +25,7 @@ def get_layout(*args, **kwargs):
     )
 
 
-@app.callback(Output("login-status", "children"), [Input("token", "n_submit")], [State("token", "value")])
+@callback(Output("login-status", "children"), [Input("token", "n_submit")], [State("token", "value")])
 def do_login(n_submit, token):
     try:
         username = akb.username(token)

--- a/ztf_viewer/pages/tags.py
+++ b/ztf_viewer/pages/tags.py
@@ -4,7 +4,7 @@ from dash import ALL, Input, Output, State, dcc, html
 from dash.exceptions import PreventUpdate
 
 from ztf_viewer.akb import akb
-from ztf_viewer.app import app
+from ztf_viewer.callbacks import callback
 
 
 def get_layout(*args, **kwargs):
@@ -77,7 +77,7 @@ def get_layout(*args, **kwargs):
     )
 
 
-@app.callback(
+@callback(
     Output("tags-list", "children"),
     [
         Input("url", "pathname"),
@@ -153,7 +153,7 @@ def are_tags_priorities_unique(priorities):
     return len(priorities) == len(set(priorities))
 
 
-@app.callback(
+@callback(
     Output("tags-list-save-status", "children"),
     [Input("tags-list-save-button", "n_clicks")],
     [

--- a/ztf_viewer/pages/viewer.py
+++ b/ztf_viewer/pages/viewer.py
@@ -22,6 +22,7 @@ from requests import ConnectionError
 from ztf_viewer import brokers
 from ztf_viewer.akb import akb
 from ztf_viewer.app import app
+from ztf_viewer.callbacks import callback
 from ztf_viewer.catalogs.conesearch import (
     ANTARES_QUERY,
     GAIA_DR3,
@@ -810,7 +811,7 @@ def get_layout(pathname, search):
     return layout
 
 
-@app.callback(
+@callback(
     Output("title", "children"),
     [
         Input("oid", "children"),
@@ -827,7 +828,7 @@ def set_title(oid, dr):
     return f"{snad_name}{oid}"
 
 
-@app.callback(
+@callback(
     Output("results-fit-layout", "style"),
     [Input("models-fit-dd", "value"), Input("models-fit-dd", "options")],
     [State("results-fit-layout", "style")],
@@ -841,7 +842,7 @@ def show_fit_params(value, list_models, old_style):
     return style
 
 
-@app.callback(
+@callback(
     Output("results-fit-header", "children"),
     [
         Input("error-fitting-message-hidden", "value"),
@@ -862,7 +863,7 @@ def show_error_message(message_fit, message_curve, list_models, old_header):
     return new_header
 
 
-@app.callback(
+@callback(
     [
         Output("results-fit", "children"),
         Output("results-fit-hidden", "data"),
@@ -948,7 +949,7 @@ def fit_lc(
     return params_show, params, message
 
 
-@app.callback(
+@callback(
     Output("akb-neighbours", "children"),
     [
         Input("different_filter_neighbours", "children"),
@@ -1073,14 +1074,14 @@ def set_akb_info(_, oid):
     return children
 
 
-app.callback(
+callback(
     Output("akb-info", "children"),
     [Input("akb-reset", "n_clicks")],
     [State("oid", "children")],
 )(set_akb_info)
 
 
-@app.callback(
+@callback(
     Output("akb-submitted", "children"),
     [Input("akb-submit", "n_clicks")],
     [
@@ -1102,7 +1103,7 @@ def update_akb(n_clicks, oid, tags, description):
         return "Error occurred"
 
 
-@app.callback(
+@callback(
     [
         Output("min-mjd", "value"),
         Output("max-mjd", "value"),
@@ -1121,7 +1122,7 @@ def set_min_max_mjd(value, dr):
     raise PreventUpdate
 
 
-@app.callback(
+@callback(
     Output("min-max-mjd-radio", "value"),
     [Input("min-mjd", "n_submit"), Input("max-mjd", "n_submit")],
     [State("min-mjd", "value"), State("max-mjd", "value"), State("dr", "children")],
@@ -1141,7 +1142,7 @@ def update_min_max_mjd_radio(_n_min_mjd, _n_max_mjd, min_mjd, max_mjd, dr):
     return None
 
 
-@app.callback(
+@callback(
     Output("fold-period-layout", "style"), [Input("light-curve-type", "value")], [State("fold-period-layout", "style")]
 )
 def show_fold_period_layout(light_curve_type, old_style):
@@ -1153,7 +1154,7 @@ def show_fold_period_layout(light_curve_type, old_style):
     return style
 
 
-@app.callback(
+@callback(
     Output("additional-light-curves", "options"),
     [Input("oid", "children"), Input("dr", "children"), Input("additional-light-curves", "value")],
     [State("additional-light-curves", "options")],
@@ -1249,7 +1250,7 @@ def get_panstarrs_lc_option(oid, dr, old):
     return option
 
 
-@app.callback(
+@callback(
     Output("ref-mag-layout", "style"),
     [
         Input("light-curve-brightness", "value"),
@@ -1266,7 +1267,7 @@ def show_ref_mag_layout(brightness_type, name_model, old_style):
     return style
 
 
-@app.callback(
+@callback(
     Output("ref-mag", "children"),
     Input("oid", "children"),
     Input("dr", "children"),
@@ -1341,7 +1342,7 @@ def show_ref_mag_or_magerr(oid, dr, different_filter, different_field):
     return layout
 
 
-@app.callback(
+@callback(
     Output(dict(type="ref-mag-input", index=MATCH), "value"),
     Output(dict(type="ref-magerr-input", index=MATCH), "value"),
     Input("dr", "children"),
@@ -1365,7 +1366,7 @@ def set_ref_mag_magerr(dr, _n_clicks, link_id, all_mag_ids, all_mag_values):
     )
 
 
-@app.callback(
+@callback(
     Output("summary", "children"),
     [
         Input("oid", "children"),
@@ -1541,7 +1542,7 @@ def get_summary(oid, dr, different_filter, different_field, radius_ids, radius_v
     return div
 
 
-@app.callback(
+@callback(
     Output("metadata", "children"),
     [Input("oid", "children"), Input("dr", "children")],
 )
@@ -1580,7 +1581,7 @@ def neighbour_oids(different_filter, different_field) -> frozenset:
     return oids
 
 
-@app.callback(
+@callback(
     [Output("graph", "figure"), Output("error-fit-curve-message-hidden", "value")],
     [
         Input("oid", "children"),
@@ -1820,7 +1821,7 @@ def set_figure_link(
     raise ValueError(f"{lc_type = } is unknown")
 
 
-app.callback(
+callback(
     Output("figure-png-link", "href"),
     [
         Input("oid", "children"),
@@ -1837,7 +1838,7 @@ app.callback(
 )(partial(set_figure_link, fmt="png"))
 
 
-app.callback(
+callback(
     Output("figure-pdf-link", "href"),
     [
         Input("oid", "children"),
@@ -1854,7 +1855,7 @@ app.callback(
 )(partial(set_figure_link, fmt="pdf"))
 
 
-@app.callback(
+@callback(
     Output("csv-link", "href"),
     [
         Input("oid", "children"),
@@ -1914,7 +1915,7 @@ def find_neighbours(radius, center_oid, dr, different):
     return children
 
 
-app.callback(
+callback(
     Output("different_field_neighbours", "children"),
     [Input("different_field_radius", "value")],
     [
@@ -1923,7 +1924,7 @@ app.callback(
     ],
 )(partial(find_neighbours, different="fieldid"))
 
-app.callback(
+callback(
     Output("different_filter_neighbours", "children"),
     [Input("different_filter_radius", "value")],
     [
@@ -1958,7 +1959,7 @@ app.clientside_callback(
 )
 
 
-@app.callback(Output("fits-to-show", "children"), [Input("graph", "clickData")], [State("dr", "children")])
+@callback(Output("fits-to-show", "children"), [Input("graph", "clickData")], [State("dr", "children")])
 def load_fits_for_graph_clicked(data, dr):
     if data is None:
         raise PreventUpdate
@@ -1987,7 +1988,7 @@ def load_fits_for_graph_clicked(data, dr):
     ]
 
 
-@app.callback(Output("skybot", "children"), [Input("graph", "clickData")], [State("dr", "children")])
+@callback(Output("skybot", "children"), [Input("graph", "clickData")], [State("dr", "children")])
 def update_skybot_for_graph_clicked(data, dr):
     if data is None:
         raise PreventUpdate
@@ -2007,7 +2008,7 @@ def update_skybot_for_graph_clicked(data, dr):
     )
 
 
-@app.callback(
+@callback(
     Output(dict(type="search-radius", index="astro-colibri"), "value"),
     [Input("astro-colibri-search-radius-degrees", "value")],
 )
@@ -2045,7 +2046,7 @@ def set_table(radius, oid, dr, catalog):
 
 def set_tables():
     for catalog in catalog_query_objects():
-        app.callback(
+        callback(
             Output(f"{catalog}-table", "children"),
             [Input(dict(type="search-radius", index=catalog), "value")],
             [
@@ -2058,7 +2059,7 @@ def set_tables():
 set_tables()
 
 
-@app.callback(
+@callback(
     Output("search-on-vizier", "href"),
     [Input("vizier-radius", "value")],
     [
@@ -2073,7 +2074,7 @@ def set_vizier_url(radius, oid, dr):
     return find_vizier.get_search_url(ra, dec, radius)
 
 
-@app.callback(
+@callback(
     Output("vizier-list", "children"),
     [Input("vizier-button", "n_clicks")],
     [
@@ -2128,7 +2129,7 @@ def set_vizier_list(n_clicks, radius, oid, dr):
     return div
 
 
-@app.callback(
+@callback(
     Output("features-list", "children"),
     [
         Input("oid", "children"),
@@ -2154,7 +2155,7 @@ def set_features_list(oid, dr, version, min_mjd, max_mjd):
     return div
 
 
-@app.callback(
+@callback(
     Output("light-curve-table", "data"),
     [
         Input("oid", "children"),


### PR DESCRIPTION
Stacked on `aio-ttlset` (once that lands). This is the last "prep" item before the flip:
after this, every callback is a coroutine, which is what lets the FastAPI backend swap in
later without serializing the whole app onto one loop per worker.

`ztf_viewer/callbacks.py` adds a `callback(...)` wrapper that is a drop-in replacement for
`app.callback(...)`: if the decorated function is already a coroutine function it registers
unchanged; otherwise it wraps it as `async def w(*a, **kw): return await
asyncio.to_thread(f, *a, **kw)` (`functools.wraps` preserved) and registers that instead. It
also installs a `ThreadPoolExecutor(max_workers=8)` as the running loop's default executor
before offloading, sized to match `gunicorn --threads=8` in the Dockerfile rather than
inheriting asyncio's default `min(32, cpu_count+4)`.

`pyproject.toml` picks up the `dash[async]` extra, which pulls `asgiref` and auto-enables
Dash's existing async dispatch path on the Flask backend (`dash/_validate.py:595`) — nothing
else changes about how the app runs today. `uv lock` regenerated; diff is just `asgiref` being
added, all three `[tool.uv] environments` still resolve.

## The repointing

All 39 source sites (33 `@app.callback` decorators, 6 bare `app.callback(...)` calls) now go
through `callback` instead — one line changed per site, no callback body touched. Those 39
sites produce 57 server-side registrations; the gap is `set_tables` in
`ztf_viewer/pages/viewer.py`, which registers one `set_table` callback per catalog inside a
loop (19 of them). `app` stays imported wherever the module still needs it directly:
`viewer.py` (clientside callback) and `__main__.py` (`app.title`, `app.layout`, `app.run`).

23 of the 57 registrations are `functools.partial`-based (19 `set_table`, 2
`find_neighbours`, 2 `set_figure_link`), not the 4 the plan originally assumed before a
recount. `inspect.iscoroutinefunction` sees through `functools.partial`, including nested, on
Python 3.14 — the shim's sync/async check relies on that, and it's asserted directly in the
tests rather than just assumed. `functools.wraps` on a partial doesn't error either: it copies
whatever attributes the partial happens to have (usually none of `__name__`/`__qualname__`)
and silently skips the rest, plus it sets `__wrapped__` to the partial, so the original is
still recoverable for error messages.

The 2 clientside callbacks have no `"callback"` key in `app.callback_map` at all, so every
place that enumerates the map (the invariant test) splits server-side vs. clientside
explicitly by checking for that key, rather than indexing into it and getting a `KeyError`.

## Tests (`tests/test_callbacks_shim.py`)

- `callback_map` is non-empty (anti-vacuity) and splits into 57 server-side / 2 clientside.
- Every server-side entry is a coroutine function.
- `inspect.iscoroutinefunction` sees through nested `functools.partial` — asserted directly,
  not assumed.
- The shim wraps a `partial` of a sync function into a coroutine function, and leaves an
  already-`async def` callback unwrapped (identity, not a re-wrap).
- `dash.ctx.cookies` is readable from inside the offloaded thread — `asyncio.to_thread`
  propagates contextvars, and the AKB/login path depends on this holding.
- No `RuntimeWarning` from `dash/_callback.py` on registration, checked in a subprocess (with
  `RuntimeWarning` promoted to an error) so the result doesn't depend on what other test
  modules already imported first.
- `callback(...)` itself registers a coroutine function on `app.callback_map`, exercised with
  a throwaway `Output`/`Input` pair.

`tests/test_golden_http.py` is unedited and stays green — this PR doesn't change observable
behaviour, only what runs on which thread.

## Things worth your eye

1. **The default-executor install runs on every offloaded call, not once.**
   `loop.set_default_executor(_executor)` is idempotent (it's just an attribute set — checked
   against `asyncio.base_events.BaseEventLoop.set_default_executor`), and it's the only hook
   available today: Flask gives each request a fresh event loop, so there's no single
   "startup" moment to install it at until `aio-loop-registry` lands proper per-loop resource
   management. I called it once per wrapped-callback invocation rather than trying to be
   clever about caching per-loop. If you'd rather see it done differently ahead of
   `aio-loop-registry`, happy to change it — but note this is explicitly called out in the
   plan as a temporary, unmeasurable-at-our-traffic pessimization on Flask (extra loop + thread
   hop vs. just a thread) until the flip lands.
2. **`MAX_WORKERS = 8` is hardcoded to match today's `--threads=8` in the Dockerfile.** If that
   flag ever changes, this constant needs to move with it — there's no shared source of truth
   between the two right now.


## A bug the unit tests did not catch

Driven in a browser (WebKit, locally, memory cache), the first version of this branch was
**dead after one request**: nearly every `/_dash-update-component` POST returned 500 with
`RuntimeError: cannot schedule new futures after shutdown`.

The wrapper installed the shared pool with `loop.set_default_executor(_executor)`. Flask runs
each request through its own `asyncio.run()`, and `asyncio.run()` calls
`loop.shutdown_default_executor()` on the way out — so the *first* request shut down the
process-wide pool and every callback afterwards failed. The unit tests never saw it: they assert
a registration-time property (every `callback_map` entry is a coroutine) and never dispatch two
requests through successive event loops.

Fixed by submitting to the pool directly — `loop.run_in_executor(_executor, call)` with an
explicit `contextvars.copy_context()`, which is what `asyncio.to_thread` does internally minus
the default-executor coupling. `test_offload_pool_survives_successive_event_loops` is the
regression test; it fails with `cannot schedule new futures after shutdown` against the previous
commit.

Re-verified in the browser after the fix: index, OID search, the full object page with all ~19
catalog tables, `/tags`, `/login`, plus repeated page loads to confirm the pool survives across
requests.


## No thread pool at all, on purpose

Two earlier versions of this branch had one, and both were wrong:

1. A private `ThreadPoolExecutor` sized to match `gunicorn --threads=8` — an invisible,
   load-bearing relationship between `Dockerfile:70` and a module constant. Change `--threads`
   and throughput drops silently.
2. Plain `asyncio.to_thread`, which falls through to asyncio's default executor and therefore to
   the stdlib default `min(32, process_cpu_count() + 4)` — a number nobody in this repo chose,
   derived from the container's CPU allocation, and not greppable from anywhere.

**The wrapper now runs the callback inline, on the thread that awaits it.** On Flask that is the
gunicorn worker thread — precisely where callbacks run today, with no shim. So this PR is
genuinely inert: it changes the *shape* of every callback (coroutine, as the flip requires) and
nothing about how or where it executes.

Offloading is a real requirement, but only for the FastAPI backend, and it needs a pool size —
which needs a single configured home. Both arrive together in `aio-uvicorn`, not here.
`test_wrapper_runs_inline_on_the_awaiting_thread` pins the current behaviour so reintroducing an
offload has to be a deliberate, visible change rather than a drive-by.

## Plan changes

- `aio-uvicorn` now states the rule that **thread-pool sizes are decided in exactly one place**
  — `config.py`, from an environment variable set beside the entrypoint — and that no module may
  build its own executor or fall through to a stdlib default. It names **both** pools that need
  setting, since missing either leaves a default in play: asyncio's default executor (every
  `asyncio.to_thread` reaches it) and anyio's limiter (Starlette runs the sync `def` route
  handlers there, default 40 tokens). It is also where this wrapper becomes an offload, with a
  test tying the two together — flipping the backend while the wrapper is still inline would
  serialize every callback onto the loop.
- `aio-offload-threads` gets the sizing rationale: fan-out width, not core count. One object page
  fans out to ~19 catalogs, so a `cpu_count + 4`-shaped pool would serialize a single user's page.
- `aio-cleanup` now says to **retire this shim**, rather than leaving it in place forever. Once
  the I/O callbacks are natively async and the sync third parties have their own semaphores, what
  remains wrapped is trivial presentation callbacks, where a thread hop costs more than running
  inline.
- `aio-uvicorn` runs **`--workers 1`**, which closes open question 1. One loop, one process:
  concurrency comes from the loop instead of replication, and a second worker would mostly buy a
  second copy of the 148 MiB bayestar map and halve the in-process cache hit rate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
