### PR TITLE
Extract a per-loop resource registry, retrofit the four ad-hoc copies

### DIFF
--- a/tests/test_cache_async.py
+++ b/tests/test_cache_async.py
@@ -314,7 +314,7 @@ def test_two_successive_asyncio_run_calls_both_work(request, monkeypatch, cache_
 
 # --------------------------------------------------------------------------------------------
 # Cross-thread registry safety: many threads, each its own loop, populate the same
-# WeakKeyDictionary concurrently (a threading.Lock guards the get-and-create, not an asyncio one)
+# LoopRegistry concurrently (a threading.Lock guards the get-and-create, not an asyncio one)
 # --------------------------------------------------------------------------------------------
 
 N_THREADS = 8
@@ -352,13 +352,13 @@ def _run_from_n_threads(touch):
 
 
 def test_async_memory_backend_lock_registry_survives_concurrent_threads():
-    """threading.Lock, not asyncio: the WeakKeyDictionary is shared across threads, one loop each."""
+    """threading.Lock, not asyncio: the LoopRegistry is shared across threads, one loop each."""
     from ztf_viewer.cache.memory import AsyncMemoryBackend, create_memory_backend
 
     backend = AsyncMemoryBackend(create_memory_backend(1 << 16, ttl=3600))
 
     async def touch():
-        return backend._lock()
+        return backend._locks.get()
 
     loops, locks = _run_from_n_threads(touch)
 
@@ -367,13 +367,13 @@ def test_async_memory_backend_lock_registry_survives_concurrent_threads():
 
 
 def test_async_redis_backend_client_registry_survives_concurrent_threads():
-    """threading.Lock, not asyncio: the WeakKeyDictionary is shared across threads, one loop each."""
+    """threading.Lock, not asyncio: the LoopRegistry is shared across threads, one loop each."""
     from ztf_viewer.cache.redis import AsyncRedisBackend
 
     backend = AsyncRedisBackend(lambda: redis.asyncio.Redis(host="localhost"), ttl=3600)
 
     async def touch():
-        return backend._client()
+        return backend._clients.get()
 
     loops, clients = _run_from_n_threads(touch)
 

--- a/tests/test_cache_single_flight.py
+++ b/tests/test_cache_single_flight.py
@@ -674,12 +674,12 @@ async def test_async_singleflight_inflight_entry_cleared_after_reentrancy_error(
 
 # --------------------------------------------------------------------------------------------
 # Cross-thread registry safety: many threads, each its own loop, populate the same
-# WeakKeyDictionary concurrently (a threading.Lock guards the get-and-create, not an asyncio one)
+# LoopRegistry concurrently (a threading.Lock guards the get-and-create, not an asyncio one)
 # --------------------------------------------------------------------------------------------
 
 
 def test_async_singleflight_table_registry_survives_concurrent_threads():
-    """threading.Lock, not asyncio: the WeakKeyDictionary is shared across threads, one loop each."""
+    """threading.Lock, not asyncio: the LoopRegistry is shared across threads, one loop each."""
     sf = AsyncSingleFlight()
     n = 8
     barrier = threading.Barrier(n)
@@ -689,7 +689,7 @@ def test_async_singleflight_table_registry_survives_concurrent_threads():
 
     async def body():
         barrier.wait(timeout=5)
-        return asyncio.get_running_loop(), sf._table()
+        return asyncio.get_running_loop(), sf._tables.get()
 
     def worker(i):
         try:

--- a/tests/test_loop_registry.py
+++ b/tests/test_loop_registry.py
@@ -1,0 +1,87 @@
+"""Tests for the per-loop resource registry."""
+
+import asyncio
+import gc
+
+from ztf_viewer.loop_registry import LoopRegistry
+
+
+def test_not_created_at_construction() -> None:
+    """Building the registry must not call the factory."""
+    calls = []
+    LoopRegistry(lambda: calls.append(1))
+    assert calls == []
+
+
+def test_two_successive_asyncio_run_calls_both_get_a_resource() -> None:
+    """Simulates Flask's per-request event loop: each `asyncio.run()` call gets a fresh
+    resource, and using it does not raise even though the first loop is long closed."""
+    registry = LoopRegistry(object)
+
+    async def body():
+        resource = registry.get()
+        assert resource is registry.get()  # same loop, same call: reused within the request
+        return resource
+
+    first = asyncio.run(body())
+    second = asyncio.run(body())
+    assert first is not second
+
+
+def test_single_long_lived_loop_reuses_one_instance() -> None:
+    """Simulates FastAPI's one-loop-per-worker model: repeated `get()` calls on the same
+    running loop return the same instance."""
+    registry = LoopRegistry(object)
+
+    async def body():
+        return registry.get(), registry.get()
+
+    first, second = asyncio.run(body())
+    assert first is second
+
+
+def test_cleanup_drops_entries_via_gc() -> None:
+    """When nothing else holds the loop, the weak entry disappears on its own."""
+    registry = LoopRegistry(object)
+
+    async def body():
+        registry.get()
+
+    asyncio.run(body())
+    gc.collect()
+    assert len(registry) == 0
+
+
+def test_discard_drops_the_entry_immediately() -> None:
+    """`discard()` is the deterministic counterpart to relying on garbage collection."""
+    registry = LoopRegistry(object)
+
+    async def body():
+        registry.get()
+        assert len(registry) == 1
+        registry.discard()
+        assert len(registry) == 0
+
+    asyncio.run(body())
+
+
+def test_concurrent_tasks_on_the_same_loop_share_one_resource() -> None:
+    """Two tasks on the same loop calling `get()` concurrently must not create two resources."""
+    calls = []
+
+    def factory():
+        calls.append(1)
+        return object()
+
+    registry = LoopRegistry(factory)
+
+    async def worker():
+        return registry.get()
+
+    async def body():
+        first, second = await asyncio.gather(worker(), worker())
+        return first, second
+
+    first, second = asyncio.run(body())
+    assert first is second
+    assert calls == [1]

--- a/ztf_viewer/cache/memory.py
+++ b/ztf_viewer/cache/memory.py
@@ -12,6 +12,7 @@ import weakref
 from cachetools import TTLCache
 
 from ztf_viewer.cache.decorator import make_async_cache
+from ztf_viewer.loop_registry import LoopRegistry
 
 # Every live memory backend, so that `clear_memory_caches()` can reach the ones captured by
 # functions that were decorated at import time.
@@ -51,30 +52,20 @@ class AsyncMemoryBackend:
     holding it, and because a lock is the cheapest guard against ever assuming otherwise.  It is
     created lazily, per running loop, rather than once in ``__init__`` — an ``asyncio.Lock``
     binds to whichever loop first uses it, and this must keep working across successive
-    ``asyncio.run()`` calls (Flask's per-request loop model). A `weakref.WeakKeyDictionary` here
-    is a stand-in for a per-loop registry a later change will retrofit onto this.
+    ``asyncio.run()`` calls (Flask's per-request loop model) — via
+    :class:`~ztf_viewer.loop_registry.LoopRegistry`.
     """
 
     def __init__(self, backend: MemoryBackend):
         self._backend = backend
-        self._locks = weakref.WeakKeyDictionary()
-        self._registry_lock = threading.Lock()
-
-    def _lock(self) -> asyncio.Lock:
-        loop = asyncio.get_running_loop()
-        # threading.Lock, not asyncio: the WeakKeyDictionary itself is shared across threads, one loop each.
-        with self._registry_lock:
-            lock = self._locks.get(loop)
-            if lock is None:
-                lock = self._locks[loop] = asyncio.Lock()
-        return lock
+        self._locks = LoopRegistry(asyncio.Lock)
 
     async def get(self, key):
-        async with self._lock():
+        async with self._locks.get():
             return self._backend.get(key)
 
     async def set(self, key, blob):
-        async with self._lock():
+        async with self._locks.get():
             self._backend.set(key, blob)
 
 

--- a/ztf_viewer/cache/redis.py
+++ b/ztf_viewer/cache/redis.py
@@ -13,15 +13,12 @@ the memory backend): both just point at the same Redis server and use the same k
 (``ztf_viewer.cache.core``), so a value either writes is a hit for the other.
 """
 
-import asyncio
-import threading
-import weakref
-
 import redis
 import redis.asyncio
 
 from ztf_viewer import config
 from ztf_viewer.cache.decorator import make_async_cache, make_cache
+from ztf_viewer.loop_registry import LoopRegistry
 
 
 class RedisBackend:
@@ -45,31 +42,19 @@ class AsyncRedisBackend:
 
     A connection pool is loop-affine — building it at import or construction time would bind it
     to whatever loop happens to be running then, and break on a second ``asyncio.run()`` (Flask's
-    per-request loop model). ``client_factory`` is called again for each new running loop
-    instead. A `weakref.WeakKeyDictionary` here is a stand-in for a per-loop registry a later
-    change will retrofit onto this.
+    per-request loop model). ``client_factory`` is called again for each new running loop instead,
+    via :class:`~ztf_viewer.loop_registry.LoopRegistry`.
     """
 
     def __init__(self, client_factory, ttl):
-        self._client_factory = client_factory
         self._ttl = ttl
-        self._clients = weakref.WeakKeyDictionary()
-        self._registry_lock = threading.Lock()
-
-    def _client(self):
-        loop = asyncio.get_running_loop()
-        # threading.Lock, not asyncio: the WeakKeyDictionary itself is shared across threads, one loop each.
-        with self._registry_lock:
-            client = self._clients.get(loop)
-            if client is None:
-                client = self._clients[loop] = self._client_factory()
-        return client
+        self._clients = LoopRegistry(client_factory)
 
     async def get(self, key):
-        return await self._client().get(key)
+        return await self._clients.get().get(key)
 
     async def set(self, key, blob):
-        await self._client().set(key, blob, ex=self._ttl)
+        await self._clients.get().set(key, blob, ex=self._ttl)
 
 
 def create_async_redis_cache(ttl):

--- a/ztf_viewer/cache/single_flight.py
+++ b/ztf_viewer/cache/single_flight.py
@@ -4,8 +4,8 @@ function, not N.
 Both implementations are the same shape — the leader resolves a future, the followers read it —
 over the two kinds of concurrency: threads (``concurrent.futures.Future``) and tasks within one
 event loop (``asyncio.Future``). Asyncio futures are loop-affine, so a leader in one loop can
-never share its future with a waiter in another; that table is keyed by loop, a stand-in for a
-per-loop registry a later change will retrofit onto this (as with the async cache backends).
+never share its future with a waiter in another; that table is keyed by loop, via
+:class:`~ztf_viewer.loop_registry.LoopRegistry` (as with the async cache backends).
 
 In both implementations a leader that raises propagates that same exception object to every
 waiter — including a leader whose own task was cancelled: cancellation is just the leader's
@@ -14,8 +14,9 @@ exception in this scheme, never a reason to leave the followers hanging.
 
 import asyncio
 import threading
-import weakref
 from concurrent.futures import Future
+
+from ztf_viewer.loop_registry import LoopRegistry
 
 
 class SingleFlight:
@@ -60,20 +61,10 @@ class AsyncSingleFlight:
     """Coalesce concurrent calls under the same key onto one task's call, within one loop."""
 
     def __init__(self):
-        self._tables = weakref.WeakKeyDictionary()
-        self._registry_lock = threading.Lock()
-
-    def _table(self) -> dict:
-        loop = asyncio.get_running_loop()
-        # threading.Lock, not asyncio: the WeakKeyDictionary itself is shared across threads, one loop each.
-        with self._registry_lock:
-            table = self._tables.get(loop)
-            if table is None:
-                table = self._tables[loop] = {}
-        return table
+        self._tables = LoopRegistry(dict)
 
     async def run(self, key, compute):
-        table = self._table()
+        table = self._tables.get()
         task = asyncio.current_task()
         entry = table.get(key)
         if entry is not None:

--- a/ztf_viewer/loop_registry.py
+++ b/ztf_viewer/loop_registry.py
@@ -1,0 +1,61 @@
+"""A registry for loop-affine resources — clients, pools, locks — bound to whichever
+asyncio event loop is running when they are first requested.
+
+Flask's async callback dispatch runs each request through its own fresh event loop
+(``asgiref.async_to_sync``); FastAPI keeps one loop per worker for its whole lifetime. Anything
+bound to a loop at construction time — a ``redis.asyncio`` pool, an ``httpx.AsyncClient``, an
+``asyncio.Lock`` — breaks the moment it is reused from a different loop. The fix is to build such
+resources lazily, keyed by ``asyncio.get_running_loop()``, one instance per loop.
+
+Keying on ``id(loop)`` would be a bug: ids are recycled once a loop is garbage collected, so a
+brand-new loop can silently inherit a dead loop's entry. Keying the table on the loop object
+itself, held only weakly, sidesteps this: identity, not a reused integer, decides equality, and
+the entry disappears on its own once nothing else holds the loop — which is exactly when Flask
+drops it after a request. ``discard()`` exists for callers that want that deterministic rather
+than GC-timed.
+
+No lock is needed around the body that runs after ``get()`` returns: only one task runs at a
+time per loop, so two tasks on the *same* loop can never race to create two resources for that
+loop. But the table is shared across loops that may live on different threads (Flask spins up
+its per-request loop on a gunicorn worker thread), so mutating the shared dict itself still
+needs a plain ``threading.Lock`` — an ``asyncio.Lock`` would itself be loop-affine and defeat
+the purpose.
+"""
+
+import asyncio
+import threading
+import weakref
+from typing import Callable, Generic, Optional, TypeVar
+
+_T = TypeVar("_T")
+
+
+class LoopRegistry(Generic[_T]):
+    """One instance of a loop-affine resource per running event loop.
+
+    ``factory`` is called with no arguments to build a fresh resource; it must not do anything
+    that only makes sense on a particular loop until :meth:`get` actually calls it.
+    """
+
+    def __init__(self, factory: Callable[[], _T]):
+        self._factory = factory
+        self._entries: "weakref.WeakKeyDictionary[asyncio.AbstractEventLoop, _T]" = weakref.WeakKeyDictionary()
+        self._registry_lock = threading.Lock()
+
+    def get(self) -> _T:
+        loop = asyncio.get_running_loop()
+        with self._registry_lock:
+            resource = self._entries.get(loop)
+            if resource is None:
+                resource = self._entries[loop] = self._factory()
+        return resource
+
+    def discard(self, loop: Optional[asyncio.AbstractEventLoop] = None) -> None:
+        """Drop the entry for `loop` (the running loop by default), if any."""
+        if loop is None:
+            loop = asyncio.get_running_loop()
+        with self._registry_lock:
+            self._entries.pop(loop, None)
+
+    def __len__(self) -> int:
+        return len(self._entries)

--- a/ztf_viewer/loop_registry.py
+++ b/ztf_viewer/loop_registry.py
@@ -9,10 +9,25 @@ resources lazily, keyed by ``asyncio.get_running_loop()``, one instance per loop
 
 Keying on ``id(loop)`` would be a bug: ids are recycled once a loop is garbage collected, so a
 brand-new loop can silently inherit a dead loop's entry. Keying the table on the loop object
-itself, held only weakly, sidesteps this: identity, not a reused integer, decides equality, and
-the entry disappears on its own once nothing else holds the loop — which is exactly when Flask
-drops it after a request. ``discard()`` exists for callers that want that deterministic rather
-than GC-timed.
+itself, held only weakly, sidesteps this — identity, not a reused integer, decides equality.
+
+**Weak keys do not by themselves reclaim entries, and for two of the current values they do not
+reclaim them at all.** A ``WeakKeyDictionary`` holds its values strongly, so any value that
+references its own loop keeps its own key alive: a connected ``redis.asyncio`` client reaches its
+loop through ``transport._loop``, and that entry then survives every collection. Measured: five
+successive ``asyncio.run`` calls leave five entries, growing without bound. The values that hold
+nothing — an ``asyncio.Lock``, a plain ``dict`` — are reclaimed as expected.
+
+Nothing in the app reaches the affected paths yet, and under a single long-lived loop one entry
+is the whole population, so this bites only a loop-per-request backend driving a real client. It
+needs an explicit sweep of closed loops rather than more weakness; that lands separately.
+``discard()`` drops one entry deterministically in the meantime.
+
+Cleaning up *after* a loop is gone is not an option worth designing toward: ``aclose()`` needs a
+live loop, ``transport.close()`` raises ``RuntimeError: Event loop is closed``, and a
+``weakref.finalize`` on the loop cannot help either — holding the resource to close it later is
+exactly what keeps the loop alive, so the finalizer never runs until interpreter exit. A resource
+is closed on its own loop, while that loop still runs, or it is left to the garbage collector.
 
 No lock is needed around the body that runs after ``get()`` returns: only one task runs at a
 time per loop, so two tasks on the *same* loop can never race to create two resources for that

--- a/ztf_viewer/ttl_set.py
+++ b/ztf_viewer/ttl_set.py
@@ -8,10 +8,7 @@ they expose plain async methods with names chosen to read naturally with `await`
 `discard`, `remove`, `clear`, `contains`, `size`, `values`.
 """
 
-import asyncio
 import pickle
-import threading
-import weakref
 from abc import ABC, abstractmethod
 from collections.abc import MutableSet
 from typing import Callable, Generic, Hashable, Iterator, TypeVar
@@ -19,6 +16,8 @@ from typing import Callable, Generic, Hashable, Iterator, TypeVar
 import redis.asyncio
 from cachetools import TTLCache
 from redis import StrictRedis
+
+from ztf_viewer.loop_registry import LoopRegistry
 
 _T_Base = TypeVar("_T_Base")
 
@@ -172,8 +171,8 @@ class AsyncRedisTTLSet(Generic[_T_AsyncRedis]):
     """Async counterpart to :class:`RedisTTLSet`, on ``redis.asyncio``.
 
     A connection pool is bound to the loop that created it, so the client is built lazily per
-    running loop rather than once in ``__init__`` — mirrors ``AsyncRedisBackend`` in
-    ``ztf_viewer/cache/redis.py``; keep the two in sync if that pattern changes.
+    running loop rather than once in ``__init__``, through
+    :class:`~ztf_viewer.loop_registry.LoopRegistry`.
 
     Nothing here does I/O in ``__init__``.
     """
@@ -185,23 +184,15 @@ class AsyncRedisTTLSet(Generic[_T_AsyncRedis]):
         prefix: str = "RedisTTLSet",
     ):
         self.ttl = ttl
-        self._client_factory = client_factory
 
         self.prefix = prefix.encode()
         if b"*" in self.prefix:
             raise ValueError('prefix must not contain "*"')
 
-        self._clients: weakref.WeakKeyDictionary = weakref.WeakKeyDictionary()
-        self._registry_lock = threading.Lock()
+        self._clients = LoopRegistry(client_factory)
 
     def _client(self) -> "redis.asyncio.Redis":
-        loop = asyncio.get_running_loop()
-        # threading.Lock, not asyncio: the WeakKeyDictionary itself is shared across threads, one loop each.
-        with self._registry_lock:
-            client = self._clients.get(loop)
-            if client is None:
-                client = self._clients[loop] = self._client_factory()
-        return client
+        return self._clients.get()
 
     def _encode(self, value: _T_AsyncRedis) -> bytes:
         serialized = pickle.dumps(value, protocol=pickle.HIGHEST_PROTOCOL)


### PR DESCRIPTION
> **Correction (after review).** This description originally claimed that "the entry disappears on its own once nothing else holds the loop — no leak accumulates request over request." **That is false for two of the four sites.** `WeakKeyDictionary` holds values strongly, and a connected `redis.asyncio` client references its own loop via `transport._loop`, so it pins its own key: five successive loops leave five entries. The `asyncio.Lock` and `dict` registries are reclaimed as described. The docstring here now states this accurately; the fix is #654. The affected paths are inert today — nothing calls `unavailable_catalogs_async`, and all 26 `@cache()` sites still wrap sync functions.

## What changed and why

Flask dispatches async callbacks through a fresh `asyncio` event loop per request
(`asgiref.async_to_sync`); FastAPI keeps one long-lived loop per worker. Anything
loop-affine — an `httpx.AsyncClient` pool, a `redis.asyncio` pool, an `asyncio.Lock` —
built at import or construction time is bound to whichever loop happened to be running
then, and breaks the moment it is reused from a different one.

The codebase already worked around this in four places, each with its own copy of the
same shape: a `weakref.WeakKeyDictionary` keyed by the running loop plus a
`threading.Lock` guarding the get-or-create. This PR pulls that pattern into one module,
`ztf_viewer/loop_registry.py` (`LoopRegistry`), and points all four existing sites at it.
It is inert: nothing observable changes at runtime, only where the pattern lives.

## The id-recycling / cleanup reasoning

Keying the table on `id(loop)` would be a bug waiting to happen: ids are recycled once an
object is garbage collected, so a brand-new loop can silently inherit a dead loop's entry
and reuse a resource bound to a closed loop.

`LoopRegistry` keys its table on the loop object itself, held only weakly
(`weakref.WeakKeyDictionary`). Identity — not a reused integer — decides equality, and the
entry disappears on its own once nothing else holds the loop, which is exactly when Flask
drops one after a request; no leak accumulates request over request. `discard()` is
provided for callers that want that deterministic rather than GC-timed (and is exercised
directly by a test rather than relying on `gc.collect()` alone).

Concurrency reasoning, written into the module docstring: only one task runs at a time per
loop, so two tasks on the *same* loop can never race to create two resources for that loop
— no `asyncio.Lock` is needed around the body after `get()` returns, and adding one would
itself be loop-affine and defeat the purpose. The table is still shared across loops that
may live on different threads (Flask can run its per-request loop on a gunicorn worker
thread), so mutating the shared `WeakKeyDictionary` still needs a plain `threading.Lock`.

## What was retrofitted

All four pre-existing per-loop caches, replacing their own `WeakKeyDictionary` +
`threading.Lock` pair with a `LoopRegistry` instance, no other behavioural change:

- `ztf_viewer/ttl_set.py` — `AsyncRedisTTLSet._client()`
- `ztf_viewer/cache/memory.py` — `AsyncMemoryBackend._lock()` (now `self._locks.get()`)
- `ztf_viewer/cache/single_flight.py` — `AsyncSingleFlight._table()` (now `self._tables.get()`)
- `ztf_viewer/cache/redis.py` — `AsyncRedisBackend._client()`

Three existing tests reached into the old private `_lock()`/`_client()`/`_table()` methods
and `WeakKeyDictionary` internals directly; they're updated to call the registry's public
`.get()` instead, and to expect a `LoopRegistry` rather than a raw `WeakKeyDictionary`
(`len()` still works — `LoopRegistry` implements `__len__`).

## Tests

New: `tests/test_loop_registry.py` — construction does not call the factory; two successive `asyncio.run()` calls (simulating Flask's per-request loop) each get a working resource and the second does not reuse the first, now-closed loop's entry; a single long-lived loop (simulating FastAPI) reuses one instance; GC drops the weak entry once the loop goes away; `discard()` drops it immediately; two tasks racing on the same loop share one resource.

Full suite **including the redis-backed tests**:

```
CACHE_TYPE=memory UNAVAILABLE_CATALOGS_CACHE_TYPE=memory pytest -m "not upstream" --basetemp=/tmp/pytest
362 passed, 1 skipped in 49.76s
```

The single skip is pre-existing and unrelated (JS9 is installed into the image at build time, not present locally). `--basetemp=/tmp/pytest` is required on macOS: the default tmpdir makes `pytest-redis`' unix socket path exceed the 104-char limit, which is what makes the `redis`-marked tests *look* broken locally.

## Things to look at skeptically

- Cleanup is by weakref, not by an explicit loop-close hook. The entry drops when the loop is collected, which on CPython is prompt. But a resource needing **async teardown** — a `redis.asyncio` client holding connections — is dropped without ever being `aclose()`d; the connections go with the loop rather than being closed on it. That is pre-existing behaviour, not introduced here, and it is worth deciding deliberately before `aio-httpx` adds a connection pool with the same shape.
- `LoopRegistry.discard()` defaults to the running loop; a caller with no running loop must pass one. No production call site uses it yet — it exists for tests and future callers.
