### PR TITLE
Fix client-side State error on /tags for logged-out users

### DIFF
--- a/tests/pages/test_tags.py
+++ b/tests/pages/test_tags.py
@@ -1,0 +1,44 @@
+"""Regression test for the new-tag State inputs on the /tags page.
+
+`new-tag-priority-input`, `new-tag-name-input` and `new-tag-description-input`
+are only rendered when logged in, so their States use ALL-wildcard pattern
+matching ids: Dash returns an empty list rather than erroring when the
+matching component is absent from the current layout. `set_save_status` must
+unpack those single-element (or empty) lists back into scalars.
+"""
+
+import inspect
+from unittest.mock import patch
+
+from ztf_viewer.pages import tags
+
+# Callback registration may wrap the function; the body under test is the innermost one.
+set_save_status = inspect.unwrap(tags.set_save_status)
+
+
+def test_set_save_status_unpacks_pattern_matched_new_tag_state():
+    with patch("ztf_viewer.pages.tags.akb") as mock_akb:
+        mock_akb.is_token_valid.return_value = True
+        set_save_status(
+            n_clicks=1,
+            tags=[],
+            priorities=[],
+            new_priority=[5],
+            new_name=["foo"],
+            new_description=["bar"],
+        )
+    mock_akb.post_tags.assert_called_once_with([dict(name="foo", priority=5, description="bar")])
+
+
+def test_set_save_status_tolerates_empty_new_tag_state():
+    with patch("ztf_viewer.pages.tags.akb") as mock_akb:
+        mock_akb.is_token_valid.return_value = True
+        set_save_status(
+            n_clicks=1,
+            tags=[],
+            priorities=[],
+            new_priority=[],
+            new_name=[],
+            new_description=[],
+        )
+    mock_akb.post_tags.assert_called_once_with([])

--- a/ztf_viewer/pages/tags.py
+++ b/ztf_viewer/pages/tags.py
@@ -113,7 +113,7 @@ def show_tags(*_):
         html.Div(
             [
                 dcc.Input(
-                    id="new-tag-priority-input",
+                    id=dict(type="new-tag-priority-input", index=0),
                     value=max((tag["priority"] for tag in akb.get_tags()), default=-1) + 1,
                     type="number",
                     step=1,
@@ -124,7 +124,7 @@ def show_tags(*_):
                 " ",
                 dcc.Input(
                     value="",
-                    id="new-tag-name-input",
+                    id=dict(type="new-tag-name-input", index=0),
                     type="text",
                     size=20,
                     placeholder="Name of new tag",
@@ -133,7 +133,7 @@ def show_tags(*_):
                 " ",
                 dcc.Input(
                     value="",
-                    id="new-tag-description-input",
+                    id=dict(type="new-tag-description-input", index=0),
                     type="text",
                     size=80,
                     placeholder="Description of new tag",
@@ -159,9 +159,9 @@ def are_tags_priorities_unique(priorities):
     [
         State(dict(type="tag-priority-input", index=ALL), "id"),
         State(dict(type="tag-priority-input", index=ALL), "value"),
-        State("new-tag-priority-input", "value"),
-        State("new-tag-name-input", "value"),
-        State("new-tag-description-input", "value"),
+        State(dict(type="new-tag-priority-input", index=ALL), "value"),
+        State(dict(type="new-tag-name-input", index=ALL), "value"),
+        State(dict(type="new-tag-description-input", index=ALL), "value"),
     ],
 )
 def set_save_status(n_clicks, tags, priorities, new_priority, new_name, new_description):
@@ -169,6 +169,10 @@ def set_save_status(n_clicks, tags, priorities, new_priority, new_name, new_desc
         raise PreventUpdate
     if not akb.is_token_valid():
         return "Error: unauthorised"
+    # New-tag inputs are only rendered when logged in, so the pattern-matching State lists are empty otherwise.
+    new_priority = new_priority[0] if new_priority else None
+    new_name = new_name[0] if new_name else ""
+    new_description = new_description[0] if new_description else ""
     tags = [dict(name=tag_id["index"], priority=priority) for tag_id, priority in zip(tags, priorities)]
     if new_name:
         if not is_tag_name_correct(new_name):


### PR DESCRIPTION
## Summary

Loading `/tags` while logged out throws a browser console error:

```
ReferenceError: A nonexistent object was used in an `State` of a Dash
callback. The id of this object is `new-tag-priority-input` and the
property is `value`. The string ids in the current layout are: [...]
```

The page still renders and there is no server-side error, but the error is
real and reproduces on `master`.

## Cause

`ztf_viewer/pages/tags.py` has two callbacks:

- `show_tags` (Output `tags-list.children`) renders the per-tag rows plus
  three "add a new tag" inputs (`new-tag-priority-input`,
  `new-tag-name-input`, `new-tag-description-input`) — but only when
  `akb.is_token_valid()` is true. When logged out it `raise PreventUpdate`s
  and `tags-list` keeps its static "Login to edit tags" placeholder from
  `get_layout`, so none of those three components ever exist in the DOM.
- `set_save_status` (Input `tags-list-save-button.n_clicks`) declares plain
  `State("new-tag-priority-input", "value")` etc. unconditionally.

`tags-list-save-button` is rendered in `get_layout` unconditionally, so its
`n_clicks` Input (initial value 0) fires the callback once on page load
regardless of login state. dash-renderer resolves every `State` id against
the *current* layout before invoking the callback, and when logged out the
three ids above aren't in it, hence the client-side `ReferenceError`. The
Python body never runs in this case (`if not n_clicks: raise PreventUpdate`
would fire first even if the lookup succeeded), so there's no server error
— the failure is purely in dash-renderer's own id resolution.

`suppress_callback_exceptions = True` (set globally in `ztf_viewer/app.py`)
does not help here: it only suppresses Dash's *build-time* check that every
callback's ids appear somewhere in the app's possible layouts. It does not
touch dash-renderer's *runtime* check that a `State`'s component is present
in the layout actually mounted when the callback fires.

The error message only names `new-tag-priority-input` (dash-renderer stops
at the first missing id it hits), but `new-tag-name-input` and
`new-tag-description-input` have the identical problem — same lifecycle,
same callback, same unconditional `State`. I fixed all three, not just the
one named in the report.

## Fix

Gave the three inputs pattern-matching ids (`dict(type=..., index=0)`) and
changed the corresponding `State`s to use the `ALL` wildcard, the same
mechanism already used for the per-tag `tag-priority-input` states just
above them in the same callback. With a wildcard selector, dash-renderer
returns an empty list instead of erroring when no matching component exists,
so it tolerates the logged-out layout. `set_save_status` now unpacks the
resulting 0-or-1-element lists back into scalars at the top of the function.

When logged in, exactly one component of each type still exists, so the
list always has exactly one element and behaviour is unchanged.

## Alternatives considered

- **`suppress_callback_exceptions`**: already on, doesn't apply — see above,
  it's a build-time check, not this runtime one.
- **Render the three inputs always, hidden when logged out**: would work,
  but the priority input's default value is
  `max(tag priorities) + 1`, computed from `akb.get_tags()`, which requires
  a valid token. Making that safe when logged out means either calling the
  authenticated endpoint anonymously (it would just fail) or duplicating the
  "am I logged in" branching into `get_layout`, which currently only lives
  in `show_tags`. That's more surface area for the same fix.
- **Restructure which callback owns the State** (e.g. move the "add new
  tag" fields into their own always-mounted component tree with a separate
  Output): a bigger refactor of `tags.py` for no behavioural gain over the
  pattern-matching fix.
- **Delete the State**: rejected outright — the three fields are exactly
  the data `set_save_status` needs to create a new tag when logged in; this
  path is load-bearing.

The pattern-matching wildcard is the smallest change: it's the same idiom
this file already uses for the (also potentially absent) per-tag inputs, it
requires no layout restructuring, and it makes the "may not exist" behaviour
explicit rather than accidental.

## Testing

- Reproduced the error in a real browser (Playwright/WebKit) against the
  unpatched code on `/tags` logged out; confirmed it disappears after the
  fix while the page still renders (tag list placeholder, Save/Reset
  buttons, instructions) with no other new console errors. Remaining
  console noise (JS9 static asset 500s, a React `defaultProps` deprecation
  warning) is pre-existing and unrelated — present before and after.
- Added `tests/pages/test_tags.py`, unit-testing `set_save_status`'s new
  list-unpacking logic directly (mocking `akb`): one test with populated
  single-element lists (the logged-in shape) asserting the correct tag dict
  is posted, one with empty lists asserting it degrades gracefully. Verified
  both fail against the pre-fix code (`TypeError: expected string or
  bytes-like object, got 'list'`), so they're not vacuous.
- Ran the full suite: all tests pass except one pre-existing skip (JS9 not
  installed locally, unrelated) and pre-existing redis `setex` deprecation
  warnings, both present on `master` too.

## What I could not test

I did not exercise the actual logged-in flow (no AKB token available in this
environment), so I could not click through "add a new tag" end-to-end in a
browser against a real session. I reasoned about it from the code instead:
`show_tags` renders exactly one `new-tag-priority-input`/`-name-input`/
`-description-input` whenever `akb.is_token_valid()` is true, so the
`ALL`-wildcard State always resolves to a single-element list in that case,
and the new unpacking line (`new_priority[0] if new_priority else None`)
recovers the same scalar the old plain `State` would have delivered. The
per-tag `tag-priority-input` states (`ALL` already) are untouched.


## Interaction with #647

The unit test calls `set_save_status` directly. On `master` that name is the plain function, but
once #647's callback shim lands it is a coroutine wrapper, and calling it returns an un-awaited
coroutine — so the two branches are green apart and red together, whichever merges second. The
test therefore resolves the innermost function with `inspect.unwrap`, which is a no-op today and
correct after #647. Verified both ways: green on this branch, and green with `callback-shim`
merged in locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
