### PR TITLE
Entrypoint, deployment, and the thread offload

### DIFF
--- a/.ci/Dockerfile_test
+++ b/.ci/Dockerfile_test
@@ -4,7 +4,7 @@ RUN apt update \
     && apt install -y redis-server
 
 WORKDIR /app
-RUN uv sync --locked --group tests --group deploy
+RUN uv sync --locked --group tests
 
 # Under /app, so pytest finds pyproject.toml walking up and applies [tool.pytest.ini_options];
 # from /tests the rootdir was / and every option there was silently ignored.

--- a/.ci/docker-compose.yml.tmpl
+++ b/.ci/docker-compose.yml.tmpl
@@ -8,7 +8,7 @@ services:
 
   ztf-web-viewer-app:
     build: .
-    entrypoint: ["gunicorn", "-w2", "-t300", "--keep-alive=75", "-b0.0.0.0:80", "ztf_viewer.__main__:app"]
+    entrypoint: ["uvicorn", "ztf_viewer.__main__:app.server", "--host", "0.0.0.0", "--port", "80", "--workers", "1", "--timeout-keep-alive", "75"]
     healthcheck:
       test: ["CMD", "curl", "-f", "http://localhost:80/health"]
       interval: 30s

--- a/Dockerfile
+++ b/Dockerfile
@@ -31,10 +31,10 @@ RUN echo "main_memory = 50000000" > /etc/texmf/texmf.d/10main_memory.cnf \
     && texhash \
     && fmtutil-sys --all || test 1
 
-# Install dependencies, including gunicorn (the "deploy" dependency group), but
-# not the project itself yet, so this layer stays cached across source changes
+# Install dependencies, but not the project itself yet, so this layer stays cached
+# across source changes
 COPY pyproject.toml uv.lock /app/
-RUN uv sync --project /app --locked --no-install-project --group deploy
+RUN uv sync --project /app --locked --no-install-project
 
 EXPOSE 80
 
@@ -43,10 +43,10 @@ ENV PYTHONUNBUFFERED TRUE
 COPY ztf_viewer /app/ztf_viewer/
 ARG GITHUB_SHA
 RUN if [ -z ${GITHUB_SHA+x} ]; then echo "$GITHUB_SHA is not set"; else echo "github_sha = \"${GITHUB_SHA}\"" >> /app/ztf_viewer/_version.py; fi
-RUN uv sync --project /app --locked --group deploy
+RUN uv sync --project /app --locked
 
 ENV PATH="/app/.venv/bin:$PATH"
 
 HEALTHCHECK CMD curl -f http://localhost:80/health || exit 1
 
-ENTRYPOINT ["gunicorn", "-w2", "--threads=8", "-t70", "--keep-alive=75", "-b0.0.0.0:80", "ztf_viewer.__main__:app"]
+ENTRYPOINT ["uvicorn", "ztf_viewer.__main__:app.server", "--host", "0.0.0.0", "--port", "80", "--workers", "1", "--timeout-keep-alive", "75"]

--- a/README.md
+++ b/README.md
@@ -62,8 +62,6 @@ Add or change a dependency with `uv add`/`uv remove` (this updates both `pyproje
 uv add "some-package>=1.0"
 ```
 
-The `deploy` group (`gunicorn`) is only needed outside `uv run`, i.e. by `Dockerfile`.
-
 After editing `pyproject.toml` by hand, refresh the lockfile with:
 ```sh
 uv lock

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -112,9 +112,6 @@ target-version = "py314"
 "ztf_viewer/lc_data/__init__.py" = ["F401"]
 
 [dependency-groups]
-deploy = [
-    "gunicorn>=26.0.0",
-]
 tests = [
     # Used by the ASGI test client and by conftest's network-error classifier.
     "httpx",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,6 +17,7 @@ keywords = ["science", "astrophysics"]
 requires-python = ">=3.14"
 dependencies = [
     "dash[async,fastapi]>=4.4.1,<5.0",
+    "uvicorn[standard]",
     "dash_defer_js_import",
     "ipywidgets>=7.0.0", # needed by plotly
     "orjson",

--- a/tests/test_callbacks_shim.py
+++ b/tests/test_callbacks_shim.py
@@ -158,12 +158,12 @@ def test_no_runtime_warning_on_registration():
     assert "OK" in result.stdout
 
 
-def test_wrapper_runs_inline_on_the_awaiting_thread():
-    """No thread pool of the shim's own: a pool needs a configured size, and that arrives with
-    the backend flip. Reintroducing an offload here must be a deliberate, visible change."""
+def test_wrapper_offloads_to_a_different_thread():
+    """A sync callback run inline on the loop would serialize the whole app; the wrapper must
+    hand it to the executor instead."""
     wrapped = _to_coroutine_function(threading.get_ident)
 
-    assert asyncio.run(wrapped()) == threading.get_ident()
+    assert asyncio.run(wrapped()) != threading.get_ident()
 
 
 def test_wrapper_works_across_successive_event_loops():

--- a/uv.lock
+++ b/uv.lock
@@ -1600,6 +1600,7 @@ dependencies = [
     { name = "redis" },
     { name = "requests" },
     { name = "scipy" },
+    { name = "uvicorn", extra = ["standard"] },
 ]
 
 [package.dev-dependencies]
@@ -1634,6 +1635,7 @@ requires-dist = [
     { name = "redis" },
     { name = "requests" },
     { name = "scipy" },
+    { name = "uvicorn", extras = ["standard"] },
 ]
 
 [package.metadata.requires-dev]

--- a/uv.lock
+++ b/uv.lock
@@ -457,18 +457,6 @@ wheels = [
 ]
 
 [[package]]
-name = "gunicorn"
-version = "26.0.0"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "packaging" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/6d/b7/a4a3f632f823e432ce6bc65f62961b7980c898c77f075a2f7118cb3846fe/gunicorn-26.0.0.tar.gz", hash = "sha256:ca9346f85e3a4aeeb64d491045c16b9a35647abd37ea15efe53080eb8b090baf", size = 727286, upload-time = "2026-05-05T06:38:25.529Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/e6/40/9c2384fc2be4ad25dd4a49decd5ad9ea5a3639814c11bd40ab77cb9f0a14/gunicorn-26.0.0-py3-none-any.whl", hash = "sha256:40233d26a5f0d1872916188c276e21641155111c2853f0c2cd55260aec0d24fc", size = 212009, upload-time = "2026-05-05T06:38:23.007Z" },
-]
-
-[[package]]
 name = "h11"
 version = "0.16.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1615,9 +1603,6 @@ dependencies = [
 ]
 
 [package.dev-dependencies]
-deploy = [
-    { name = "gunicorn" },
-]
 tests = [
     { name = "httpx" },
     { name = "pytest" },
@@ -1652,7 +1637,6 @@ requires-dist = [
 ]
 
 [package.metadata.requires-dev]
-deploy = [{ name = "gunicorn", specifier = ">=26.0.0" }]
 tests = [
     { name = "httpx" },
     { name = "pytest", specifier = ">=9.1.1" },

--- a/ztf_viewer/__main__.py
+++ b/ztf_viewer/__main__.py
@@ -1,11 +1,15 @@
 #!/usr/bin/env python3
 
 import argparse
+import asyncio
 import logging
 import pathlib
 import re
 import urllib.parse
+from concurrent.futures import ThreadPoolExecutor
 
+import anyio.to_thread
+import uvicorn
 from astropy.coordinates import SkyCoord, get_icrs_coordinates
 from astropy.coordinates.name_resolve import NameResolveError
 from dash import Input, Output, State, dcc, html, no_update
@@ -16,6 +20,7 @@ from ztf_viewer.app import app
 from ztf_viewer.callbacks import callback
 from ztf_viewer.catalogs.conesearch import ANTARES_QUERY, TNS_QUERY
 from ztf_viewer.catalogs.snad import SnadCatalogSource
+from ztf_viewer.config import THREAD_POOL_SIZE
 from ztf_viewer.exceptions import CatalogUnavailable, NotFound, UnAuthorized
 from ztf_viewer.pages import favicon as _  # noqa: F811,F401
 from ztf_viewer.pages import figure as _  # noqa: F811,F401
@@ -29,6 +34,22 @@ from ztf_viewer.util import DEFAULT_DR, YEAR, available_drs, list_join
 from ztf_viewer.version import version_string, version_url
 
 logging.basicConfig(level=logging.INFO)
+
+
+async def _size_thread_pools() -> None:
+    """Size asyncio's default executor and anyio's sync-route limiter from config.
+
+    Both fall back to a stdlib default derived from CPU count if left unset; this is the one
+    place, run once at startup, that pins them instead.
+    """
+    loop = asyncio.get_running_loop()
+    loop.set_default_executor(ThreadPoolExecutor(max_workers=THREAD_POOL_SIZE))
+    anyio.to_thread.current_default_thread_limiter().total_tokens = THREAD_POOL_SIZE
+
+
+# Registered unconditionally so it fires whether uvicorn imports this module directly
+# (the Dockerfile entrypoint) or runs it via `uvicorn.run` below (dev).
+app.server.router.add_event_handler("startup", _size_thread_pools)
 
 
 app.title = "SNAD ZTF viewer"
@@ -578,4 +599,12 @@ def parse_args(args):
 
 if __name__ == "__main__":
     args = parse_args(None)
-    app.run(host=args.host, debug=True)
+    # Not `app.run(debug=True)`: under the FastAPI backend that re-execs uvicorn as a
+    # subprocess by inspecting the caller frame, which is fragile for a `python -m` entry point.
+    uvicorn.run(
+        "ztf_viewer.__main__:app.server",
+        host=args.host,
+        port=8050,
+        reload=True,
+        timeout_keep_alive=75,
+    )

--- a/ztf_viewer/__main__.py
+++ b/ztf_viewer/__main__.py
@@ -36,14 +36,19 @@ from ztf_viewer.version import version_string, version_url
 logging.basicConfig(level=logging.INFO)
 
 
-async def _size_thread_pools() -> None:
-    """Size asyncio's default executor and anyio's sync-route limiter from config.
+# One pool per process, not per loop: `set_default_executor` replaces the executor without
+# shutting the old one down, so building it here keeps a second startup from doubling the
+# thread count. Threads are spawned on first use, so this costs nothing at import.
+_thread_pool = ThreadPoolExecutor(max_workers=THREAD_POOL_SIZE, thread_name_prefix="ztf-viewer")
 
-    Both fall back to a stdlib default derived from CPU count if left unset; this is the one
-    place, run once at startup, that pins them instead.
+
+async def _size_thread_pools() -> None:
+    """Point asyncio's default executor and anyio's sync-route limiter at our own sizes.
+
+    Both otherwise fall back to a stdlib default derived from CPU count. The limiter is a
+    per-loop value, so it has to be set on each startup; the executor is shared.
     """
-    loop = asyncio.get_running_loop()
-    loop.set_default_executor(ThreadPoolExecutor(max_workers=THREAD_POOL_SIZE))
+    asyncio.get_running_loop().set_default_executor(_thread_pool)
     anyio.to_thread.current_default_thread_limiter().total_tokens = THREAD_POOL_SIZE
 
 

--- a/ztf_viewer/callbacks.py
+++ b/ztf_viewer/callbacks.py
@@ -5,12 +5,13 @@ hop, so leaving any callback as a plain ``def`` would serialize the whole app on
 worker. Dash only checks ``inspect.iscoroutinefunction`` at registration time, so wrapping here
 is enough to satisfy that constraint without touching a single callback body.
 
-The wrapper runs the callback **inline**, on the thread that awaits it — today the gunicorn
-worker thread, exactly as before this shim existed. Offloading it to a thread pool is what the
-FastAPI backend will need, and it is deliberately not done here: a pool needs a size, a size
-needs one configured home, and neither exists until the backend flip introduces them together.
+The wrapper offloads the callback via ``asyncio.to_thread``, which runs it on the event loop's
+default executor and propagates the current context — so ``dash.ctx`` still resolves correctly
+inside the offloaded call. That executor is sized once, from config, by the entrypoint; nothing
+here creates a pool of its own.
 """
 
+import asyncio
 import functools
 import inspect
 from collections.abc import Callable
@@ -26,7 +27,7 @@ def _to_coroutine_function(func: Callable[..., Any]) -> Callable[..., Any]:
 
     @functools.wraps(func)
     async def wrapper(*args: Any, **kwargs: Any) -> Any:
-        return func(*args, **kwargs)
+        return await asyncio.to_thread(func, *args, **kwargs)
 
     return wrapper
 

--- a/ztf_viewer/config.py
+++ b/ztf_viewer/config.py
@@ -13,3 +13,7 @@ ZTF_PERIODIC_API_URL = os.environ.get("ZTF_PERIODIC_API_URL", "https://periodic.
 TNS_API_URL = os.environ.get("TNS_API_URL", "https://tns.snad.space")
 JS9_URL = os.environ.get("JS9_URL", "https://www.js9.org/js9.html")
 DUSTMAPS_API_URL = os.environ.get("DUSTMAPS_API_URL", "https://dustmaps.snad.space")
+
+# Size of both thread pools the entrypoint installs: asyncio's default executor and anyio's
+# sync-route limiter. Matches today's gunicorn `--threads=8`.
+THREAD_POOL_SIZE = int(os.environ.get("THREAD_POOL_SIZE", "8"))

--- a/ztf_viewer/config.py
+++ b/ztf_viewer/config.py
@@ -15,5 +15,5 @@ JS9_URL = os.environ.get("JS9_URL", "https://www.js9.org/js9.html")
 DUSTMAPS_API_URL = os.environ.get("DUSTMAPS_API_URL", "https://dustmaps.snad.space")
 
 # Size of both thread pools the entrypoint installs: asyncio's default executor and anyio's
-# sync-route limiter. Matches today's gunicorn `--threads=8`.
-THREAD_POOL_SIZE = int(os.environ.get("THREAD_POOL_SIZE", "8"))
+# sync-route limiter. Caps how many blocking calls the single event loop can have in flight.
+THREAD_POOL_SIZE = int(os.environ.get("THREAD_POOL_SIZE", "16"))


### PR DESCRIPTION
## What this is

PR 4 of 4 in the atomic "flip" stack (plan `001_async_dash.md`). This is the PR that makes the stack deployable: it swaps the deployment entrypoint from gunicorn to uvicorn, gives the app's thread pools their one configured home, and turns the callback shim's inline wrapper into a real offload. Draft only, not to be merged on its own — the coordinator rebases it onto `aio-routes` (PR 3) and retargets the base.

## Entrypoint: before / after

**Prod (`Dockerfile`):**
```
gunicorn -w2 --threads=8 -t70 --keep-alive=75 -b0.0.0.0:80 ztf_viewer.__main__:app
```
→
```
uvicorn ztf_viewer.__main__:app.server --host 0.0.0.0 --port 80 --workers 1 --timeout-keep-alive 75
```
Plain uvicorn, not `gunicorn -k uvicorn.workers.UvicornWorker` — one fewer moving part. Uvicorn has no per-request worker timeout (gunicorn's `-t70`); long upstream calls get bounded later in the plan by our own `asyncio.timeout`. `--timeout-keep-alive 75` carries over gunicorn's `--keep-alive=75` so it still matches nginx's expectation. `HEALTHCHECK` untouched.

**Dev (`.ci/docker-compose.yml.tmpl`, F11):** this file hardcodes its own `entrypoint:`, overriding the Dockerfile's, for every dev and PR-preview deploy. Missing this would pass CI and then fail `master.ztf.snad.space` at startup. Before:
```
gunicorn -w2 -t300 --keep-alive=75 -b0.0.0.0:80 ztf_viewer.__main__:app
```
— note: **no** `--threads`, i.e. 2 single-threaded workers, already diverging from prod's `-w2 --threads=8`. After:
```
uvicorn ztf_viewer.__main__:app.server --host 0.0.0.0 --port 80 --workers 1 --timeout-keep-alive 75
```
Same command as prod now — the dev/prod divergence F11 flagged is gone, not just patched.

**Local dev (`ztf_viewer/__main__.py`, `python -m ztf_viewer`):**
```
app.run(host=args.host, debug=True)
```
→
```
uvicorn.run("ztf_viewer.__main__:app.server", host=args.host, port=8050, reload=True, timeout_keep_alive=75)
```
Not `app.run(debug=True)`: under the FastAPI backend it re-execs uvicorn as a subprocess by inspecting the caller frame, which is fragile for a `python -m` entry point. `--host` keeps working; `reload=True` is the closest equivalent to the old `debug=True`'s auto-restart. Kept behind the `if __name__ == "__main__":` guard per repo convention.

## The two thread pools

Sizes are decided in exactly one place, `ztf_viewer/config.py`, from `THREAD_POOL_SIZE` (default `16`) — and nowhere else. The two pools are **independent** (anyio runs sync route handlers on its own worker threads, not on asyncio's default executor), so this is 16 each, i.e. up to 32 blocking threads in the process — against `2 x 8` under gunicorn today:

1. **asyncio's default executor**, which every `asyncio.to_thread` reaches. The pool is built **once per process**, at module level, and handed to each loop by the startup hook. Building it inside the hook instead would leak: `set_default_executor` replaces the executor without shutting the old one down, so a second startup on a fresh loop silently doubles the thread count — which already happens in the test suite, where two modules each drive an ASGI lifespan.
2. **anyio's limiter**, which Starlette uses to run sync `def` route handlers (default 40 tokens): `anyio.to_thread.current_default_thread_limiter().total_tokens = THREAD_POOL_SIZE`. This one is a per-loop `RunVar`, so it is genuinely set on every startup — it is an integer, not a resource.

The hook is registered unconditionally at module import time (`app.server.router.add_event_handler("startup", _size_thread_pools)`), not inside the `if __name__` guard, because the Docker entrypoint (`uvicorn ztf_viewer.__main__:app.server`) imports the module directly and never executes that guard — only a startup-event hook fires under both invocation paths. Verified in isolation (can't go through `ztf_viewer.__main__` itself until PR 3 lands — see below): after the hook runs, the loop's default executor is the sized pool, the anyio limiter reads `16` tokens, and a callback wrapped by the shim actually lands on a thread from that exact pool.

## The shim: inline → offload

`ztf_viewer/callbacks.py`'s wrapper previously awaited the callback **inline**, correct on Flask (no threadpool hop needed under `asgiref`) and catastrophic on FastAPI (would serialize every sync callback onto the one long-lived loop). Now:
```python
return await asyncio.to_thread(func, *args, **kwargs)
```
`asyncio.to_thread` reaches the loop's default executor — the pool sized above — and propagates the current context, so `dash.ctx` still resolves inside the offloaded call. `tests/test_callbacks_shim.py::test_ctx_cookies_readable_from_offloaded_thread` already existed (written ahead of this PR, per the plan) and covers exactly that: it's what the AKB/login path depends on. `test_wrapper_runs_inline_on_the_awaiting_thread`, which pinned the old inline behaviour, is repurposed into `test_wrapper_offloads_to_a_different_thread`, asserting the callback now runs on a different thread than the one awaiting it.

The offload covers every callback the shim wrapped — i.e. everything registered through `ztf_viewer.callbacks.callback`. No callback in this codebase is natively `async def` yet, so there's nothing currently exempt from it (F15 is moot here; the first async-I/O PR that converts a body has to keep that invariant true).

## Why `--workers 1`

One process, one loop: concurrency comes from the loop rather than replication, and it makes the in-process caches and `unavailable_catalogs` whole again — with two workers they're per-process and roughly half the hits are missed today. Revisit only against a load test showing one loop saturating a core.

## gunicorn removal

Its only caller was the entrypoint this PR replaces (grepped to confirm). Dropped from `pyproject.toml`'s `deploy` dependency group — which then had no other members, so the group itself is removed and the two `uv sync` calls in the Dockerfile drop `--group deploy` accordingly. `uv.lock` regenerated. Updated the two docs (`README.md`, a `Dockerfile` comment) that referenced the group.

## What I verified

- `uv venv --python 3.14` + `uv pip install -e . --group tests`, then the full suite:
  `CACHE_TYPE=memory UNAVAILABLE_CATALOGS_CACHE_TYPE=memory pytest tests --basetemp=/tmp/pytest -m "not upstream"` →
  **`1 failed, 358 passed, 1 skipped, 16 errors`** — identical to the stated inherited baseline from `starlette-web` (red at collection until PR 3 lands: `favicon.py`/`figure.py`/`lc_csv.py` still call `@app.server.route(...)`, which `FastAPI` doesn't have). No new failures, no new errors.
- Both target tests in `tests/test_callbacks_shim.py` pass individually.
- `pre-commit run --all-files` — all hooks pass.
- Since `ztf_viewer.__main__` can't import until PR 3 lands (fails on `favicon.py`'s `@app.server.route`), I verified the startup hook and the shim's offload **independent of `__main__.py`**: constructed `ztf_viewer.app.app`, registered the same hook, drove its lifespan manually, and confirmed (a) the loop's default executor becomes the sized pool, (b) the anyio limiter reads `THREAD_POOL_SIZE` tokens, and (c) a shim-wrapped callback actually runs on a thread belonging to that pool.

## What I could not verify

- Starting `ztf_viewer.__main__` itself and curling `/health` — blocked on PR 3 (`favicon.py` import failure). Will do once rebased.
- The PR-preview smoke test (`pr<N>.ztf.snad.space` serving an object page) — same blocker, plus this PR is draft-only against `starlette-web`.
- Did not build the Docker image (JS9 + TeXLive compile time).

## Anything found but not fixed

Nothing beyond what's described above. `ztf_viewer/__main__.py:257,265` uses bare-tuple `except NotFound, CatalogUnavailable:` (no parens) — parses fine in Python 3 as `except (NotFound, CatalogUnavailable):`, so not a bug, just unusual style; pre-existing and out of scope.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
