### PR TITLE
aio-starlette-web: swap web.py internals to Starlette

### DIFF
--- a/tests/test_web.py
+++ b/tests/test_web.py
@@ -1,0 +1,138 @@
+"""Unit tests for the Starlette-backed helpers in `ztf_viewer/web.py`.
+
+Each helper is exercised directly by constructing its response and driving it through a
+throwaway Starlette app with `fastapi.testclient.TestClient`, independent of Dash/FastAPI
+route registration (which is not ported to this backend until a later PR in the stack).
+"""
+
+import pathlib
+
+import pytest
+from fastapi.applications import Starlette
+from fastapi.datastructures import QueryParams
+from fastapi.testclient import TestClient
+from starlette.routing import Route
+
+import ztf_viewer
+from ztf_viewer.web import (
+    QueryArgs,
+    binary_response,
+    csv_response,
+    error_response,
+    file_response,
+    query_args,
+    request_body,
+)
+
+_PACKAGE_ROOT = pathlib.Path(ztf_viewer.__file__).parent
+
+
+def _client_for(handler):
+    """A `TestClient` for a single-route Starlette app wrapping `handler`."""
+    app = Starlette(routes=[Route("/", handler, methods=["GET", "POST"])])
+    return TestClient(app)
+
+
+def test_file_response_resolves_relative_path_against_package_root():
+    """`favicon.py` passes a *relative* path; it must resolve against the package directory,
+    not the process CWD, or it 404s depending on where the process happens to be started from.
+    """
+
+    def handler(request):
+        return file_response("static/img/logo.svg", mimetype="image/svg+xml")
+
+    response = _client_for(handler).get("/")
+
+    assert response.status_code == 200
+    assert "image/svg+xml" in response.headers.get("content-type", "")
+    assert response.content == (_PACKAGE_ROOT / "static" / "img" / "logo.svg").read_bytes()
+
+
+def test_file_response_accepts_absolute_path():
+    def handler(request):
+        return file_response(str(_PACKAGE_ROOT / "static" / "img" / "logo.svg"), mimetype="image/svg+xml")
+
+    response = _client_for(handler).get("/")
+
+    assert response.status_code == 200
+    assert response.content == (_PACKAGE_ROOT / "static" / "img" / "logo.svg").read_bytes()
+
+
+@pytest.mark.parametrize("mimetype", ["image/png", "application/pdf"])
+def test_binary_response_content_type_is_exact(mimetype):
+    """`tests/test_golden_http.py` asserts these content types exactly, with no charset suffix."""
+
+    def handler(request):
+        return binary_response(b"\x00\x01\x02", mimetype=mimetype, filename="thing.bin")
+
+    response = _client_for(handler).get("/")
+
+    assert response.status_code == 200
+    assert response.headers["content-type"] == mimetype
+    assert response.headers["content-disposition"] == "attachment; filename=thing.bin"
+    assert response.content == b"\x00\x01\x02"
+
+
+def test_csv_response_content_type_and_disposition():
+    def handler(request):
+        return csv_response("a,b\n1,2\n", filename="data.csv")
+
+    response = _client_for(handler).get("/")
+
+    assert response.status_code == 200
+    assert "text/csv" in response.headers["content-type"]
+    assert response.headers["content-disposition"] == "attachment; filename=data.csv"
+    assert response.text == "a,b\n1,2\n"
+
+
+def test_error_response_defaults_to_html():
+    """Flask's bare `(body, status)` return is `text/html; charset=utf-8`; keep it that way."""
+
+    def handler(request):
+        return error_response("not found", 404)
+
+    response = _client_for(handler).get("/")
+
+    assert response.status_code == 404
+    assert "text/html" in response.headers["content-type"]
+    assert response.text == "not found"
+
+
+def test_query_args_wraps_any_get_getlist_multidict():
+    """`QueryArgs` itself is already backend-neutral: it only needs `.get`/`.getlist`, which
+    Starlette's `request.query_params` offers directly -- confirmed here against a real
+    `QueryParams` instance rather than Flask's `request.args`.
+    """
+    args = QueryArgs(QueryParams("a=1&b=2&b=3"))
+
+    assert args.get("a") == "1"
+    assert args.getlist("b") == ["2", "3"]
+    assert args.get("missing", "default") == "default"
+
+
+def test_query_args_function_still_reads_flask_style_dot_args():
+    """`query_args(request)` still reaches for `request.args` (Flask's attribute name), because
+    the ambient `request` it is fed today is still `flask.request`. Swapping this to
+    `request.query_params` belongs with the route port that starts passing a real Starlette
+    request in.
+    """
+
+    class _FakeFlaskRequest:
+        args = QueryParams("a=1&b=2&b=3")
+
+    wrapped = query_args(_FakeFlaskRequest())
+
+    assert wrapped.get("a") == "1"
+    assert wrapped.getlist("b") == ["2", "3"]
+
+
+def test_request_body_is_left_as_is_for_now():
+    """`request_body` still expects Flask's sync `get_data`; it is not called from a Starlette
+    handler anywhere yet, so this only pins the current (Flask-shaped) behaviour.
+    """
+
+    class _FakeFlaskRequest:
+        def get_data(self, cache=False):
+            return b"payload"
+
+    assert request_body(_FakeFlaskRequest()) == b"payload"

--- a/ztf_viewer/web.py
+++ b/ztf_viewer/web.py
@@ -2,17 +2,23 @@
 
 The routes in `ztf_viewer/pages/{figure,lc_csv,favicon}.py` are registered with
 `@app.server.route(...)` rather than as Dash callbacks, so they talk to the WSGI/ASGI backend
-directly instead of through `dash.ctx`. Today that backend is Flask, and this module is the
-*only* place allowed to `import flask` (enforced by a repo-wide grep / AST guard) so that a
-later swap to Starlette touches this one file instead of every route.
+directly instead of through `dash.ctx`. Today that backend is Starlette (via FastAPI), and this
+module is the *only* place allowed to `import flask` (enforced by a repo-wide grep / AST guard).
 
-Call sites should only use the names exported here, never `flask` directly.
+Call sites should only use the names exported here, never `flask` or `starlette` directly.
 """
 
+import pathlib
+
 import flask
+from fastapi.responses import FileResponse, HTMLResponse, Response
 
 #: The current request, re-exported so call sites never import `flask` themselves.
+#: Starlette has no ambient request equivalent -- this is the one name in this module that
+#: still needs a real request object threaded through as a handler argument at every call site.
 request = flask.request
+
+_PACKAGE_ROOT = pathlib.Path(__file__).parent
 
 
 class QueryArgs:
@@ -39,24 +45,31 @@ def request_body(request) -> bytes:
 
 
 def file_response(path, mimetype):
-    """Serve a file from disk (e.g. the favicon)."""
-    return flask.send_file(path, mimetype=mimetype)
+    """Serve a file from disk (e.g. the favicon).
+
+    `path` may be relative (as `favicon.py` passes it); resolve it against the package
+    directory rather than the process CWD, matching Flask's `send_file` app-root resolution.
+    """
+    path = pathlib.Path(path)
+    if not path.is_absolute():
+        path = _PACKAGE_ROOT / path
+    return FileResponse(path, media_type=mimetype)
 
 
 def binary_response(data: bytes, mimetype: str, filename: str):
     """A binary attachment response, e.g. a rendered PNG/PDF figure."""
-    return flask.Response(
+    return Response(
         data,
-        mimetype=mimetype,
+        media_type=mimetype,
         headers={"Content-disposition": f"attachment; filename={filename}"},
     )
 
 
 def csv_response(text: str, filename: str):
     """A CSV attachment response."""
-    return flask.Response(
+    return Response(
         text,
-        mimetype="text/csv",
+        media_type="text/csv",
         headers={"Content-disposition": f"attachment; filename={filename}"},
     )
 
@@ -64,7 +77,7 @@ def csv_response(text: str, filename: str):
 def error_response(body: str, status: int):
     """An error response, replacing the old `(body, status)` tuple pattern.
 
-    No explicit mimetype is set so this matches Flask's own default (`text/html`) for a bare
-    `(body, status)` return, keeping behaviour identical to what these routes did before.
+    Explicit `text/html` so this matches Flask's own default for a bare `(body, status)`
+    return, keeping behaviour identical to what these routes did before.
     """
-    return flask.Response(body, status=status)
+    return HTMLResponse(body, status_code=status)


### PR DESCRIPTION
## What

PR 2 of 4 in the `flip` stack (plan 001). Swaps the internals of `ztf_viewer/web.py`
from Flask to Starlette while keeping every exported name and signature identical, so
no call site (`figure.py`, `lc_csv.py`, `favicon.py`) changes in this PR.

- `file_response(path, mimetype)` → Starlette's `FileResponse`. Relative paths
  (as `favicon.py` passes: `"static/img/logo.svg"`) are resolved against the package
  directory (`ztf_viewer/`) before constructing the response, instead of Starlette's
  default CWD-relative resolution — otherwise this 404s depending on where the process
  happens to start from.
- `binary_response`/`csv_response` → Starlette's `Response`, same
  `Content-disposition: attachment; filename=...` header. Verified against a live
  ASGI response rather than assumed: `image/png` and `application/pdf` come out with no
  charset suffix (binary media types), `text/csv` gets `; charset=utf-8` appended —
  which is fine, `tests/test_golden_http.py` uses exact equality for the former two and
  `in` for the latter.
- `error_response(body, status)` → Starlette's `HTMLResponse`, keeping the
  `text/html; charset=utf-8` default the docstring already promised.
- `request` (the `flask.request` re-export) — **left as-is**. Starlette has no ambient
  request; `figure.py:34,56,58` and `lc_csv.py:47` use it as a module-level import today,
  and threading a real request through them is `aio-routes`' job. Removing the name here
  would break those modules at import time, which is strictly worse than leaving it.
- `request_body(request)` — **left as-is; genuinely blocked here.** See "Handoff to
  aio-routes" below.

## Import convention: `fastapi.responses`, not `starlette.*`

Decided in review: `web.py` imports `FileResponse`, `HTMLResponse`, and `Response` from
`fastapi.responses` rather than `starlette.responses`, matching `ztf_viewer/app.py` on
the base branch. `starlette` is not a package we declare a dependency on — it arrives
transitively through `fastapi` — so every import should point at a package that's
actually in `pyproject.toml`. `fastapi.responses` re-exports the exact same Starlette
classes (verified: `fastapi.responses.Response is starlette.responses.Response`), so this
is a pure import-path change with no behaviour difference.

The tests follow the same rule wherever `fastapi` re-exports the name:
`fastapi.testclient.TestClient`, `fastapi.applications.Starlette`, and
`fastapi.datastructures.QueryParams` are all the identical Starlette objects under a
`fastapi.*` path. The one exception is `starlette.routing.Route`, which `fastapi` does
not re-export anywhere (`fastapi.routing` only has its own `APIRoute` family, which is
not a drop-in replacement) — that import stays `starlette.routing.Route`.

## QueryArgs / query_args — did not need to change

`QueryArgs` itself only calls `.get()`/`.getlist()` on whatever it wraps, and
Starlette's `request.query_params` already implements both — confirmed with a real
`QueryParams` (imported via `fastapi.datastructures`) in `tests/test_web.py`. So the
class is already backend-neutral and untouched.

The free function `query_args(request)` still does `QueryArgs(request.args)`, i.e. it
still reaches for Flask's `.args` attribute name, because the `request` object it is fed
at every current call site is still `flask.request` (see above). Swapping that one
attribute access to `request.query_params` is explicitly `aio-routes`' job, once real
Starlette request objects start flowing into these handlers — the plan calls this out
directly under that PR's section. Doing it here would just be premature churn against an
argument that, today, is still a Flask object.

## Handoff to aio-routes: `request_body`

`request_body(request)` still calls Flask's synchronous `request.get_data(cache=False)`
and is otherwise untouched. It cannot be ported to Starlette as a same-shaped function:
`Request.body()` on Starlette is a coroutine, and `response_figure`
(`ztf_viewer/pages/figure.py`) is a plain sync `def` handler that FastAPI runs in a
threadpool — there is no ambient event loop to await from inside it, and no clean way to
get the coroutine's result synchronously without one of:

- `asyncio.run(...)`/event-loop nesting — fragile from inside a threadpool worker,
- a manual thread hop to somewhere with a loop — forbidden before `aio-uvicorn` (the
  plan's single-thread-pool-owner rule).

The clean fix belongs to `aio-routes`: FastAPI can inject the raw body straight into a
sync handler as a parameter (`body: bytes = Body(...)`), because FastAPI awaits the body
before ever calling the handler — no coroutine surfaces inside `figure.py` at all. At
that point `request_body` in `web.py` is either deleted (the handler takes `body: bytes`
directly) or becomes a thin passthrough with the parameter already in hand; either way
it's not a request-shaped call anymore.

## Tests

Added `tests/test_web.py`: each response helper is exercised by wrapping it in a
throwaway Starlette route and driving it through `fastapi.testclient.TestClient`
(same pattern as `tests/test_app.py` on the base branch), asserting status code,
exact/partial content type, `Content-Disposition`, and body. `QueryArgs`/`query_args`
are covered against both a real `QueryParams` and a Flask-shaped fake to pin the current
(correct) behaviour described above.

`tests/test_flask_import_guard.py::test_web_py_still_imports_flask` still passes:
`web.py` still does `import flask` for the `request` re-export, as expected, and the
guard is unchanged.

## CI is red here, by design

This is the PR the plan says makes the stack atomic: `aio-fastapi-app` runs Dash on the
FastAPI backend unconditionally, but the six routes in `figure.py`/`lc_csv.py`/
`favicon.py` still register with `@app.server.route(...)`, which `FastAPI` doesn't have.
That was already true on `fastapi-app` before this PR and stays true until `aio-routes`
ports the registrations.

Base branch (`fastapi-app`): `1 failed, 349 passed, 1 skipped, 16 errors`
(13 errors in `tests/test_golden_http.py`, 3 errors + 1 failure in
`tests/test_callbacks_shim.py`).

This branch: `1 failed, 358 passed, 1 skipped, 16 errors`.

The delta is exactly the 9 new tests added in `tests/test_web.py`, all passing; the
inherited failure and all 16 errors are identical in kind and count to the base branch
(all still `AttributeError: 'FastAPI' object has no attribute 'route'`, from the
un-ported route registrations). No new failures introduced.

## Stack

This is PR 2 of 4 in the atomic `flip` stack (plan 001):
`aio-fastapi-app` (#658, base) → **`aio-starlette-web`** (this PR) →
`aio-routes` → `aio-uvicorn`. **Do not merge this alone** — only the stack tip needs to
be green, and this PR is deliberately red until `aio-routes` lands. Draft only; will be
marked ready once the full stack exists.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
