### PR TITLE
Sweep closed loops out of the registry

### DIFF
--- a/tests/test_cache_async.py
+++ b/tests/test_cache_async.py
@@ -362,7 +362,7 @@ def test_async_memory_backend_lock_registry_survives_concurrent_threads():
 
     loops, locks = _run_from_n_threads(touch)
 
-    assert len(backend._locks) == N_THREADS, "one registry entry per still-live loop"
+    assert len({id(lock) for lock in locks}) == N_THREADS, "each loop gets its own lock, never a shared one"
     assert all(isinstance(lock, asyncio.Lock) for lock in locks)
 
 
@@ -377,5 +377,5 @@ def test_async_redis_backend_client_registry_survives_concurrent_threads():
 
     loops, clients = _run_from_n_threads(touch)
 
-    assert len(backend._clients) == N_THREADS, "one registry entry per still-live loop"
+    assert len({id(client) for client in clients}) == N_THREADS, "each loop gets its own client, never a shared one"
     assert all(isinstance(client, redis.asyncio.Redis) for client in clients)

--- a/tests/test_cache_single_flight.py
+++ b/tests/test_cache_single_flight.py
@@ -705,5 +705,5 @@ def test_async_singleflight_table_registry_survives_concurrent_threads():
 
     assert not errors, errors
     assert len(set(id(loop) for loop in loops)) == n, "each thread must run its own loop"
-    assert len(sf._tables) == n, "one registry entry per still-live loop"
+    assert len({id(table) for table in tables}) == n, "each loop gets its own table, never a shared one"
     assert all(isinstance(table, dict) for table in tables)

--- a/tests/test_loop_registry.py
+++ b/tests/test_loop_registry.py
@@ -52,6 +52,26 @@ def test_cleanup_drops_entries_via_gc() -> None:
     assert len(registry) == 0
 
 
+def test_a_value_holding_its_own_loop_does_not_accumulate() -> None:
+    """The shape a connected `redis.asyncio` client has: the value reaches its loop, so weak keys
+    alone never reclaim it and the table grew once per loop until `get()` started sweeping."""
+
+    class HoldsItsLoop:
+        def __init__(self) -> None:
+            self.loop = asyncio.get_running_loop()
+
+    registry = LoopRegistry(HoldsItsLoop)
+
+    async def body():
+        registry.get()
+
+    for _ in range(5):
+        asyncio.run(body())
+        gc.collect()
+
+    assert len(registry) <= 1
+
+
 def test_discard_drops_the_entry_immediately() -> None:
     """`discard()` is the deterministic counterpart to relying on garbage collection."""
     registry = LoopRegistry(object)

--- a/ztf_viewer/loop_registry.py
+++ b/ztf_viewer/loop_registry.py
@@ -17,8 +17,9 @@ its own key alive: a connected ``redis.asyncio`` client reaches its loop through
 ``transport._loop``, and that entry then survives every collection — five successive
 ``asyncio.run`` calls left five entries before the sweep existed. Values that hold nothing, an
 ``asyncio.Lock`` or a plain ``dict``, were reclaimed even without it. A closed loop is never
-coming back, so dropping its entry on the next lookup bounds the table by the number of live
-loops, whatever the value happens to reference. ``discard()`` drops one entry immediately.
+coming back, so dropping its entry when a *new* loop asks for a resource bounds the table by the
+number of live loops, whatever the value happens to reference — and a hit stays a plain lookup.
+``discard()`` drops one entry immediately.
 
 Cleaning up *after* a loop is gone is not an option worth designing toward: ``aclose()`` needs a
 live loop, ``transport.close()`` raises ``RuntimeError: Event loop is closed``, and a
@@ -57,9 +58,9 @@ class LoopRegistry(Generic[_T]):
     def get(self) -> _T:
         loop = asyncio.get_running_loop()
         with self._registry_lock:
-            self._sweep()
             resource = self._entries.get(loop)
             if resource is None:
+                self._sweep()
                 resource = self._entries[loop] = self._factory()
         return resource
 
@@ -68,6 +69,9 @@ class LoopRegistry(Generic[_T]):
 
         A value that references its own loop keeps its key alive, so weak keys alone never
         reclaim it. Closedness is the signal weakness cannot provide.
+
+        Only a miss can grow the table, so sweeping there alone holds the same bound and keeps
+        the scan off the hit path — under one long-lived loop it runs once, ever.
         """
         for loop in [loop for loop in list(self._entries) if loop.is_closed()]:
             del self._entries[loop]

--- a/ztf_viewer/loop_registry.py
+++ b/ztf_viewer/loop_registry.py
@@ -11,17 +11,14 @@ Keying on ``id(loop)`` would be a bug: ids are recycled once a loop is garbage c
 brand-new loop can silently inherit a dead loop's entry. Keying the table on the loop object
 itself, held only weakly, sidesteps this — identity, not a reused integer, decides equality.
 
-**Weak keys do not by themselves reclaim entries, and for two of the current values they do not
-reclaim them at all.** A ``WeakKeyDictionary`` holds its values strongly, so any value that
-references its own loop keeps its own key alive: a connected ``redis.asyncio`` client reaches its
-loop through ``transport._loop``, and that entry then survives every collection. Measured: five
-successive ``asyncio.run`` calls leave five entries, growing without bound. The values that hold
-nothing — an ``asyncio.Lock``, a plain ``dict`` — are reclaimed as expected.
-
-Nothing in the app reaches the affected paths yet, and under a single long-lived loop one entry
-is the whole population, so this bites only a loop-per-request backend driving a real client. It
-needs an explicit sweep of closed loops rather than more weakness; that lands separately.
-``discard()`` drops one entry deterministically in the meantime.
+**Weak keys alone do not reclaim entries, which is why :meth:`get` sweeps.** A
+``WeakKeyDictionary`` holds its values strongly, so any value that references its own loop keeps
+its own key alive: a connected ``redis.asyncio`` client reaches its loop through
+``transport._loop``, and that entry then survives every collection — five successive
+``asyncio.run`` calls left five entries before the sweep existed. Values that hold nothing, an
+``asyncio.Lock`` or a plain ``dict``, were reclaimed even without it. A closed loop is never
+coming back, so dropping its entry on the next lookup bounds the table by the number of live
+loops, whatever the value happens to reference. ``discard()`` drops one entry immediately.
 
 Cleaning up *after* a loop is gone is not an option worth designing toward: ``aclose()`` needs a
 live loop, ``transport.close()`` raises ``RuntimeError: Event loop is closed``, and a
@@ -60,10 +57,20 @@ class LoopRegistry(Generic[_T]):
     def get(self) -> _T:
         loop = asyncio.get_running_loop()
         with self._registry_lock:
+            self._sweep()
             resource = self._entries.get(loop)
             if resource is None:
                 resource = self._entries[loop] = self._factory()
         return resource
+
+    def _sweep(self) -> None:
+        """Drop entries whose loop is closed. Call with the lock held.
+
+        A value that references its own loop keeps its key alive, so weak keys alone never
+        reclaim it. Closedness is the signal weakness cannot provide.
+        """
+        for loop in [loop for loop in list(self._entries) if loop.is_closed()]:
+            del self._entries[loop]
 
     def discard(self, loop: Optional[asyncio.AbstractEventLoop] = None) -> None:
         """Drop the entry for `loop` (the running loop by default), if any."""


### PR DESCRIPTION
Follow-up to #651, which documents this defect; this fixes it.

## The bug

`WeakKeyDictionary` holds its **values** strongly. So a value that references its own loop keeps its own key alive, and the entry is never reclaimed. A connected `redis.asyncio` client reaches its loop through `transport._loop`, so it pins itself:

```
after loop 1: len(registry) = 1
after loop 2: len(registry) = 2
...
after loop 5: len(registry) = 5      ← unbounded
```

Two of the four registry sites have this shape — `AsyncRedisTTLSet._clients` and `AsyncRedisBackend._clients`. The other two (`asyncio.Lock`, `dict`) hold nothing and were reclaimed correctly, which is why it went unnoticed.

Against a live redis, each discarded loop also left a connection open until GC got to it.

## Why not weakrefs, a finalizer, or teardown

- **More weakness doesn't help.** Weak *values* would let a live resource be collected mid-use.
- **`weakref.finalize(loop, close, resource)` cannot fire.** The finalizer holds the resource, the resource holds the loop, so the finalizer keeps its own key alive. Measured: the callback runs at interpreter exit, not at loop death.
- **Post-mortem cleanup is impossible anyway.** `aclose()` needs a live loop; `transport.close()` raises `RuntimeError: Event loop is closed`; even `asyncio.run(client.aclose())` on a fresh loop raises the same, because the transport is bound to the original loop.

A closed loop is never coming back, and closedness is exactly the signal weakness cannot provide. So `get()` drops closed-loop entries before the lookup. The table is then bounded by the number of live loops whatever the value references.

## Not graceful, deliberately

Dropping the last reference lets GC close the socket, which still emits `unclosed Connection`. Graceful close means `aclose()` on the loop while it still runs — a lifespan shutdown hook, which does not exist until the FastAPI backend lands. This PR bounds the growth; it does not make the close polite.

## Tests

`test_a_value_holding_its_own_loop_does_not_accumulate` uses a stand-in that captures its running loop — the same shape as the redis client, no server needed. Without the sweep it fails `assert 5 <= 1`; with it, passes.

The two concurrency tests in `test_cache_async.py` asserted `len(registry) == N_THREADS` *after* their loops had closed, which the sweep makes timing-dependent (a thread arriving later sweeps an earlier thread's closed loop). They now assert what they were really about: no two loops share a resource.

```
368 passed, 1 skipped in 48.71s
```