### PR TITLE
Convert three pilot callbacks to native async def

### DIFF
--- a/tests/pages/test_tags.py
+++ b/tests/pages/test_tags.py
@@ -8,7 +8,10 @@ unpack those single-element (or empty) lists back into scalars.
 """
 
 import inspect
+import types
 from unittest.mock import patch
+
+from dash._callback_context import context_value
 
 from ztf_viewer.pages import tags
 
@@ -42,3 +45,25 @@ def test_set_save_status_tolerates_empty_new_tag_state():
             new_description=[],
         )
     mock_akb.post_tags.assert_called_once_with([])
+
+
+async def test_show_tags_is_a_native_coroutine_that_reads_ctx_cookies():
+    """``show_tags`` is ``async def`` directly, not shim-wrapped; ``dash.ctx.cookies`` must
+    still resolve to the token from the current callback context."""
+    assert inspect.iscoroutinefunction(tags.show_tags)
+
+    token = context_value.set(types.SimpleNamespace(cookies={"akb_token": "abc123"}))
+    try:
+        with (
+            patch.object(tags.akb, "_is_token_valid") as mock_is_token_valid,
+            patch.object(tags.akb, "get_tags", return_value=[]),
+        ):
+            mock_is_token_valid.return_value = True
+            result = await tags.show_tags(None, None, None)
+    finally:
+        context_value.reset(token)
+
+    # The mock is only reachable through `is_token_valid` -> `_token_from_cookies`, so this
+    # also proves the cookie set above is the value that made it through.
+    mock_is_token_valid.assert_called_once_with(token="abc123")
+    assert isinstance(result, list)

--- a/tests/test_viewer_async_pilots.py
+++ b/tests/test_viewer_async_pilots.py
@@ -1,0 +1,65 @@
+"""Mechanics tests for the natively-async pilot callbacks in ``ztf_viewer.pages.viewer``.
+
+These callbacks are unchanged in behaviour from their shim-wrapped ``def`` form; the point of
+these tests is proving the registration and dispatch mechanics work, not re-testing business
+logic already covered elsewhere (or, for ``get_summary``, not covered at all yet).
+"""
+
+import functools
+import inspect
+
+import pytest
+from dash.exceptions import PreventUpdate
+
+from ztf_viewer.pages import viewer
+
+
+def test_set_figure_link_partial_registrations_are_coroutines_in_callback_map():
+    """19 `set_table` aside, this is the shape most registrations take: `partial` of a shared body."""
+    png_entry = viewer.app.callback_map["figure-png-link.href"]
+    pdf_entry = viewer.app.callback_map["figure-pdf-link.href"]
+    assert inspect.iscoroutinefunction(png_entry["callback"])
+    assert inspect.iscoroutinefunction(pdf_entry["callback"])
+
+
+async def test_partial_of_set_figure_link_is_a_coroutine_the_shim_does_not_need_to_wrap():
+    """`inspect.iscoroutinefunction` sees through `functools.partial` of an `async def`, so the
+    shim's `_to_coroutine_function` passes it through untouched."""
+    bound = functools.partial(viewer.set_figure_link, fmt="png")
+    assert inspect.iscoroutinefunction(bound)
+
+    href = await bound(
+        cur_oid="123",
+        dr="dr8",
+        title="t",
+        different_filter=None,
+        different_field=None,
+        min_mjd=None,
+        max_mjd=None,
+        lc_type="full",
+        period=None,
+        phase0=None,
+    )
+
+    assert href == "/dr8/figure/123?title=t&format=png"
+
+
+def test_get_summary_is_registered_as_a_coroutine():
+    entry = viewer.app.callback_map["summary.children"]
+    assert inspect.iscoroutinefunction(entry["callback"])
+
+
+async def test_get_summary_await_propagates_prevent_update_from_the_fan_out_callback():
+    """A fan-out callback's early-exit `raise PreventUpdate` must still surface through `await`
+    exactly as it did as a synchronous exception."""
+    assert inspect.iscoroutinefunction(viewer.get_summary)
+
+    with pytest.raises(PreventUpdate):
+        await viewer.get_summary(
+            oid="1",
+            dr="dr8",
+            different_filter=None,
+            different_field=None,
+            radius_ids=[{"index": "some_catalog"}],
+            radius_values=[None],
+        )

--- a/ztf_viewer/pages/tags.py
+++ b/ztf_viewer/pages/tags.py
@@ -85,7 +85,7 @@ def get_layout(*args, **kwargs):
         Input("tags-list-reset", "n_clicks"),
     ],
 )
-def show_tags(*_):
+async def show_tags(*_):
     if not akb.is_token_valid():
         raise PreventUpdate
     tags = akb.get_tags()

--- a/ztf_viewer/pages/viewer.py
+++ b/ztf_viewer/pages/viewer.py
@@ -1377,7 +1377,7 @@ def set_ref_mag_magerr(dr, _n_clicks, link_id, all_mag_ids, all_mag_values):
         Input(dict(type="search-radius", index=ALL), "value"),
     ],
 )
-def get_summary(oid, dr, different_filter, different_field, radius_ids, radius_values):
+async def get_summary(oid, dr, different_filter, different_field, radius_ids, radius_values):
     if None in radius_values:
         raise PreventUpdate
     radii = {id["index"]: float(value) for id, value in zip(radius_ids, radius_values)}
@@ -1795,7 +1795,7 @@ def set_figure(
     return fw, message_fit
 
 
-def set_figure_link(
+async def set_figure_link(
     cur_oid, dr, title, different_filter, different_field, min_mjd, max_mjd, lc_type, period, phase0, fmt
 ):
     if lc_type == "folded" and not period:


### PR DESCRIPTION
Three callbacks move from the registration-layer shim (`ztf_viewer/callbacks.py`, which wraps
any sync `def` into an `async def` that awaits it inline) to genuinely `async def`, chosen to
exercise the three riskiest registration/dispatch paths before the rest of the callback set
follows:

1. **`ztf_viewer/pages/tags.py::show_tags`** — the AKB/login path. It calls
   `akb.is_token_valid()`, which reads `dash.ctx.cookies` through
   `AKB._token_from_cookies` (`ztf_viewer/akb.py:35`). This proves `dash.ctx.cookies` still
   resolves correctly when read from *inside* a native coroutine, not just from a thread the
   shim spawned.
2. **`ztf_viewer/pages/viewer.py::set_figure_link`** — registered twice via
   `functools.partial` (`fmt="png"` / `fmt="pdf"`, `viewer.py:1824,1841`), one of the two
   partial-based shapes named in the plan (the other, `find_neighbours`, was left on the shim —
   one partial pilot is enough to prove the mechanic, and `set_figure_link`'s body has no I/O,
   which keeps the test trivial to write). `set_table`, the loop-registered 19-way partial site,
   was deliberately **not** touched here — the task brief calls it out as the riskiest of the
   `partial` sites and not the best pilot; it stays for a dedicated PR in the async-I/O stack.
3. **`ztf_viewer/pages/viewer.py::get_summary`** — the fan-out callback the plan's own "Why"
   section names explicitly: it loops over every cone-search catalog sequentially
   (`viewer.py:1388,1455`) plus half a dozen more upstream calls (features, extinction, ZTF
   reference, brokers). Converting its signature is the same one-line change as the other two;
   it is included because it is the shape the async-I/O stack will spend the most PRs on later,
   so proving today that an `async def` with a large, mixed body still dispatches, awaits, and
   raises `PreventUpdate` correctly is worth doing while rollback is still a one-line revert.

## This is behaviour-neutral, on purpose

None of these three bodies changed. `ztf_viewer/callbacks.py`'s shim already awaits every sync
callback inline on the calling thread (there is no thread pool anywhere in this codebase yet —
see `b27163b`/`7be023b` on `callback-shim`, which deliberately retired the shim's own pool).
Turning `def` into `async def` while the body still makes blocking `requests`/`astroquery`
calls changes **nothing at runtime today** on either backend: Flask still runs each request
callback through `asgiref`'s per-request loop, FastAPI isn't wired up at all yet. The only thing
that changes is who is holding the coroutine — Dash's own dispatcher instead of our shim's
`_to_coroutine_function` wrapper.

**This PR adds no thread pool, no `asyncio.to_thread`, no `run_in_executor`, and no `httpx`.**
That is all deliberately out of scope until `aio-uvicorn` (thread pool sizing) and `aio-httpx`
(async I/O) land. If a reviewer sees an offload anywhere in this diff, that is a bug, not a
feature.

## Conversion recipe

The mechanical procedure used for all three, meant to be repeatable ~15 more times without
re-deriving it:

1. **Find the source site.** `grep -n "^def <name>\|^@callback\|^callback("` in the owning
   module, or search `app.callback_map` by output id (`"<component-id>.<property>"`) if the
   registration is indirect (`partial`, loop).
2. **Change `def` to `async def` on the function itself.** Nothing else in the signature or
   body changes. Do not add `await` anywhere unless a call already returns an awaitable (none
   do yet — every I/O call in this codebase is still sync `requests`/`astroquery`).
3. **Leave the registration call site untouched.** `@callback(...)` / `callback(...)(fn)` /
   `callback(...)(partial(fn, ...))` all keep working: `ztf_viewer/callbacks.py`'s
   `_to_coroutine_function` checks `inspect.iscoroutinefunction`, which sees through
   `functools.partial` (including nested), so an already-async function or a partial of one is
   registered as-is — no wrapper, no behaviour change in the shim.
4. **Check for anything that assumes a synchronous call site.** In particular:
   `inspect.unwrap(...)` used in tests to reach "the real function" now finds the function
   itself (no wrapping happened), so such tests may need to drop the `unwrap` and instead
   `await` the function directly.
5. **Check for module-level use of the function as a plain callable** (not through Dash) —
   none of the three pilots had this, but a future site might; calling an `async def` without
   `await` silently returns a coroutine object instead of running the body, which is easy to
   miss without a test.
6. **Do not add offloading.** If the body is slow because of blocking I/O, that is out of scope
   here — leave it exactly as slow as it was. Converting the call itself to `httpx`/async is a
   separate, later stack.
7. **Write a mechanics test, not a behaviour test**, unless one doesn't already exist for that
   callback:
   - assert `inspect.iscoroutinefunction(the_function)` (and, for `partial` sites, of the bound
     `functools.partial`);
   - assert the corresponding `app.callback_map[...]["callback"]` entry is a coroutine function;
   - if the callback touches `dash.ctx` (cookies, triggered, etc.), set
     `dash._callback_context.context_value` directly (see
     `tests/pages/test_tags.py::test_show_tags_is_a_native_coroutine_that_reads_ctx_cookies`)
     and `await` the callback to prove context propagation still works with no thread hop
     involved at all.
8. **Run the full suite**, including `tests/test_callbacks_shim.py` — its
   `test_every_server_side_callback_is_a_coroutine_function` guard is what actually enforces F1
   for the whole app; a native conversion should never make it fail, only make one more entry
   "trivially" pass (it was already passing via the shim).

## Test evidence

```
367 passed, 1 skipped, 34 warnings in 49.53s
```
(Baseline before this PR: 362 passed, 1 skipped — the 5 new tests are
`tests/pages/test_tags.py::test_show_tags_is_a_native_coroutine_that_reads_ctx_cookies` and four
in `tests/test_viewer_async_pilots.py`.)

Command:
```
CACHE_TYPE=memory UNAVAILABLE_CATALOGS_CACHE_TYPE=memory PATH=/opt/homebrew/bin:$PATH \
  ~/.virtualenvs/web/bin/pytest -m "not upstream" --basetemp=/tmp/pytest
```

`pre-commit run --all-files` is clean (black reformatted one test file on the first run; clean
on the second).

## What a reviewer should be skeptical about

- **`get_summary`'s test is a negative-path test only** (`radius_values` containing `None` →
  `PreventUpdate`), not a full run through the catalog fan-out — there is no stub-catalog
  infrastructure in this repo yet (`aio-golden-callbacks` is still unlanded), and building one
  just for this PR felt like scope creep for a change that provably doesn't touch the fan-out
  body. The mechanics this test proves (coroutine registration, `await`-transparent
  `PreventUpdate`) are the same regardless of which branch of the function runs; the untested
  branches are exactly as tested (or untested) as they were before this PR, since the body is
  byte-for-byte identical.
- **`find_neighbours`, the other partial-registered site named in the plan, was left alone.**
  `set_figure_link` was judged sufficient to prove the `partial` mechanic and has no I/O, which
  kept its test simple. If a reviewer wants both partial shapes covered before the flip, that's
  a one-line follow-up, not a design question.
- **No performance claim is made or measurable here.** Everything still runs exactly where it
  ran before — inline, on the same thread, blocking exactly as long as it always did. Do not
  read "async def" here as "faster."
- **`set_table`'s 19-way loop registration was deliberately excluded** per the task brief; it
  remains on the shim. Its mechanics (partial-of-partial, one function reused across 19
  registrations) are not exercised by this PR at all.