### PR TITLE
aio-snad-apis: convert first-party HTTP services to async

### DIFF
--- a/tests/catalogs/test_ztf_ref.py
+++ b/tests/catalogs/test_ztf_ref.py
@@ -1,7 +1,7 @@
 from pytest import approx
 
 
-def test_fits_url():
+async def test_fits_url():
     from ztf_viewer.catalogs.ztf_ref import ztf_ref
     from ztf_viewer.config import ZTF_FITS_PROXY_URL
 
@@ -9,11 +9,11 @@ def test_fits_url():
     dr = "dr8"  # any supported
     assert (
         f"{ZTF_FITS_PROXY_URL}/products/ref/000/field000633/zr/ccd07/q4/ztf_000633_zr_c07_q4_refpsfcat.fits"
-        == ztf_ref.fits_url(oid, dr)
+        == await ztf_ref.fits_url(oid, dr)
     )
 
 
-def test_regression_get():
+async def test_regression_get():
     from ztf_viewer.catalogs.ztf_ref import ztf_ref
 
     oid = 633207400004730
@@ -38,6 +38,6 @@ def test_regression_get():
         "infobits": 0,
     }
 
-    actual = ztf_ref.get(oid, dr)
+    actual = await ztf_ref.get(oid, dr)
 
     assert expected == approx(actual)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -98,6 +98,36 @@ def setup_cache(item):
     cache.clear_memory_caches()
 
 
+def reset_shared_thread_pool():
+    """Give ``ztf_viewer.__main__``'s module-level thread pool a fresh executor.
+
+    That pool is a single object shared by every event loop in the process — correct for
+    production, where the entrypoint starts exactly one loop. This suite instead builds several
+    independent ``TestClient``s, each driving its own ``asyncio.run`` lifespan, and
+    ``asyncio.run``'s teardown shuts down whatever object was set as *that* loop's default
+    executor — the object itself, not just that loop's use of it. Since every lifespan points at
+    the same shared pool, the first one to finish would otherwise leave it dead for every
+    ``TestClient`` built afterwards.
+
+    Call this before constructing a ``TestClient`` around ``ztf_viewer.app.app`` (or anything that
+    imports it), never from application code — the app itself only ever sees one startup.
+    """
+    import sys
+
+    if "ztf_viewer.__main__" not in sys.modules:
+        # Nothing registered `_size_thread_pools` as a startup handler yet, so there is nothing
+        # to reset; importing `ztf_viewer.__main__` just to reset it would be its own bug source.
+        return
+
+    from concurrent.futures import ThreadPoolExecutor
+
+    import ztf_viewer.__main__ as main_module
+
+    main_module._thread_pool = ThreadPoolExecutor(
+        max_workers=main_module.THREAD_POOL_SIZE, thread_name_prefix="ztf-viewer-test"
+    )
+
+
 def pytest_addoption(parser):
     parser.addoption(
         "--no-net-skip",

--- a/tests/pages/test_tags.py
+++ b/tests/pages/test_tags.py
@@ -8,18 +8,27 @@ unpack those single-element (or empty) lists back into scalars.
 """
 
 import inspect
-from unittest.mock import patch
+from unittest.mock import AsyncMock, patch
 
-from ztf_viewer.pages import tags
+from ztf_viewer import config
+
+# `ztf_viewer.pages.tags` now pulls in `ztf_viewer.akb`, which pulls in `ztf_viewer.cache`, whose
+# module-level `cache()` decorator is bound to a backend at first import and never rebinds. Set
+# this before that import, the same guard other test modules that import the app use.
+config.CACHE_TYPE = "memory"
+config.UNAVAILABLE_CATALOGS_CACHE_TYPE = "memory"
+
+from ztf_viewer.pages import tags  # noqa: E402
 
 # Callback registration may wrap the function; the body under test is the innermost one.
 set_save_status = inspect.unwrap(tags.set_save_status)
 
 
-def test_set_save_status_unpacks_pattern_matched_new_tag_state():
+async def test_set_save_status_unpacks_pattern_matched_new_tag_state():
     with patch("ztf_viewer.pages.tags.akb") as mock_akb:
-        mock_akb.is_token_valid.return_value = True
-        set_save_status(
+        mock_akb.is_token_valid = AsyncMock(return_value=True)
+        mock_akb.post_tags = AsyncMock()
+        await set_save_status(
             n_clicks=1,
             tags=[],
             priorities=[],
@@ -30,10 +39,11 @@ def test_set_save_status_unpacks_pattern_matched_new_tag_state():
     mock_akb.post_tags.assert_called_once_with([dict(name="foo", priority=5, description="bar")])
 
 
-def test_set_save_status_tolerates_empty_new_tag_state():
+async def test_set_save_status_tolerates_empty_new_tag_state():
     with patch("ztf_viewer.pages.tags.akb") as mock_akb:
-        mock_akb.is_token_valid.return_value = True
-        set_save_status(
+        mock_akb.is_token_valid = AsyncMock(return_value=True)
+        mock_akb.post_tags = AsyncMock()
+        await set_save_status(
             n_clicks=1,
             tags=[],
             priorities=[],

--- a/tests/pages/test_tags.py
+++ b/tests/pages/test_tags.py
@@ -12,7 +12,7 @@ from unittest.mock import AsyncMock, patch
 
 from ztf_viewer import config
 
-# `ztf_viewer.pages.tags` now pulls in `ztf_viewer.akb`, which pulls in `ztf_viewer.cache`, whose
+# `ztf_viewer.pages.tags` pulls in `ztf_viewer.akb`, which pulls in `ztf_viewer.cache`, whose
 # module-level `cache()` decorator is bound to a backend at first import and never rebinds. Set
 # this before that import, the same guard other test modules that import the app use.
 config.CACHE_TYPE = "memory"

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -23,8 +23,11 @@ def client():
     `app` is a module-level singleton, so assigning its layout here would otherwise outlive this
     file and race with whatever set it first.
     """
+    from tests.conftest import reset_shared_thread_pool
+
     original = app._layout, app._layout_is_function
     app.layout = html.Div("test")
+    reset_shared_thread_pool()
     try:
         with TestClient(app.server) as test_client:
             yield test_client

--- a/tests/test_async_offload.py
+++ b/tests/test_async_offload.py
@@ -1,0 +1,56 @@
+"""Guards that a callback converted to ``async def`` this cycle doesn't leave a blocking call
+directly in its body.
+
+Once a callback is a coroutine function, the registration shim (``ztf_viewer/callbacks.py``)
+returns it unchanged rather than wrapping it in a thread offload — that's the whole point of the
+shim, but it means anything still synchronous inside the body now runs inline on the event loop.
+Every callback below still reaches a client that stayed synchronous on purpose (an unconverted
+conesearch ``find``, an astroquery client, or a still-sync extinction lookup); this test pins
+that each such call is routed through ``asyncio.to_thread`` rather than called bare.
+
+A fully general static check (walk every ``async def`` in the app and flag any call that isn't
+either awaited or wrapped) is impractical here — it would need to know which callables are safe
+to call inline (pure computation) versus which are blocking I/O, and that distinction isn't
+recoverable from the AST alone. So this only covers the specific call sites this change touches.
+"""
+
+import inspect
+
+import pytest
+
+from ztf_viewer import config
+
+config.CACHE_TYPE = "memory"
+config.UNAVAILABLE_CATALOGS_CACHE_TYPE = "memory"
+
+from ztf_viewer.catalogs.conesearch._base import _BaseLightCurveQuery  # noqa: E402
+from ztf_viewer.pages import viewer  # noqa: E402
+
+# function (or unbound method) -> a substring of the sync call it must route through a thread
+CALLBACKS_WITH_REMAINING_BLOCKING_CALLS = {
+    viewer.fit_lc: "csfd.ebv",
+    viewer.get_antares_lc_option: "ANTARES_QUERY.find_closest",
+    viewer.get_gaia_lc_option: "GAIA_DR3.find_closest",
+    viewer.get_panstarrs_lc_option: "PANSTARRS_DR2_QUERY.find_closest",
+    viewer.get_summary: "query.find",
+    viewer.update_skybot_for_graph_clicked: "SKYBOT_QUERY.find",
+    viewer.set_table: "query.find",
+    viewer.set_vizier_list: "find_vizier.find",
+    _BaseLightCurveQuery.closest_light_curve_by_oid: "self.closest_light_curve",
+}
+
+
+@pytest.mark.parametrize("func", list(CALLBACKS_WITH_REMAINING_BLOCKING_CALLS), ids=lambda f: f.__qualname__)
+def test_async_callback_is_a_coroutine_function(func):
+    assert inspect.iscoroutinefunction(inspect.unwrap(func))
+
+
+@pytest.mark.parametrize(
+    "func,blocking_call",
+    CALLBACKS_WITH_REMAINING_BLOCKING_CALLS.items(),
+    ids=[f.__qualname__ for f in CALLBACKS_WITH_REMAINING_BLOCKING_CALLS],
+)
+def test_remaining_blocking_call_goes_through_to_thread(func, blocking_call):
+    source = inspect.getsource(inspect.unwrap(func))
+    assert blocking_call in source, f"expected {func.__qualname__} to still call {blocking_call}"
+    assert "asyncio.to_thread" in source, f"{func.__qualname__} calls {blocking_call} without asyncio.to_thread"

--- a/tests/test_async_support.py
+++ b/tests/test_async_support.py
@@ -19,9 +19,7 @@ async def test_async_tests_are_collected_and_awaited():
 
 @pytest.mark.network
 async def test_ztf_dr_find_is_awaited():
-    """`find_ztf_oid.find` is a real ``async def`` — a plain first-party network call, awaited
-    directly rather than bridged through a thread.
-    """
+    """A plain first-party network call, awaited directly."""
     from ztf_viewer.catalogs.ztf_dr import find_ztf_oid
 
     meta = await find_ztf_oid.find(_OID, _DR)

--- a/tests/test_async_support.py
+++ b/tests/test_async_support.py
@@ -18,22 +18,13 @@ async def test_async_tests_are_collected_and_awaited():
 
 
 @pytest.mark.network
-def test_ztf_dr_find_sync():
-    """The sync half of the pair: a plain first-party network call."""
+async def test_ztf_dr_find_is_awaited():
+    """`find_ztf_oid.find` is a real ``async def`` — a plain first-party network call, awaited
+    directly rather than bridged through a thread.
+    """
     from ztf_viewer.catalogs.ztf_dr import find_ztf_oid
 
-    meta = find_ztf_oid.find(_OID, _DR)
+    meta = await find_ztf_oid.find(_OID, _DR)
 
     assert "lc" in meta
     assert "meta" in meta
-
-
-@pytest.mark.network
-async def test_ztf_dr_find_async_matches_sync():
-    """`to_thread` is the shim the async migration leans on — assert it agrees."""
-    from ztf_viewer.catalogs.ztf_dr import find_ztf_oid
-
-    from_sync = find_ztf_oid.find(_OID, _DR)
-    from_async = await asyncio.to_thread(find_ztf_oid.find, _OID, _DR)
-
-    assert from_async == from_sync

--- a/tests/test_golden_http.py
+++ b/tests/test_golden_http.py
@@ -87,6 +87,9 @@ def client(dash_app):
     """
     from fastapi.testclient import TestClient
 
+    from tests.conftest import reset_shared_thread_pool
+
+    reset_shared_thread_pool()
     with TestClient(dash_app.server) as test_client:
         yield test_client
 

--- a/ztf_viewer/__main__.py
+++ b/ztf_viewer/__main__.py
@@ -49,6 +49,14 @@ async def _size_thread_pools() -> None:
     Both otherwise fall back to a stdlib default derived from CPU count. The limiter is a
     per-loop value, so it has to be set on each startup; the executor is shared.
     """
+    global _thread_pool
+    # `asyncio.run`'s teardown calls `shutdown_default_executor()` on whatever executor a loop
+    # ends with, which shuts down the shared object, not just that loop's use of it. The single
+    # production worker only ever starts up once, so this never fires there; it only bites
+    # multiple independent event loops sharing this process (several test clients in one run),
+    # where an earlier loop's teardown would otherwise leave the pool dead for every later one.
+    if _thread_pool._shutdown:
+        _thread_pool = ThreadPoolExecutor(max_workers=THREAD_POOL_SIZE, thread_name_prefix="ztf-viewer")
     asyncio.get_running_loop().set_default_executor(_thread_pool)
     anyio.to_thread.current_default_thread_limiter().total_tokens = THREAD_POOL_SIZE
 

--- a/ztf_viewer/__main__.py
+++ b/ztf_viewer/__main__.py
@@ -246,9 +246,9 @@ def set_dr_title(dr):
     Output("username", "children"),
     [Input("url", "pathname")],
 )
-def set_username(_url):
+async def set_username(_url):
     try:
-        return akb.username()
+        return await akb.username()
     except UnAuthorized:
         return html.A("login", href="/login")
 
@@ -350,7 +350,7 @@ def go_to_url(
         Input("url", "search"),
     ],
 )
-def app_select_by_url(pathname, search):
+async def app_select_by_url(pathname, search):
     if not isinstance(pathname, str):
         raise PreventUpdate
     # DR7 is not supported anymore:
@@ -518,13 +518,13 @@ archivePrefix = {arXiv},
         ]
     if match := re.search(r"^/+view/+(\d+)", pathname):
         return [
-            get_viewer_layout(f"/{DEFAULT_DR}/view/{match.group(1)}", search),
+            await get_viewer_layout(f"/{DEFAULT_DR}/view/{match.group(1)}", search),
             no_update,
             no_update,
         ]
     if re.search(r"^/+dr\d{1,2}/+view/+(\d+)", pathname):
         return [
-            get_viewer_layout(pathname, search),
+            await get_viewer_layout(pathname, search),
             no_update,
             no_update,
         ]
@@ -569,7 +569,7 @@ archivePrefix = {arXiv},
             ]
         dr = search_match.group("dr") or DEFAULT_DR
         return [
-            get_search_layout(coordinates, radius_arcsec, dr),
+            await get_search_layout(coordinates, radius_arcsec, dr),
             coord_or_name,
             radius_arcsec,
         ]

--- a/ztf_viewer/__main__.py
+++ b/ztf_viewer/__main__.py
@@ -49,14 +49,6 @@ async def _size_thread_pools() -> None:
     Both otherwise fall back to a stdlib default derived from CPU count. The limiter is a
     per-loop value, so it has to be set on each startup; the executor is shared.
     """
-    global _thread_pool
-    # `asyncio.run`'s teardown calls `shutdown_default_executor()` on whatever executor a loop
-    # ends with, which shuts down the shared object, not just that loop's use of it. The single
-    # production worker only ever starts up once, so this never fires there; it only bites
-    # multiple independent event loops sharing this process (several test clients in one run),
-    # where an earlier loop's teardown would otherwise leave the pool dead for every later one.
-    if _thread_pool._shutdown:
-        _thread_pool = ThreadPoolExecutor(max_workers=THREAD_POOL_SIZE, thread_name_prefix="ztf-viewer")
     asyncio.get_running_loop().set_default_executor(_thread_pool)
     anyio.to_thread.current_default_thread_limiter().total_tokens = THREAD_POOL_SIZE
 

--- a/ztf_viewer/akb.py
+++ b/ztf_viewer/akb.py
@@ -1,11 +1,13 @@
 import logging
 from urllib.parse import urljoin
 
-import cachetools
 import dash
-import requests
+import httpx
 
+from ztf_viewer.cache import cache
+from ztf_viewer.config import TIMEOUT_AKB
 from ztf_viewer.exceptions import NotFound, UnAuthorized
+from ztf_viewer.http import get_client
 
 
 class AKB:
@@ -14,11 +16,9 @@ class AKB:
     _objects_api_url = urljoin(_base_api_url, "/objects/")
     _whoami_api_url = urljoin(_base_api_url, "/whoami/")
 
-    def __init__(self):
-        self.session = requests.Session()
-
-    def _get(self, url, token=None):
-        response = self.session.get(url, headers=self._token_header(token))
+    async def _get(self, url, token=None):
+        client = get_client()
+        response = await client.get(url, headers=self._token_header(token), timeout=TIMEOUT_AKB)
         if response.status_code == 200:
             return response.json()
         message = f"{response.url} returned {response.status_code}: {response.text}"
@@ -29,8 +29,9 @@ class AKB:
             raise NotFound(message)
         response.raise_for_status()
 
-    def _head(self, url, token=None):
-        return self.session.head(url, headers=self._token_header(token))
+    async def _head(self, url, token=None):
+        client = get_client()
+        return await client.head(url, headers=self._token_header(token), timeout=TIMEOUT_AKB)
 
     def _token_from_cookies(self):
         try:
@@ -52,45 +53,46 @@ class AKB:
     def _tag_url(self, tag_name):
         return urljoin(self._tags_api_url, f"{tag_name}/")
 
-    def _put_or_post(self, put_url, post_url, data, token=None):
+    async def _put_or_post(self, put_url, post_url, data, token=None):
+        client = get_client()
         headers = self._token_header(token)
-        resp = self.session.put(put_url, json=data, headers=headers)
+        resp = await client.put(put_url, json=data, headers=headers, timeout=TIMEOUT_AKB)
         if resp.status_code == 404:
-            resp = self.session.post(post_url, json=data, headers=headers)
+            resp = await client.post(post_url, json=data, headers=headers, timeout=TIMEOUT_AKB)
         try:
             resp.raise_for_status()
-        except requests.HTTPError as e:
+        except httpx.HTTPError as e:
             logging.info(f"Post into {resp.url} returned {resp.status_code}: {resp.text}")
             raise RuntimeError from e
 
-    def get_tags(self, token=None):
-        return self._get(self._tags_api_url, token=token)
+    async def get_tags(self, token=None):
+        return await self._get(self._tags_api_url, token=token)
 
-    def get_tag_names(self, token=None):
-        tags = self.get_tags(token=token)
+    async def get_tag_names(self, token=None):
+        tags = await self.get_tags(token=token)
         names = [tag["name"] for tag in sorted(tags, key=lambda tag: tag["priority"])]
         return names
 
-    def post_tag(self, name, priority=None, description=None, token=None):
+    async def post_tag(self, name, priority=None, description=None, token=None):
         if priority is None:
-            priority = max((tag["priority"] for tag in self.get_tags()), default=-1) + 1
+            priority = max((tag["priority"] for tag in await self.get_tags()), default=-1) + 1
         data = dict(name=name, priority=priority)
         if description is not None:
             data["description"] = description
-        self._put_or_post(self._tag_url(name), self._tags_api_url, data, token=token)
+        await self._put_or_post(self._tag_url(name), self._tags_api_url, data, token=token)
 
-    def post_tags(self, tags, token=None):
+    async def post_tags(self, tags, token=None):
         for tag in tags:
-            self.post_tag(tag["name"], tag["priority"], tag.get("description"), token=token)
+            await self.post_tag(tag["name"], tag["priority"], tag.get("description"), token=token)
 
-    def get_objects(self, token=None):
-        return self._get(self._objects_api_url, token=token)
+    async def get_objects(self, token=None):
+        return await self._get(self._objects_api_url, token=token)
 
-    def get_by_oid(self, oid, token=None):
-        return self._get(self._object_url(oid), token=token)
+    async def get_by_oid(self, oid, token=None):
+        return await self._get(self._object_url(oid), token=token)
 
-    def oid_exists(self, oid, token=None):
-        response = self._head(self._object_url(oid), token=token)
+    async def oid_exists(self, oid, token=None):
+        response = await self._head(self._object_url(oid), token=token)
         if response.status_code == 200:
             return True
         if response.status_code == 404:
@@ -98,49 +100,50 @@ class AKB:
         response.raise_for_status()
         raise RuntimeError("Unexpected error while HEAD request to AKB server")
 
-    def post_object(self, oid, tags, description, token=None):
+    async def post_object(self, oid, tags, description, token=None):
         data = dict(oid=oid, tags=tags, description=description)
-        self._put_or_post(self._object_url(oid), self._objects_api_url, data, token=token)
+        await self._put_or_post(self._object_url(oid), self._objects_api_url, data, token=token)
 
-    def get_object_log(self, oid, token=None):
+    async def get_object_log(self, oid, token=None):
         try:
-            return self._get(self._object_log_url(oid), token=token)
+            return await self._get(self._object_log_url(oid), token=token)
         except NotFound:
             return []
 
-    @cachetools.cached(cachetools.TTLCache(maxsize=1024, ttl=3600))
-    def whoami(self, token):
+    @cache()
+    async def whoami(self, token):
         if not isinstance(token, str):
             raise ValueError(f"token must be a str, not {type(token)}")
-        resp = self.session.get(self._whoami_api_url, headers=self._token_header(token))
+        client = get_client()
+        resp = await client.get(self._whoami_api_url, headers=self._token_header(token), timeout=TIMEOUT_AKB)
         if resp.status_code == 401:
             raise UnAuthorized
         resp.raise_for_status()
         return resp.json()
 
-    def username(self, token=None):
+    async def username(self, token=None):
         if token is None:
             token = self._token_from_cookies()
-        json = self.whoami(token=token)
+        json = await self.whoami(token=token)
         if json["first_name"] or json["last_name"]:
             return f"{json['first_name']} {json['last_name']}"
         return json["username"]
 
-    @cachetools.cached(cachetools.TTLCache(maxsize=1024, ttl=3600))
-    def _is_token_valid(self, token):
+    @cache()
+    async def _is_token_valid(self, token):
         try:
-            self.whoami(token)
+            await self.whoami(token)
             return True
         except UnAuthorized:
             return False
 
-    def is_token_valid(self, token=None):
+    async def is_token_valid(self, token=None):
         if token is None:
             try:
                 token = self._token_from_cookies()
             except UnAuthorized:
                 return False
-        return self._is_token_valid(token=token)
+        return await self._is_token_valid(token=token)
 
 
 akb = AKB()

--- a/ztf_viewer/catalogs/conesearch/_base.py
+++ b/ztf_viewer/catalogs/conesearch/_base.py
@@ -274,8 +274,6 @@ class _BaseLightCurveQuery:
 
     async def closest_light_curve_by_oid(self, oid, dr, radius_arcsec, fail_on_empty=True, fail_on_unavailable=True):
         ra, dec = await find_ztf_oid.get_coord(oid, dr)
-        # `closest_light_curve` is still sync conesearch code (out of scope here); offload to
-        # a thread with a bare `asyncio.to_thread`.
         return await asyncio.to_thread(
             self.closest_light_curve,
             ra,

--- a/ztf_viewer/catalogs/conesearch/_base.py
+++ b/ztf_viewer/catalogs/conesearch/_base.py
@@ -1,3 +1,4 @@
+import asyncio
 import dataclasses
 import logging
 import urllib.parse
@@ -271,10 +272,17 @@ class _BaseLightCurveQuery:
                 raise
             return self._empty_light_curve()
 
-    def closest_light_curve_by_oid(self, oid, dr, radius_arcsec, fail_on_empty=True, fail_on_unavailable=True):
-        ra, dec = find_ztf_oid.get_coord(oid, dr)
-        return self.closest_light_curve(
-            ra, dec, radius_arcsec, fail_on_empty=fail_on_empty, fail_on_unavailable=fail_on_unavailable
+    async def closest_light_curve_by_oid(self, oid, dr, radius_arcsec, fail_on_empty=True, fail_on_unavailable=True):
+        ra, dec = await find_ztf_oid.get_coord(oid, dr)
+        # `closest_light_curve` is still sync conesearch code (out of scope here); offload to
+        # a thread with a bare `asyncio.to_thread`.
+        return await asyncio.to_thread(
+            self.closest_light_curve,
+            ra,
+            dec,
+            radius_arcsec,
+            fail_on_empty=fail_on_empty,
+            fail_on_unavailable=fail_on_unavailable,
         )
 
 

--- a/ztf_viewer/catalogs/ztf_dr.py
+++ b/ztf_viewer/catalogs/ztf_dr.py
@@ -1,32 +1,26 @@
 import logging
 from urllib.parse import urlencode, urljoin, urlsplit, urlunsplit
 
-import requests
 from astropy.coordinates import SkyCoord
 
 from ztf_viewer.cache import cache
-from ztf_viewer.config import LC_API_URL
+from ztf_viewer.config import LC_API_URL, TIMEOUT_ZTF_DR
 from ztf_viewer.exceptions import CatalogUnavailable, NotFound
+from ztf_viewer.http import get_client
 from ztf_viewer.util import INF
 
 
 class _BaseFindZTF:
     _base_api_url = urljoin(LC_API_URL, "/api/v3/")
 
-    def __init__(self):
-        self._api_session = requests.Session()
-
     def _api_url(self, dr):
         return urljoin(self._base_api_url, f"data/{dr}/")
 
-    def find(self, *args, **kwargs):
+    async def find(self, *args, **kwargs):
         raise NotImplementedError
 
 
 class FindZTFOID(_BaseFindZTF):
-    def __init__(self):
-        super().__init__()
-
     def _oid_api_url(self, dr):
         return urljoin(self._api_url(dr), "oid/full/json")
 
@@ -40,8 +34,9 @@ class FindZTFOID(_BaseFindZTF):
         return dict(oid=oid)
 
     @cache()
-    def find(self, oid, dr):
-        resp = self._api_session.get(self._oid_api_url(dr), params=self._query_dict(oid), timeout=60)
+    async def find(self, oid, dr):
+        client = get_client()
+        resp = await client.get(self._oid_api_url(dr), params=self._query_dict(oid), timeout=TIMEOUT_ZTF_DR)
         if resp.status_code != 200:
             message = f"{resp.url} returned {resp.status_code}: {resp.text}"
             logging.info(message)
@@ -51,20 +46,20 @@ class FindZTFOID(_BaseFindZTF):
             raise NotFound
         return j[str(oid)]
 
-    def get_coord(self, oid, dr):
-        meta = self.get_meta(oid, dr)
+    async def get_coord(self, oid, dr):
+        meta = await self.get_meta(oid, dr)
         if meta is None:
             raise NotFound
         coord = meta["coord"]
         return coord["ra"], coord["dec"]
 
-    def get_sky_coord(self, oid, dr):
-        ra, dec = self.get_coord(oid, dr)
+    async def get_sky_coord(self, oid, dr):
+        ra, dec = await self.get_coord(oid, dr)
         return SkyCoord(ra=ra, dec=dec, unit="deg")
 
-    def get_coord_string(self, oid, dr, frame=None):
+    async def get_coord_string(self, oid, dr, frame=None):
         try:
-            ra, dec = self.get_coord(oid, dr)
+            ra, dec = await self.get_coord(oid, dr)
         except TypeError as e:
             raise NotFound from e
         if frame is None:
@@ -73,16 +68,16 @@ class FindZTFOID(_BaseFindZTF):
         frame_coord = sky_coord.transform_to(frame)
         return frame_coord.to_string()
 
-    def get_meta(self, oid, dr):
-        j = self.find(oid, dr)
+    async def get_meta(self, oid, dr):
+        j = await self.find(oid, dr)
         return j["meta"]
 
-    def get_lc(self, oid, dr, min_mjd=None, max_mjd=None):
+    async def get_lc(self, oid, dr, min_mjd=None, max_mjd=None):
         if min_mjd is None:
             min_mjd = -INF
         if max_mjd is None:
             max_mjd = INF
-        j = self.find(oid, dr)
+        j = await self.find(oid, dr)
         lc = [obs.copy() for obs in j["lc"] if min_mjd <= obs["mjd"] <= max_mjd]
         return lc
 
@@ -91,18 +86,16 @@ find_ztf_oid = FindZTFOID()
 
 
 class FindZTFCircle(_BaseFindZTF):
-    def __init__(self):
-        super().__init__()
-
     def _circle_api_url(self, dr):
         return urljoin(self._api_url(dr), "circle/full/json")
 
     @cache()
-    def find(self, ra, dec, radius_arcsec, dr):
-        resp = self._api_session.get(
+    async def find(self, ra, dec, radius_arcsec, dr):
+        client = get_client()
+        resp = await client.get(
             self._circle_api_url(dr),
             params=dict(ra=ra, dec=dec, radius_arcsec=radius_arcsec),
-            timeout=60,
+            timeout=TIMEOUT_ZTF_DR,
         )
         if resp.status_code != 200:
             raise CatalogUnavailable

--- a/ztf_viewer/catalogs/ztf_ref.py
+++ b/ztf_viewer/catalogs/ztf_ref.py
@@ -16,7 +16,7 @@ from ztf_viewer.util import ccdid_from_rcid, qid_from_rcid
 
 
 def _parse_fits(data: bytes, url: str, sourceid: int) -> dict:
-    """Parse the reference-catalog FITS payload. CPU-bound, meant to run in a thread."""
+    """Parse the reference-catalog FITS payload and pull out the row for `sourceid`."""
     with fits.open(BytesIO(data)) as f:
         header = f[0].header
         table = f[1].data

--- a/ztf_viewer/catalogs/ztf_ref.py
+++ b/ztf_viewer/catalogs/ztf_ref.py
@@ -1,27 +1,43 @@
+import asyncio
 import logging
+from io import BytesIO
 from pathlib import Path
-from urllib.error import HTTPError, URLError
 
+import httpx
 import numpy as np
-import requests
 from astropy.io import fits
 
 from ztf_viewer.cache import cache
 from ztf_viewer.catalogs import find_ztf_oid
-from ztf_viewer.config import ZTF_FITS_PROXY_URL
+from ztf_viewer.config import TIMEOUT_ZTF_FITS_PROXY, ZTF_FITS_PROXY_URL
 from ztf_viewer.exceptions import NotFound, CatalogUnavailable
+from ztf_viewer.http import get_client
 from ztf_viewer.util import ccdid_from_rcid, qid_from_rcid
+
+
+def _parse_fits(data: bytes, url: str, sourceid: int) -> dict:
+    """Parse the reference-catalog FITS payload. CPU-bound, meant to run in a thread."""
+    with fits.open(BytesIO(data)) as f:
+        header = f[0].header
+        table = f[1].data
+        where = np.where(table["sourceid"] == sourceid)[0]
+        if where.size == 0:
+            logging.warning(f"Object with sourceid={sourceid} is not found in the reference catalog file {url}")
+            raise NotFound
+        idx = where.item()
+        record = dict(zip(table.names, table[idx]))
+        record["magzp"] = header["MAGZP"]
+        record["magzp_rms"] = header["MAGZPRMS"]
+        record["infobits"] = header["INFOBITS"]
+    return record
 
 
 class ZTFRef:
     _base_fits_url = f"{ZTF_FITS_PROXY_URL}"
     _base_path = "/products/ref/"
 
-    def __init__(self):
-        self._api_session = requests.Session()
-
-    def fits_url(self, oid, dr):
-        meta = find_ztf_oid.get_meta(oid, dr)
+    async def fits_url(self, oid, dr):
+        meta = await find_ztf_oid.get_meta(oid, dr)
         if meta["fieldid"] < 1000:
             root = "000"
         else:
@@ -39,28 +55,18 @@ class ZTFRef:
         return f"{self._base_fits_url}{path}"
 
     @cache()
-    def get(self, oid, dr):
-        url = self.fits_url(oid, dr)
+    async def get(self, oid, dr):
+        url = await self.fits_url(oid, dr)
         sourceid = int(oid) % 10_000_000
+        client = get_client()
         try:
-            with fits.open(url) as f:
-                header = f[0].header
-                data = f[1].data
-                where = np.where(data["sourceid"] == sourceid)[0]
-                if where.size == 0:
-                    logging.warning(f"Object {oid} is not found in the reference catalog file {url}")
-                    raise NotFound
-                idx = where.item()
-                record = dict(zip(data.names, data[idx]))
-                record["magzp"] = header["MAGZP"]
-                record["magzp_rms"] = header["MAGZPRMS"]
-                record["infobits"] = header["INFOBITS"]
-        except HTTPError:
+            response = await client.get(url, timeout=TIMEOUT_ZTF_FITS_PROXY)
+            response.raise_for_status()
+        except httpx.HTTPStatusError:
             raise NotFound
-        except URLError:
+        except httpx.RequestError:
             raise CatalogUnavailable
-
-        return record
+        return await asyncio.to_thread(_parse_fits, response.content, url, sourceid)
 
 
 ztf_ref = ZTFRef()

--- a/ztf_viewer/date_with_frac.py
+++ b/ztf_viewer/date_with_frac.py
@@ -4,10 +4,10 @@ from dataclasses import dataclass
 from urllib.parse import urljoin
 
 import numpy as np
-import requests
 
 from ztf_viewer.cache import cache
-from ztf_viewer.config import ZTF_FITS_PROXY_URL
+from ztf_viewer.config import TIMEOUT_ZTF_FITS_PROXY, ZTF_FITS_PROXY_URL
+from ztf_viewer.http import get_client
 from ztf_viewer.util import ccdid_from_rcid, hmjd_to_earth, qid_from_rcid
 
 
@@ -53,15 +53,16 @@ class DateWithFrac:
 
 
 @cache()
-def _fracs(products_root):
+async def _fracs(products_root):
     url = urljoin(ZTF_FITS_PROXY_URL, products_root)
-    body = requests.get(url).text
-    fracs = re.findall(r'<a href="(\d{6})/">\1/</a>', body)
+    client = get_client()
+    response = await client.get(url, timeout=TIMEOUT_ZTF_FITS_PROXY)
+    fracs = re.findall(r'<a href="(\d{6})/">\1/</a>', response.text)
     return sorted(int(f) for f in fracs)
 
 
-def correct_date(date_with_frac):
-    fracs = _fracs(date_with_frac.products_root)
+async def correct_date(date_with_frac):
+    fracs = await _fracs(date_with_frac.products_root)
     digits = 6
     i = np.searchsorted(fracs, date_with_frac.frac_digits(digits))
     date_with_frac.fraction = fracs[i - 1] / (10.0**digits)

--- a/ztf_viewer/lc_data/plot_data.py
+++ b/ztf_viewer/lc_data/plot_data.py
@@ -80,7 +80,7 @@ def folded_plot_data(plot_data, period, offset=None):
 
 
 @cache()
-def get_plot_data(
+async def get_plot_data(
     cur_oid,
     dr,
     other_oids=frozenset(),
@@ -113,49 +113,41 @@ def get_plot_data(
         ...
     }
     """
-    lcs = (
-        {
-            cur_oid: plot_data(
-                ztf_dr_lc(cur_oid, dr),
-                mark_size=3,
-                min_mjd=min_mjd,
-                max_mjd=max_mjd,
-                ref_mag=ref_mag,
-                ref_magerr=ref_magerr,
-            ),
-        }
-        | {
-            oid: plot_data(
-                ztf_dr_lc(oid, dr),
-                mark_size=1,
-                min_mjd=min_mjd,
-                max_mjd=max_mjd,
-                ref_mag=ref_mag,
-                ref_magerr=ref_magerr,
-            )
-            for oid in sorted(other_oids, key=int)
-        }
-        | {
-            id: plot_data(lc, mark_size=3, min_mjd=min_mjd, max_mjd=max_mjd, ref_mag=ref_mag, ref_magerr=ref_magerr)
-            for id, lc in add_id_to_obs(additional_data).items()
-        }
-        | {
-            source: plot_data(
-                EXTERNAL_LC_DATA[source](cur_oid, dr, **kwargs),
-                mark_size=1,
-                min_mjd=min_mjd,
-                max_mjd=max_mjd,
-                ref_mag=ref_mag,
-                ref_magerr=ref_magerr,
-            )
-            for source, kwargs in external_data.items()
-        }
-    )
+    lcs = {
+        cur_oid: plot_data(
+            await ztf_dr_lc(cur_oid, dr),
+            mark_size=3,
+            min_mjd=min_mjd,
+            max_mjd=max_mjd,
+            ref_mag=ref_mag,
+            ref_magerr=ref_magerr,
+        ),
+    }
+    for oid in sorted(other_oids, key=int):
+        lcs[oid] = plot_data(
+            await ztf_dr_lc(oid, dr),
+            mark_size=1,
+            min_mjd=min_mjd,
+            max_mjd=max_mjd,
+            ref_mag=ref_mag,
+            ref_magerr=ref_magerr,
+        )
+    for id, lc in add_id_to_obs(additional_data).items():
+        lcs[id] = plot_data(lc, mark_size=3, min_mjd=min_mjd, max_mjd=max_mjd, ref_mag=ref_mag, ref_magerr=ref_magerr)
+    for source, kwargs in external_data.items():
+        lcs[source] = plot_data(
+            await EXTERNAL_LC_DATA[source](cur_oid, dr, **kwargs),
+            mark_size=1,
+            min_mjd=min_mjd,
+            max_mjd=max_mjd,
+            ref_mag=ref_mag,
+            ref_magerr=ref_magerr,
+        )
     return lcs
 
 
 @cache()
-def get_folded_plot_data(
+async def get_folded_plot_data(
     cur_oid,
     dr,
     period,
@@ -168,7 +160,7 @@ def get_folded_plot_data(
     ref_mag=immutabledefaultdict(lambda: np.inf),
     ref_magerr=immutabledefaultdict(float),
 ):
-    lcs = get_plot_data(
+    lcs = await get_plot_data(
         cur_oid=cur_oid,
         dr=dr,
         other_oids=other_oids,

--- a/ztf_viewer/lc_data/ztf_dr.py
+++ b/ztf_viewer/lc_data/ztf_dr.py
@@ -1,9 +1,9 @@
 from ztf_viewer.catalogs import find_ztf_oid
 
 
-def ztf_dr_lc(oid, dr):
-    lc = find_ztf_oid.get_lc(oid, dr)
-    meta = find_ztf_oid.get_meta(oid, dr)
+async def ztf_dr_lc(oid, dr):
+    lc = await find_ztf_oid.get_lc(oid, dr)
+    meta = await find_ztf_oid.get_meta(oid, dr)
     for obs in lc:
         obs["oid"] = oid
         obs["fieldid"] = meta["fieldid"]

--- a/ztf_viewer/lc_features.py
+++ b/ztf_viewer/lc_features.py
@@ -1,24 +1,23 @@
 from typing import List
 
-import requests
-
 from ztf_viewer.cache import cache
 from ztf_viewer.catalogs.ztf_dr import find_ztf_oid
-from ztf_viewer.config import FEATURES_API_URL
+from ztf_viewer.config import FEATURES_API_URL, TIMEOUT_FEATURES
 from ztf_viewer.exceptions import NotFound
+from ztf_viewer.http import get_client
 
 
 class LightCurveFeatures:
     _base_api_url = FEATURES_API_URL
 
     def __init__(self):
-        self._api_session = requests.Session()
         self._find_ztf_oid = find_ztf_oid
 
     @cache()
-    def versions(self) -> List[str]:
+    async def versions(self) -> List[str]:
         url = f"{self._base_api_url}/versions"
-        resp = self._api_session.get(url)
+        client = get_client()
+        resp = await client.get(url, timeout=TIMEOUT_FEATURES)
         if resp.status_code != 200:
             raise NotFound
         return resp.json()
@@ -27,11 +26,12 @@ class LightCurveFeatures:
         return f"{self._base_api_url}/api/{version}/"
 
     @cache()
-    def __call__(self, oid, dr, version, min_mjd=None, max_mjd=None):
-        lc = find_ztf_oid.get_lc(oid, dr, min_mjd=min_mjd, max_mjd=max_mjd)
+    async def __call__(self, oid, dr, version, min_mjd=None, max_mjd=None):
+        lc = await find_ztf_oid.get_lc(oid, dr, min_mjd=min_mjd, max_mjd=max_mjd)
         light_curve = [dict(t=obs["mjd"], m=obs["mag"], err=obs["magerr"]) for obs in lc]
         j = dict(light_curve=light_curve)
-        resp = self._api_session.post(self.url(version), json=j)
+        client = get_client()
+        resp = await client.post(self.url(version), json=j, timeout=TIMEOUT_FEATURES)
         if resp.status_code != 200:
             raise NotFound
         return resp.json()

--- a/ztf_viewer/model_fit.py
+++ b/ztf_viewer/model_fit.py
@@ -1,41 +1,36 @@
+import logging
+
+import httpx
 import numpy as np
-import requests
 from pydantic import BaseModel
 from typing import Literal, List, Dict, Optional
 
 from ztf_viewer.cache import cache
 from ztf_viewer.catalogs.ztf_dr import find_ztf_oid
-from ztf_viewer.config import MODEL_FIT_API_URL
+from ztf_viewer.config import MODEL_FIT_API_URL, TIMEOUT_MODEL_FIT
+from ztf_viewer.http import get_client
 from ztf_viewer.util import ABZPMAG_JY, LN10_04, immutabledefaultdict
 
 
-def post_request(url, data):
+async def post_request(url, data):
     try:
-        response = requests.post(url, json=data.model_dump())
+        client = get_client()
+        response = await client.post(url, json=data.model_dump(), timeout=TIMEOUT_MODEL_FIT)
         response.raise_for_status()
         return {"success": True, "body": response.json()}
-    except (
-        requests.exceptions.HTTPError,
-        requests.exceptions.ConnectionError,
-        requests.exceptions.Timeout,
-        requests.exceptions.RequestException,
-    ) as e:
-        print(f"A model-fit-api error occurred: {e}")
+    except httpx.HTTPError as e:
+        logging.warning(f"A model-fit-api error occurred: {e}")
         return {"success": False, "body": "API is unavailable"}
 
 
-def get_request(url):
+async def get_request(url):
     try:
-        response = requests.get(url)
+        client = get_client()
+        response = await client.get(url, timeout=TIMEOUT_MODEL_FIT)
         response.raise_for_status()
         return {"success": True, "body": response.json()}
-    except (
-        requests.exceptions.HTTPError,
-        requests.exceptions.ConnectionError,
-        requests.exceptions.Timeout,
-        requests.exceptions.RequestException,
-    ) as e:
-        print(f"A model-fit-api error occurred: {e}")
+    except httpx.HTTPError as e:
+        logging.warning(f"A model-fit-api error occurred: {e}")
         return {"success": False, "body": "API is unavailable"}
 
 
@@ -80,11 +75,8 @@ class ModelFit:
     _fit_api_url = _base_api_url + "/sncosmo/fit"
     _get_curve_api_url = _base_api_url + "/sncosmo/get_curve"
 
-    def __init__(self):
-        self._api_session = requests.Session()
-
     @cache()
-    def fit(
+    async def fit(
         self,
         oids: tuple[int],
         dr: str,
@@ -98,8 +90,8 @@ class ModelFit:
     ):
         observations = []
         for oid in oids:
-            lc = find_ztf_oid.get_lc(oid, dr, min_mjd=min_mjd, max_mjd=max_mjd)
-            flt = find_ztf_oid.get_meta(oid, dr)["filter"]
+            lc = await find_ztf_oid.get_lc(oid, dr, min_mjd=min_mjd, max_mjd=max_mjd)
+            flt = (await find_ztf_oid.get_meta(oid, dr))["filter"]
             ref_flux = 10 ** (-0.4 * (ref_mag[oid] - ABZPMAG_JY))
             ref_fluxerr = LN10_04 * ref_flux * ref_magerr[oid]
             for obs in lc:
@@ -115,7 +107,7 @@ class ModelFit:
                         band="ztf" + flt[1:],
                     )
                 )
-        res_fit = post_request(
+        res_fit = await post_request(
             self._fit_api_url,
             Target(light_curve=observations, ebv=ebv, name_model=fit_model),
         )
@@ -124,7 +116,7 @@ class ModelFit:
         else:
             return Response(success=res_fit["success"], data={"parameters": {}}, message=res_fit["body"])
 
-    def get_curve(
+    async def get_curve(
         self,
         oids: tuple[int],
         dr: str,
@@ -141,8 +133,8 @@ class ModelFit:
         mjd_values = []
 
         for oid in oids:
-            lc = find_ztf_oid.get_lc(oid, dr, min_mjd=min_mjd, max_mjd=max_mjd)
-            flt = find_ztf_oid.get_meta(oid, dr)["filter"]
+            lc = await find_ztf_oid.get_lc(oid, dr, min_mjd=min_mjd, max_mjd=max_mjd)
+            flt = (await find_ztf_oid.get_meta(oid, dr))["filter"]
             ref_flux = 10 ** (-0.4 * (ref_mag[oid] - ABZPMAG_JY))
             for obs in lc:
                 mjd_values.append(obs["mjd"])
@@ -154,7 +146,7 @@ class ModelFit:
         mjd_min = min(mjd_values)
         mjd_max = max(mjd_values)
 
-        res_curve = post_request(
+        res_curve = await post_request(
             self._get_curve_api_url,
             ModelData(
                 parameters=dict(params),
@@ -171,8 +163,8 @@ class ModelFit:
         else:
             return Response(success=res_curve["success"], data={"bright": {}}, message=res_curve["body"])
 
-    def get_list_models(self):
-        res_models = get_request(self._models_api_url)
+    async def get_list_models(self):
+        res_models = await get_request(self._models_api_url)
         if res_models["success"]:
             return Response(success=res_models["success"], data=res_models["body"])
         else:

--- a/ztf_viewer/pages/akb_table.py
+++ b/ztf_viewer/pages/akb_table.py
@@ -42,10 +42,10 @@ def get_layout(*args, **kwargs):
     Output("anomaly-table", "data"),
     [Input("url", "pathname")],
 )
-def set_table_data(pathname):
-    if not akb.is_token_valid():
+async def set_table_data(pathname):
+    if not await akb.is_token_valid():
         raise PreventUpdate
-    objs = akb.get_objects()
+    objs = await akb.get_objects()
     objs = sorted(objs, key=lambda obj: obj["oid"])
     for item in objs:
         oid = item["oid"]

--- a/ztf_viewer/pages/figure.py
+++ b/ztf_viewer/pages/figure.py
@@ -1,3 +1,4 @@
+import asyncio
 from datetime import datetime
 from io import BytesIO
 
@@ -30,7 +31,10 @@ class UnknownFormat(Exception):
 
 
 @app.server.api_route("/{dr}/figure/{oid}/folded/{period}")
-def response_figure_folded(dr: str, oid: int, period: float, request: Request):
+async def response_figure_folded(dr: str, oid: int, period: float, request: Request):
+    """Async because `get_folded_plot_data` now awaits `find_ztf_oid`; the FastAPI threadpool
+    that plain-`def` routes get doesn't apply once a route itself needs to await.
+    """
     args = query_args(request)
     try:
         kwargs = parse_figure_args_helper(args)
@@ -45,14 +49,20 @@ def response_figure_folded(dr: str, oid: int, period: float, request: Request):
     if repeat is not None:
         repeat = int(repeat)
 
-    data = get_folded_plot_data(oid, dr, period=period, offset=offset, **kwargs)
-    img = plot_folded_data(oid, data, period=period, repeat=repeat, fmt=fmt, caption=caption, title=title)
+    data = await get_folded_plot_data(oid, dr, period=period, offset=offset, **kwargs)
+    # matplotlib rendering is CPU-heavy; keep it off the event loop.
+    img = await asyncio.to_thread(
+        plot_folded_data, oid, data, period=period, repeat=repeat, fmt=fmt, caption=caption, title=title
+    )
 
     return binary_response(img, mimetype=MIMES[fmt], filename=f"{oid}.{fmt}")
 
 
 @app.server.api_route("/{dr}/figure/{oid}", methods=["GET", "POST"])
-def response_figure(dr: str, oid: int, request: Request, body: bytes = Body(default=b"")):
+async def response_figure(dr: str, oid: int, request: Request, body: bytes = Body(default=b"")):
+    """Async because `get_plot_data` now awaits `find_ztf_oid`; the FastAPI threadpool
+    that plain-`def` routes get doesn't apply once a route itself needs to await.
+    """
     args = query_args(request)
     try:
         kwargs = parse_figure_args_helper(args, body)
@@ -62,8 +72,9 @@ def response_figure(dr: str, oid: int, request: Request, body: bytes = Body(defa
     caption = kwargs.pop("caption")
     title = kwargs.pop("title")
 
-    data = get_plot_data(oid, dr, **kwargs)
-    img = plot_data(oid, data, fmt=fmt, caption=caption, title=title)
+    data = await get_plot_data(oid, dr, **kwargs)
+    # matplotlib rendering is CPU-heavy; keep it off the event loop.
+    img = await asyncio.to_thread(plot_data, oid, data, fmt=fmt, caption=caption, title=title)
 
     return binary_response(img, mimetype=MIMES[fmt], filename=f"{oid}.{fmt}")
 

--- a/ztf_viewer/pages/figure.py
+++ b/ztf_viewer/pages/figure.py
@@ -32,9 +32,6 @@ class UnknownFormat(Exception):
 
 @app.server.api_route("/{dr}/figure/{oid}/folded/{period}")
 async def response_figure_folded(dr: str, oid: int, period: float, request: Request):
-    """Async because `get_folded_plot_data` now awaits `find_ztf_oid`; the FastAPI threadpool
-    that plain-`def` routes get doesn't apply once a route itself needs to await.
-    """
     args = query_args(request)
     try:
         kwargs = parse_figure_args_helper(args)
@@ -59,9 +56,6 @@ async def response_figure_folded(dr: str, oid: int, period: float, request: Requ
 
 @app.server.api_route("/{dr}/figure/{oid}", methods=["GET", "POST"])
 async def response_figure(dr: str, oid: int, request: Request, body: bytes = Body(default=b"")):
-    """Async because `get_plot_data` now awaits `find_ztf_oid`; the FastAPI threadpool
-    that plain-`def` routes get doesn't apply once a route itself needs to await.
-    """
     args = query_args(request)
     try:
         kwargs = parse_figure_args_helper(args, body)

--- a/ztf_viewer/pages/figure.py
+++ b/ztf_viewer/pages/figure.py
@@ -50,7 +50,6 @@ async def response_figure_folded(dr: str, oid: int, period: float, request: Requ
         repeat = int(repeat)
 
     data = await get_folded_plot_data(oid, dr, period=period, offset=offset, **kwargs)
-    # matplotlib rendering is CPU-heavy; keep it off the event loop.
     img = await asyncio.to_thread(
         plot_folded_data, oid, data, period=period, repeat=repeat, fmt=fmt, caption=caption, title=title
     )
@@ -73,7 +72,6 @@ async def response_figure(dr: str, oid: int, request: Request, body: bytes = Bod
     title = kwargs.pop("title")
 
     data = await get_plot_data(oid, dr, **kwargs)
-    # matplotlib rendering is CPU-heavy; keep it off the event loop.
     img = await asyncio.to_thread(plot_data, oid, data, fmt=fmt, caption=caption, title=title)
 
     return binary_response(img, mimetype=MIMES[fmt], filename=f"{oid}.{fmt}")

--- a/ztf_viewer/pages/lc_csv.py
+++ b/ztf_viewer/pages/lc_csv.py
@@ -99,9 +99,6 @@ def response_antares_csv(locus_id: str):
 # Keep last: `oid` is an int, so this also matches the catalog routes above.
 @app.server.api_route("/{dr}/csv/{oid}")
 async def response_csv(dr: str, oid: int, request: Request):
-    """Async because `get_csv` calls `find_ztf_oid.get_lc`, which now awaits; the FastAPI
-    threadpool that plain-`def` routes get doesn't apply once a route itself needs to await.
-    """
     args = query_args(request)
 
     try:

--- a/ztf_viewer/pages/lc_csv.py
+++ b/ztf_viewer/pages/lc_csv.py
@@ -5,6 +5,7 @@ match wins, so the specific catalog routes must be registered before the generic
 `/{dr}/csv/{oid}` one.
 """
 
+import asyncio
 from io import StringIO
 
 import pandas as pd
@@ -18,19 +19,19 @@ from ztf_viewer.catalogs.conesearch import ANTARES_QUERY, GAIA_DR3, PANSTARRS_DR
 from ztf_viewer.web import csv_response, error_response, query_args
 
 
-def get_csv(dr, oids, min_mjd=None, max_mjd=None):
+async def get_csv(dr, oids, min_mjd=None, max_mjd=None):
     dfs = []
     for oid in oids:
-        lc = find_ztf_oid.get_lc(oid, dr, min_mjd=min_mjd, max_mjd=max_mjd)
+        lc = await find_ztf_oid.get_lc(oid, dr, min_mjd=min_mjd, max_mjd=max_mjd)
         if lc is None:
             raise NotFound
-        meta = find_ztf_oid.get_meta(oid, dr)
+        meta = await find_ztf_oid.get_meta(oid, dr)
         oid_df = pd.DataFrame.from_records(lc)
         oid_df["oid"] = oid
         oid_df["filter"] = meta["filter"]
 
         try:
-            ref = ztf_ref.get(oid, dr)
+            ref = await ztf_ref.get(oid, dr)
         except NotFound, CatalogUnavailable:
             oid_df["ref"] = [None] * oid_df.shape[0]
             oid_df["ref_err"] = [None] * oid_df.shape[0]
@@ -41,6 +42,11 @@ def get_csv(dr, oids, min_mjd=None, max_mjd=None):
             oid_df["ref_err"] = ref_err
 
         dfs.append(oid_df)
+    # pandas concat/sort is CPU-bound; keep it off the event loop.
+    return await asyncio.to_thread(_dfs_to_csv, dfs)
+
+
+def _dfs_to_csv(dfs):
     df = pd.concat(dfs, axis="index")
     df.sort_values(by="mjd", inplace=True)
     df = df[["oid", "filter", "mjd", "mag", "magerr", "clrcoeff", "ref", "ref_err"]]
@@ -93,7 +99,10 @@ def response_antares_csv(locus_id: str):
 
 # Keep last: `oid` is an int, so this also matches the catalog routes above.
 @app.server.api_route("/{dr}/csv/{oid}")
-def response_csv(dr: str, oid: int, request: Request):
+async def response_csv(dr: str, oid: int, request: Request):
+    """Async because `get_csv` calls `find_ztf_oid.get_lc`, which now awaits; the FastAPI
+    threadpool that plain-`def` routes get doesn't apply once a route itself needs to await.
+    """
     args = query_args(request)
 
     try:
@@ -117,7 +126,7 @@ def response_csv(dr: str, oid: int, request: Request):
             return error_response("max_mjd query parameter must be a float", 400)
 
     try:
-        csv = get_csv(dr, oids, min_mjd=min_mjd, max_mjd=max_mjd)
+        csv = await get_csv(dr, oids, min_mjd=min_mjd, max_mjd=max_mjd)
     except NotFound:
         return error_response("", 404)
     return csv_response(csv, filename=f"{oid}.csv")

--- a/ztf_viewer/pages/lc_csv.py
+++ b/ztf_viewer/pages/lc_csv.py
@@ -42,7 +42,6 @@ async def get_csv(dr, oids, min_mjd=None, max_mjd=None):
             oid_df["ref_err"] = ref_err
 
         dfs.append(oid_df)
-    # pandas concat/sort is CPU-bound; keep it off the event loop.
     return await asyncio.to_thread(_dfs_to_csv, dfs)
 
 

--- a/ztf_viewer/pages/login.py
+++ b/ztf_viewer/pages/login.py
@@ -26,9 +26,9 @@ def get_layout(*args, **kwargs):
 
 
 @callback(Output("login-status", "children"), [Input("token", "n_submit")], [State("token", "value")])
-def do_login(n_submit, token):
+async def do_login(n_submit, token):
     try:
-        username = akb.username(token)
+        username = await akb.username(token)
     except UnAuthorized:
         return "Login failed: wrong token"
     if token:

--- a/ztf_viewer/pages/search.py
+++ b/ztf_viewer/pages/search.py
@@ -14,12 +14,12 @@ COLUMNS = {
 }
 
 
-def get_layout(coordinates, radius_arcsec, dr):
+async def get_layout(coordinates, radius_arcsec, dr):
     ra = coordinates.ra.to_value("deg")
     dec = coordinates.dec.to_value("deg")
     cone_str = f"({ra:.5f} deg, {dec:.5f} deg), r = {radius_arcsec:.1f}″"
     try:
-        j = find_ztf_circle.find(ra, dec, radius_arcsec, dr)
+        j = await find_ztf_circle.find(ra, dec, radius_arcsec, dr)
     except NotFound:
         return html.Div(
             [

--- a/ztf_viewer/pages/tags.py
+++ b/ztf_viewer/pages/tags.py
@@ -85,10 +85,10 @@ def get_layout(*args, **kwargs):
         Input("tags-list-reset", "n_clicks"),
     ],
 )
-def show_tags(*_):
-    if not akb.is_token_valid():
+async def show_tags(*_):
+    if not await akb.is_token_valid():
         raise PreventUpdate
-    tags = akb.get_tags()
+    tags = await akb.get_tags()
     children = [
         html.Div(
             [
@@ -114,7 +114,7 @@ def show_tags(*_):
             [
                 dcc.Input(
                     id=dict(type="new-tag-priority-input", index=0),
-                    value=max((tag["priority"] for tag in akb.get_tags()), default=-1) + 1,
+                    value=max((tag["priority"] for tag in await akb.get_tags()), default=-1) + 1,
                     type="number",
                     step=1,
                     size=3,
@@ -164,10 +164,10 @@ def are_tags_priorities_unique(priorities):
         State(dict(type="new-tag-description-input", index=ALL), "value"),
     ],
 )
-def set_save_status(n_clicks, tags, priorities, new_priority, new_name, new_description):
+async def set_save_status(n_clicks, tags, priorities, new_priority, new_name, new_description):
     if not n_clicks:
         raise PreventUpdate
-    if not akb.is_token_valid():
+    if not await akb.is_token_valid():
         return "Error: unauthorised"
     # New-tag inputs are only rendered when logged in, so the pattern-matching State lists are empty otherwise.
     new_priority = new_priority[0] if new_priority else None
@@ -180,5 +180,5 @@ def set_save_status(n_clicks, tags, priorities, new_priority, new_name, new_desc
         tags.append(dict(name=new_name, priority=new_priority, description=new_description))
     if not are_tags_priorities_unique([tag["priority"] for tag in tags]):
         return "Error: tag priorities should be unique"
-    akb.post_tags(tags)
+    await akb.post_tags(tags)
     return "saved"

--- a/ztf_viewer/pages/viewer.py
+++ b/ztf_viewer/pages/viewer.py
@@ -1,6 +1,7 @@
+import asyncio
 import pathlib
 from collections import OrderedDict, defaultdict
-from functools import lru_cache, partial
+from functools import partial
 from itertools import chain
 from typing import Any
 from urllib.parse import parse_qs, urlencode, urljoin, urlparse
@@ -126,9 +127,9 @@ def parse_search(search_query: str) -> dict[str, Any]:
     return result
 
 
-def set_div_for_aladin(oid, version):
-    ra, dec = find_ztf_oid.get_coord(oid, version)
-    coord = find_ztf_oid.get_coord_string(oid, version)
+async def set_div_for_aladin(oid, version):
+    ra, dec = await find_ztf_oid.get_coord(oid, version)
+    coord = await find_ztf_oid.get_coord_string(oid, version)
     style = {"display": "none"}
     return html.Div(
         [
@@ -141,11 +142,12 @@ def set_div_for_aladin(oid, version):
     )
 
 
-@lru_cache(maxsize=128)
-def get_layout(pathname, search):
+# Not `@lru_cache`: it caches a coroutine object by identity, and a coroutine can only be
+# awaited once. The `@cache()`-decorated calls this makes are already cached below it.
+async def get_layout(pathname, search):
     dr, oid, is_short = parse_pathname(pathname)
     try:
-        find_ztf_oid.find(oid, dr)
+        await find_ztf_oid.find(oid, dr)
     except NotFound:
         return html.Div(
             [
@@ -154,8 +156,8 @@ def get_layout(pathname, search):
             ]
         )
     other_drs = [other_dr for other_dr in available_drs if other_dr != dr]
-    ra, dec = find_ztf_oid.get_coord(oid, dr)
-    coord = find_ztf_oid.get_coord_string(oid, dr)
+    ra, dec = await find_ztf_oid.get_coord(oid, dr)
+    coord = await find_ztf_oid.get_coord_string(oid, dr)
 
     short_min_mjd, short_max_mjd = min_max_mjd_short(dr)
     min_mjd, max_mjd = (short_min_mjd, short_max_mjd) if is_short else (-INF, INF)
@@ -164,9 +166,14 @@ def get_layout(pathname, search):
     max_mjd = search_query_parsed.get("max_mjd", max_mjd)
 
     try:
-        features = light_curve_features(oid, dr, version="latest", min_mjd=min_mjd, max_mjd=max_mjd)
+        features = await light_curve_features(oid, dr, version="latest", min_mjd=min_mjd, max_mjd=max_mjd)
     except NotFound:
         features = None
+
+    akb_info = await set_akb_info(0, oid)
+    list_models = await model_fit.get_list_models()
+    feature_versions = sorted(await light_curve_features.versions())
+    aladin_div = await set_div_for_aladin(oid, dr)
     layout = html.Div(
         [
             html.Div("", id="placeholder", style={"display": "none"}),
@@ -174,7 +181,7 @@ def get_layout(pathname, search):
             html.Div(f"{dr}", id="dr", style={"display": "none"}),
             html.H2(id="title"),
             html.Div(id="akb-neighbours"),
-            html.Div(set_akb_info(0, oid), id="akb-info"),
+            html.Div(akb_info, id="akb-info"),
             html.Div(
                 [
                     html.Div(
@@ -320,7 +327,7 @@ def get_layout(pathname, search):
                                                 [
                                                     html.H3("Supernova model"),
                                                     dcc.Dropdown(
-                                                        model_fit.get_list_models().data["models"],
+                                                        list_models.data["models"],
                                                         id="models-fit-dd",
                                                         style={"width": "200px", "marginLeft": "20px"},
                                                     ),
@@ -448,7 +455,7 @@ def get_layout(pathname, search):
                     html.Div(
                         [
                             html.H2(html.A("Aladin", href=f"//aladin.u-strasbg.fr/AladinLite/?target={coord}")),
-                            set_div_for_aladin(oid, dr),
+                            aladin_div,
                             html.Div(
                                 id="aladin-lite-div",
                                 style={"width": "450px", "height": "450px"},
@@ -771,7 +778,7 @@ def get_layout(pathname, search):
                                 placeholder="light-curve-feature version",
                                 options=[
                                     dict(value=v, label=f"{v}{LIGHT_CURVE_VALUE_VERSION_ANNOTATION[v]}")
-                                    for v in sorted(light_curve_features.versions())
+                                    for v in feature_versions
                                 ],
                                 value="latest",
                                 multi=False,
@@ -818,8 +825,8 @@ def get_layout(pathname, search):
         Input("dr", "children"),
     ],
 )
-def set_title(oid, dr):
-    ra, dec = find_ztf_oid.get_coord(oid, dr)
+async def set_title(oid, dr):
+    ra, dec = await find_ztf_oid.get_coord(oid, dr)
     try:
         snad_name = snad_catalog.search_region(ra, dec, radius_arcsec=3)
         snad_name = f"{snad_name} — "
@@ -883,7 +890,7 @@ def show_error_message(message_fit, message_curve, list_models, old_header):
         Input("models-fit-dd", "value"),
     ],
 )
-def fit_lc(
+async def fit_lc(
     cur_oid,
     dr,
     different_filter,
@@ -907,9 +914,10 @@ def fit_lc(
     )
 
     other_oids = neighbour_oids(different_filter, different_field)
-    coord = find_ztf_oid.get_sky_coord(cur_oid, dr)
+    coord = await find_ztf_oid.get_sky_coord(cur_oid, dr)
     try:
-        ebv = csfd.ebv(coord)
+        # csfd is still a sync `requests` client (out of scope here); offload to a thread.
+        ebv = await asyncio.to_thread(csfd.ebv, coord)
     except CatalogUnavailable:
         ebv = None
     items = []
@@ -921,7 +929,7 @@ def fit_lc(
         if ebv is None:
             return [], {}, "Extinction data unavailable, cannot fit model"
         oids = (cur_oid,) + tuple(sorted(other_oids))
-        response = model_fit.fit(
+        response = await model_fit.fit(
             oids,
             dr,
             fit_model=name_model,
@@ -956,12 +964,12 @@ def fit_lc(
         Input("different_field_neighbours", "children"),
     ],
 )
-def set_akb_neighbours(different_filter, different_field):
-    if not akb.is_token_valid():
+async def set_akb_neighbours(different_filter, different_field):
+    if not await akb.is_token_valid():
         return None
 
     oids = neighbour_oids(different_filter, different_field)
-    labeled_oids = [oid for oid in oids if akb.oid_exists(oid)]
+    labeled_oids = [oid for oid in oids if await akb.oid_exists(oid)]
     if len(labeled_oids) == 0:
         return None
 
@@ -972,13 +980,13 @@ def set_akb_neighbours(different_filter, different_field):
     )
 
 
-def set_akb_info(_, oid):
-    if not akb.is_token_valid():
+async def set_akb_info(_, oid):
+    if not await akb.is_token_valid():
         return None
 
-    available_tags = akb.get_tags()
+    available_tags = await akb.get_tags()
     try:
-        akb_item = akb.get_by_oid(oid)
+        akb_item = await akb.get_by_oid(oid)
         tags_enabled = frozenset(akb_item["tags"])
         description = akb_item["description"]
     except NotFound:
@@ -1040,7 +1048,7 @@ def set_akb_info(_, oid):
         ),
     ]
 
-    log = akb.get_object_log(oid)
+    log = await akb.get_object_log(oid)
     for entry in log:
         entry["tags_str"] = ", ".join(chain(*entry["tags"]))
         entry["changed_by_str"] = ", ".join(entry["changed_by"])
@@ -1090,14 +1098,14 @@ callback(
         State("akb-description", "value"),
     ],
 )
-def update_akb(n_clicks, oid, tags, description):
+async def update_akb(n_clicks, oid, tags, description):
     if n_clicks == 0 or n_clicks is None or tags is None:
         raise PreventUpdate
     if description is None:
         description = ""
     tags = list(chain.from_iterable(tags))
     try:
-        akb.post_object(oid, tags, description)
+        await akb.post_object(oid, tags, description)
         return "Submitted"
     except RuntimeError:
         return "Error occurred"
@@ -1159,28 +1167,31 @@ def show_fold_period_layout(light_curve_type, old_style):
     [Input("oid", "children"), Input("dr", "children"), Input("additional-light-curves", "value")],
     [State("additional-light-curves", "options")],
 )
-def update_additional_light_curve_options(oid, dr, values, old_options):
+async def update_additional_light_curve_options(oid, dr, values, old_options):
     if len(values) == 0:
         raise PreventUpdate
     options_dict = {option["value"]: option for option in old_options}
     for value in values:
         if value == "antares":
-            option = get_antares_lc_option(oid, dr, old=options_dict[value])
+            option = await get_antares_lc_option(oid, dr, old=options_dict[value])
         elif value == "gaia":
-            option = get_gaia_lc_option(oid, dr, old=options_dict[value])
+            option = await get_gaia_lc_option(oid, dr, old=options_dict[value])
         elif value == "panstarrs":
-            option = get_panstarrs_lc_option(oid, dr, old=options_dict[value])
+            option = await get_panstarrs_lc_option(oid, dr, old=options_dict[value])
         else:
             raise ValueError(f'additional light curve value "{value}" unknown')
         options_dict[value] = option
     return list(options_dict.values())
 
 
-def get_antares_lc_option(oid, dr, old):
+async def get_antares_lc_option(oid, dr, old):
     option = old.copy()
-    ra, dec = find_ztf_oid.get_coord(oid, dr)
+    ra, dec = await find_ztf_oid.get_coord(oid, dr)
     try:
-        row = ANTARES_QUERY.find_closest(ra, dec, radius_arcsec=ADDITIONAL_LC_SEARCH_RADIUS_ARCSEC)
+        # `find_closest` is still sync conesearch code (out of scope here); offload to a thread.
+        row = await asyncio.to_thread(
+            ANTARES_QUERY.find_closest, ra, dec, radius_arcsec=ADDITIONAL_LC_SEARCH_RADIUS_ARCSEC
+        )
     except NotFound:
         option["label"] = f"Antares object (not found in {ADDITIONAL_LC_SEARCH_RADIUS_ARCSEC}″)"
         option["disabled"] = True
@@ -1199,11 +1210,17 @@ def get_antares_lc_option(oid, dr, old):
     return option
 
 
-def get_gaia_lc_option(oid, dr, old):
+async def get_gaia_lc_option(oid, dr, old):
     option = old.copy()
-    ra, dec = find_ztf_oid.get_coord(oid, dr)
+    ra, dec = await find_ztf_oid.get_coord(oid, dr)
     try:
-        row = GAIA_DR3.find_closest(ra, dec, radius_arcsec=ADDITIONAL_LC_SEARCH_RADIUS_ARCSEC, has_light_curve=True)
+        row = await asyncio.to_thread(
+            GAIA_DR3.find_closest,
+            ra,
+            dec,
+            radius_arcsec=ADDITIONAL_LC_SEARCH_RADIUS_ARCSEC,
+            has_light_curve=True,
+        )
     except NotFound:
         option["label"] = f"Gaia object (not found in {ADDITIONAL_LC_SEARCH_RADIUS_ARCSEC}″)"
         option["disabled"] = True
@@ -1218,8 +1235,13 @@ def get_gaia_lc_option(oid, dr, old):
         option["disabled"] = False
     # Check if we can load data
     try:
-        _ = GAIA_DR3.closest_light_curve(
-            ra, dec, radius_arcsec=ADDITIONAL_LC_SEARCH_RADIUS_ARCSEC, fail_on_empty=False, fail_on_unavailable=True
+        _ = await asyncio.to_thread(
+            GAIA_DR3.closest_light_curve,
+            ra,
+            dec,
+            radius_arcsec=ADDITIONAL_LC_SEARCH_RADIUS_ARCSEC,
+            fail_on_empty=False,
+            fail_on_unavailable=True,
         )
     except CatalogUnavailable:
         option["label"] = "Gaia DataLink is unavailable now"
@@ -1227,11 +1249,13 @@ def get_gaia_lc_option(oid, dr, old):
     return option
 
 
-def get_panstarrs_lc_option(oid, dr, old):
+async def get_panstarrs_lc_option(oid, dr, old):
     option = old.copy()
-    ra, dec = find_ztf_oid.get_coord(oid, dr)
+    ra, dec = await find_ztf_oid.get_coord(oid, dr)
     try:
-        row = PANSTARRS_DR2_QUERY.find_closest(ra, dec, radius_arcsec=ADDITIONAL_LC_SEARCH_RADIUS_ARCSEC)
+        row = await asyncio.to_thread(
+            PANSTARRS_DR2_QUERY.find_closest, ra, dec, radius_arcsec=ADDITIONAL_LC_SEARCH_RADIUS_ARCSEC
+        )
     except NotFound:
         option["label"] = f"Pan-STARRS object (not found in {ADDITIONAL_LC_SEARCH_RADIUS_ARCSEC}″)"
         option["disabled"] = True
@@ -1274,12 +1298,12 @@ def show_ref_mag_layout(brightness_type, name_model, old_style):
     Input("different_filter_neighbours", "children"),
     Input("different_field_neighbours", "children"),
 )
-def show_ref_mag_or_magerr(oid, dr, different_filter, different_field):
+async def show_ref_mag_or_magerr(oid, dr, different_filter, different_field):
     oids = sorted(neighbour_oids(different_filter, different_field) | {oid}, key=int)
 
     filters = defaultdict(list)
     for objectid in oids:
-        fltr = find_ztf_oid.get_meta(objectid, dr)["filter"]
+        fltr = (await find_ztf_oid.get_meta(objectid, dr))["filter"]
         filters[fltr].append(objectid)
 
     layout = []
@@ -1351,13 +1375,13 @@ def show_ref_mag_or_magerr(oid, dr, different_filter, different_field):
     State(dict(type="ref-mag-input", index=ALL), "id"),
     State(dict(type="ref-mag-input", index=ALL), "value"),
 )
-def set_ref_mag_magerr(dr, _n_clicks, link_id, all_mag_ids, all_mag_values):
+async def set_ref_mag_magerr(dr, _n_clicks, link_id, all_mag_ids, all_mag_values):
     objectid = link_id["index"]
     existing = {i["index"]: v for i, v in zip(all_mag_ids, all_mag_values) if v is not None}
     if objectid in existing:
         raise PreventUpdate
     try:
-        ref = ztf_ref.get(objectid, dr)
+        ref = await ztf_ref.get(objectid, dr)
     except NotFound, CatalogUnavailable:
         raise PreventUpdate
     return (
@@ -1377,17 +1401,18 @@ def set_ref_mag_magerr(dr, _n_clicks, link_id, all_mag_ids, all_mag_values):
         Input(dict(type="search-radius", index=ALL), "value"),
     ],
 )
-def get_summary(oid, dr, different_filter, different_field, radius_ids, radius_values):
+async def get_summary(oid, dr, different_filter, different_field, radius_ids, radius_values):
     if None in radius_values:
         raise PreventUpdate
     radii = {id["index"]: float(value) for id, value in zip(radius_ids, radius_values)}
-    ra, dec = find_ztf_oid.get_coord(oid, dr)
-    coord = find_ztf_oid.get_sky_coord(oid, dr)
+    ra, dec = await find_ztf_oid.get_coord(oid, dr)
+    coord = await find_ztf_oid.get_sky_coord(oid, dr)
 
     elements = OrderedDict()
     for catalog, query in catalog_query_objects().items():
         try:
-            table = query.find(ra, dec, radii[catalog])
+            # `query.find` is still sync conesearch code (out of scope here); offload to a thread.
+            table = await asyncio.to_thread(query.find, ra, dec, radii[catalog])
         except NotFound, CatalogUnavailable, KeyError:
             continue
         idx = np.argmin(table["separation"])
@@ -1429,7 +1454,7 @@ def get_summary(oid, dr, different_filter, different_field, radius_ids, radius_v
                 )
             )
     try:
-        features = light_curve_features(oid, dr, version="latest")
+        features = await light_curve_features(oid, dr, version="latest")
         period = features.get("period_0_magn", features.get("period_0"))
         period_s2n = features.get("period_s_to_n_0_magn", features.get("period_s_to_n_0"))
         el = elements.setdefault("Period, days", [])
@@ -1454,7 +1479,7 @@ def get_summary(oid, dr, different_filter, different_field, radius_ids, radius_v
     ml_classifications = []
     for catalog, query in catalog_query_objects().items():
         try:
-            table = query.find(ra, dec, radii[catalog])
+            table = await asyncio.to_thread(query.find, ra, dec, radii[catalog])
         except NotFound, CatalogUnavailable, KeyError:
             continue
         if len(table) == 0:
@@ -1494,7 +1519,7 @@ def get_summary(oid, dr, different_filter, different_field, radius_ids, radius_v
             pass
 
     other_oids = neighbour_oids(different_filter, different_field)
-    lcs = get_plot_data(oid, dr, other_oids=other_oids)
+    lcs = await get_plot_data(oid, dr, other_oids=other_oids)
     mags = {}
     for obs in chain.from_iterable(lcs.values()):
         mags.setdefault(obs["filter"], []).append(obs["mag"])
@@ -1506,15 +1531,17 @@ def get_summary(oid, dr, different_filter, different_field, radius_ids, radius_v
         elements["Average mag (including neighbourhood)"].append(f'(zg–zr) {mean_mag["zg"] - mean_mag["zr"]: .2f}')
 
     try:
-        elements["Extinction"] = [f"CSFD E(B-V) = {csfd.ebv(coord):.2f}"]
+        # csfd/bayestar are still sync `requests` clients (out of scope here); offload to a thread.
+        ebv = await asyncio.to_thread(csfd.ebv, coord)
+        elements["Extinction"] = [f"CSFD E(B-V) = {ebv:.2f}"]
     except CatalogUnavailable:
         pass
     try:
-        table = get_catalog_query("Gaia EDR3 Distances").find(ra, dec, 1)
+        table = await asyncio.to_thread(get_catalog_query("Gaia EDR3 Distances").find, ra, dec, 1)
         row = QTable(table[np.argmin(table["separation"])])
 
         distance = row["__distance"]
-        af = bayestar(SkyCoord(coord, distance=distance))
+        af = await asyncio.to_thread(bayestar, SkyCoord(coord, distance=distance))
         elements["Extinction"].append(
             f'Bayestar & Gaia EDR distance Ag = {af["zg"]:.2f} Ar = {af["zr"]:.2f} Ai = {af["zi"]:.2f}'
         )
@@ -1529,8 +1556,8 @@ def get_summary(oid, dr, different_filter, different_field, radius_ids, radius_v
     ]
 
     elements["Coordinates"] = [
-        f"Eq {find_ztf_oid.get_coord_string(oid, dr, frame=None)}",
-        f'Gal {find_ztf_oid.get_coord_string(oid, dr, frame="galactic")}',
+        f"Eq {await find_ztf_oid.get_coord_string(oid, dr, frame=None)}",
+        f'Gal {await find_ztf_oid.get_coord_string(oid, dr, frame="galactic")}',
     ]
 
     div = html.Div(
@@ -1546,12 +1573,12 @@ def get_summary(oid, dr, different_filter, different_field, radius_ids, radius_v
     Output("metadata", "children"),
     [Input("oid", "children"), Input("dr", "children")],
 )
-def get_metadata(oid, dr):
-    meta = find_ztf_oid.get_meta(oid, dr).copy()
-    meta["coord_string"] = find_ztf_oid.get_coord_string(oid, dr)
+async def get_metadata(oid, dr):
+    meta = (await find_ztf_oid.get_meta(oid, dr)).copy()
+    meta["coord_string"] = await find_ztf_oid.get_coord_string(oid, dr)
 
     try:
-        ref = ztf_ref.get(oid, dr)
+        ref = await ztf_ref.get(oid, dr)
     except NotFound, CatalogUnavailable:
         pass
     else:
@@ -1604,7 +1631,7 @@ def neighbour_oids(different_filter, different_field) -> frozenset:
         Input("results-fit-hidden", "data"),
     ],
 )
-def set_figure(
+async def set_figure(
     cur_oid,
     dr,
     different_filter,
@@ -1666,7 +1693,7 @@ def set_figure(
 
     other_oids = neighbour_oids(different_filter, different_field)
     if lc_type == "full":
-        lcs = get_plot_data(
+        lcs = await get_plot_data(
             cur_oid,
             dr,
             other_oids=other_oids,
@@ -1678,7 +1705,7 @@ def set_figure(
         )
     elif lc_type == "folded":
         offset = -(phase0 or 0.0) * period
-        lcs = get_folded_plot_data(
+        lcs = await get_folded_plot_data(
             cur_oid,
             dr,
             period=period,
@@ -1754,7 +1781,7 @@ def set_figure(
     message_fit = ""
     if fit_params:
         oids = (cur_oid,) + tuple(sorted(other_oids))
-        response = model_fit.get_curve(
+        response = await model_fit.get_curve(
             oids,
             dr,
             bright=bright,
@@ -1882,16 +1909,17 @@ def set_csv_link(oid, dr, different_filter, different_field, min_mjd, max_mjd):
     return url
 
 
-def find_neighbours(radius, center_oid, dr, different):
+async def find_neighbours(radius, center_oid, dr, different):
     if radius is None:
         return html.P("No radius is specified")
     if float(radius) <= 0:
         return html.P("Radius should be positive")
-    ra, dec = find_ztf_oid.get_coord(center_oid, dr)
+    ra, dec = await find_ztf_oid.get_coord(center_oid, dr)
     kwargs = dict(ra=ra, dec=dec, radius_arcsec=radius, dr=dr)
-    fltr = find_ztf_oid.get_meta(center_oid, dr)["filter"]
-    fieldid = find_ztf_oid.get_meta(center_oid, dr)["fieldid"]
-    j = find_ztf_circle.find(**kwargs)
+    meta = await find_ztf_oid.get_meta(center_oid, dr)
+    fltr = meta["filter"]
+    fieldid = meta["fieldid"]
+    j = await find_ztf_circle.find(**kwargs)
     if different == "filter":
         j = {
             oid: value
@@ -1960,17 +1988,17 @@ app.clientside_callback(
 
 
 @callback(Output("fits-to-show", "children"), [Input("graph", "clickData")], [State("dr", "children")])
-def load_fits_for_graph_clicked(data, dr):
+async def load_fits_for_graph_clicked(data, dr):
     if data is None:
         raise PreventUpdate
     if not (points := data.get("points")):
         raise PreventUpdate
     point = points[0]
     mjd, oid, fieldid, rcid, fltr, *_ = point["customdata"]
-    ra, dec = find_ztf_oid.get_coord(oid, dr)
-    coord = find_ztf_oid.get_sky_coord(oid, dr)
+    ra, dec = await find_ztf_oid.get_coord(oid, dr)
+    coord = await find_ztf_oid.get_sky_coord(oid, dr)
     date = DateWithFrac.from_hmjd(mjd, coord=coord)
-    correct_date(date)
+    await correct_date(date)
     fits_url = urljoin(ZTF_FITS_PROXY_URL, date.sciimg_path(fieldid=fieldid, rcid=rcid, filter=fltr))
     cutout_query = urlencode(dict(size="449pix", gzip="false", center=f"{ra},{dec}"))
     fits_cutout_url = f"{fits_url}?{cutout_query}"
@@ -1989,17 +2017,20 @@ def load_fits_for_graph_clicked(data, dr):
 
 
 @callback(Output("skybot", "children"), [Input("graph", "clickData")], [State("dr", "children")])
-def update_skybot_for_graph_clicked(data, dr):
+async def update_skybot_for_graph_clicked(data, dr):
     if data is None:
         raise PreventUpdate
     if not (points := data.get("points")):
         raise PreventUpdate
     point = points[0]
     mjd, oid, *_ = point["customdata"]
-    coord = find_ztf_oid.get_sky_coord(oid, dr)
+    coord = await find_ztf_oid.get_sky_coord(oid, dr)
     observatory_mjd = hmjd_to_earth(mjd, coord).mjd
     try:
-        table = SKYBOT_QUERY.find(coord.ra.deg, coord.dec.deg, observatory_mjd, radius_arcsec=15.0)
+        # SKYBOT_QUERY is still a sync astroquery client (out of scope here); offload to a thread.
+        table = await asyncio.to_thread(
+            SKYBOT_QUERY.find, coord.ra.deg, coord.dec.deg, observatory_mjd, radius_arcsec=15.0
+        )
     except NotFound:
         return html.Div("No minor planets found in 15″")
 
@@ -2016,8 +2047,8 @@ def convert_astro_colibri_search_radius_to_arcsec(radius_deg):
     return int(np.round(float(radius_deg) * 3600))
 
 
-def set_table(radius, oid, dr, catalog):
-    ra, dec = find_ztf_oid.get_coord(oid, dr)
+async def set_table(radius, oid, dr, catalog):
+    ra, dec = await find_ztf_oid.get_coord(oid, dr)
     if radius is None:
         return html.P("No radius is specified")
     radius = float(radius)
@@ -2025,7 +2056,8 @@ def set_table(radius, oid, dr, catalog):
         return html.P("Radius should be positive")
     query = get_catalog_query(catalog)
     try:
-        table = query.find(ra, dec, radius)
+        # `query.find` is still sync conesearch code (out of scope here); offload to a thread.
+        table = await asyncio.to_thread(query.find, ra, dec, radius)
     except NotFound:
         return html.P(
             f'No {catalog.replace("-", " ")} objects within {format_sep(radius, 0, 0)} from {ra:.5f}, {dec:.5f}'
@@ -2067,8 +2099,8 @@ set_tables()
         State("dr", "children"),
     ],
 )
-def set_vizier_url(radius, oid, dr):
-    ra, dec = find_ztf_oid.get_coord(oid, dr)
+async def set_vizier_url(radius, oid, dr):
+    ra, dec = await find_ztf_oid.get_coord(oid, dr)
     if radius is None:
         radius = 0
     return find_vizier.get_search_url(ra, dec, radius)
@@ -2083,7 +2115,7 @@ def set_vizier_url(radius, oid, dr):
         State("dr", "children"),
     ],
 )
-def set_vizier_list(n_clicks, radius, oid, dr):
+async def set_vizier_list(n_clicks, radius, oid, dr):
     if n_clicks == 0:
         return ""
 
@@ -2091,9 +2123,10 @@ def set_vizier_list(n_clicks, radius, oid, dr):
         return html.P("No radius is specified")
 
     radius = float(radius)
-    ra, dec = find_ztf_oid.get_coord(oid, dr)
+    ra, dec = await find_ztf_oid.get_coord(oid, dr)
 
-    table_list = find_vizier.find(ra, dec, radius)
+    # `find_vizier.find` is still a sync astroquery client (out of scope here); offload to a thread.
+    table_list = await asyncio.to_thread(find_vizier.find, ra, dec, radius)
     if len(table_list) == 0:
         return html.P(f"No vizier catalogs found within {format_sep(radius, 0, 0)} from {ra:.5f}, {dec:.5f}")
 
@@ -2101,7 +2134,7 @@ def set_vizier_list(n_clicks, radius, oid, dr):
     lengths = []
     for catalog, table in zip(table_list.keys(), table_list.values()):
         try:
-            description = vizier_catalog_details.description(catalog)
+            description = await asyncio.to_thread(vizier_catalog_details.description, catalog)
         except NotFound:
             description = catalog
         n = len(table)
@@ -2139,11 +2172,11 @@ def set_vizier_list(n_clicks, radius, oid, dr):
         Input("max-mjd", "value"),
     ],
 )
-def set_features_list(oid, dr, version, min_mjd, max_mjd):
+async def set_features_list(oid, dr, version, min_mjd, max_mjd):
     if min_mjd is not None and max_mjd is not None and min_mjd >= max_mjd:
         raise PreventUpdate
     try:
-        features = light_curve_features(oid, dr, version=version, min_mjd=min_mjd, max_mjd=max_mjd)
+        features = await light_curve_features(oid, dr, version=version, min_mjd=min_mjd, max_mjd=max_mjd)
     except NotFound:
         return "Not available"
     items = [f"**{k}**: {v:.4g}" for k, v in sorted(features.items(), key=lambda item: item[0])]
@@ -2164,7 +2197,7 @@ def set_features_list(oid, dr, version, min_mjd, max_mjd):
         Input("max-mjd", "value"),
     ],
 )
-def set_lc_table(oid, dr, min_mjd, max_mjd):
+async def set_lc_table(oid, dr, min_mjd, max_mjd):
     if min_mjd is not None and max_mjd is not None and min_mjd >= max_mjd:
         raise PreventUpdate
-    return find_ztf_oid.get_lc(oid, dr, min_mjd=min_mjd, max_mjd=max_mjd)
+    return await find_ztf_oid.get_lc(oid, dr, min_mjd=min_mjd, max_mjd=max_mjd)

--- a/ztf_viewer/pages/viewer.py
+++ b/ztf_viewer/pages/viewer.py
@@ -916,7 +916,6 @@ async def fit_lc(
     other_oids = neighbour_oids(different_filter, different_field)
     coord = await find_ztf_oid.get_sky_coord(cur_oid, dr)
     try:
-        # csfd is still a sync `requests` client (out of scope here); offload to a thread.
         ebv = await asyncio.to_thread(csfd.ebv, coord)
     except CatalogUnavailable:
         ebv = None
@@ -1188,7 +1187,6 @@ async def get_antares_lc_option(oid, dr, old):
     option = old.copy()
     ra, dec = await find_ztf_oid.get_coord(oid, dr)
     try:
-        # `find_closest` is still sync conesearch code (out of scope here); offload to a thread.
         row = await asyncio.to_thread(
             ANTARES_QUERY.find_closest, ra, dec, radius_arcsec=ADDITIONAL_LC_SEARCH_RADIUS_ARCSEC
         )
@@ -1411,7 +1409,6 @@ async def get_summary(oid, dr, different_filter, different_field, radius_ids, ra
     elements = OrderedDict()
     for catalog, query in catalog_query_objects().items():
         try:
-            # `query.find` is still sync conesearch code (out of scope here); offload to a thread.
             table = await asyncio.to_thread(query.find, ra, dec, radii[catalog])
         except NotFound, CatalogUnavailable, KeyError:
             continue
@@ -1531,7 +1528,6 @@ async def get_summary(oid, dr, different_filter, different_field, radius_ids, ra
         elements["Average mag (including neighbourhood)"].append(f'(zg–zr) {mean_mag["zg"] - mean_mag["zr"]: .2f}')
 
     try:
-        # csfd/bayestar are still sync `requests` clients (out of scope here); offload to a thread.
         ebv = await asyncio.to_thread(csfd.ebv, coord)
         elements["Extinction"] = [f"CSFD E(B-V) = {ebv:.2f}"]
     except CatalogUnavailable:
@@ -2027,7 +2023,6 @@ async def update_skybot_for_graph_clicked(data, dr):
     coord = await find_ztf_oid.get_sky_coord(oid, dr)
     observatory_mjd = hmjd_to_earth(mjd, coord).mjd
     try:
-        # SKYBOT_QUERY is still a sync astroquery client (out of scope here); offload to a thread.
         table = await asyncio.to_thread(
             SKYBOT_QUERY.find, coord.ra.deg, coord.dec.deg, observatory_mjd, radius_arcsec=15.0
         )
@@ -2056,7 +2051,6 @@ async def set_table(radius, oid, dr, catalog):
         return html.P("Radius should be positive")
     query = get_catalog_query(catalog)
     try:
-        # `query.find` is still sync conesearch code (out of scope here); offload to a thread.
         table = await asyncio.to_thread(query.find, ra, dec, radius)
     except NotFound:
         return html.P(
@@ -2125,7 +2119,6 @@ async def set_vizier_list(n_clicks, radius, oid, dr):
     radius = float(radius)
     ra, dec = await find_ztf_oid.get_coord(oid, dr)
 
-    # `find_vizier.find` is still a sync astroquery client (out of scope here); offload to a thread.
     table_list = await asyncio.to_thread(find_vizier.find, ra, dec, radius)
     if len(table_list) == 0:
         return html.P(f"No vizier catalogs found within {format_sep(radius, 0, 0)} from {ra:.5f}, {dec:.5f}")


### PR DESCRIPTION
## Scope

Converts the first-party JSON/HTTP services to `async def` per the plan's `aio-snad-apis` PR:

- `ztf_viewer/catalogs/ztf_dr.py` — `FindZTFOID.find`, `FindZTFCircle.find`, and the
  `get_lc`/`get_meta`/`get_coord`/`get_sky_coord`/`get_coord_string` accessors.
- `ztf_viewer/lc_features.py` — `versions`, `__call__`.
- `ztf_viewer/model_fit.py` — `fit`, `get_curve`, `get_list_models`, `post_request`/`get_request`;
  also drops the bare `requests.post`/`get` and `print()` error reporting for `httpx` + `logging`.
- `ztf_viewer/akb.py` — all of it, including `whoami`/`_is_token_valid`, which move off
  `cachetools.cached` onto the shared `@cache()`.
- `ztf_viewer/catalogs/ztf_ref.py` — fetches FITS bytes with `httpx`, parses from an in-memory
  buffer on a thread instead of letting `astropy.io.fits.open` do its own blocking URL fetch.
- `ztf_viewer/date_with_frac.py` — `_fracs`/`correct_date`.

Every `requests.RequestException` handler in the converted code is now `httpx.HTTPError` (or the
narrower `httpx.HTTPStatusError`/`httpx.RequestError` pair in `ztf_ref.py`); every outbound call
uses the shared `ztf_viewer.http.get_client()` and the per-endpoint `config.TIMEOUT_*` constant,
not the previous no-timeout-means-forever `requests` calls. `ztf_viewer/cache/` is untouched —
every `@cache()` line stays exactly as it was.

## The ripple

`find_ztf_oid`/`find_ztf_circle` sit on the critical path of nearly every callback (~44 call
sites, ~30 of them in `ztf_viewer/pages/viewer.py`), so converting their signatures forces most of
the app's callback graph to convert with them in this same PR — per the plan's rule, a callback
only becomes `async def` in the same change that gives it something to await, so this couldn't be
split further without temporarily reinstating the failure mode the shim exists to prevent.
Touches, besides the six modules above: `ztf_viewer/lc_data/ztf_dr.py`,
`ztf_viewer/lc_data/plot_data.py`, `ztf_viewer/pages/{viewer,search,login,tags,akb_table,figure,
lc_csv}.py`, `ztf_viewer/__main__.py`, and the one method noted below in
`ztf_viewer/catalogs/conesearch/_base.py`.

### Callbacks converted and what got offloaded to a thread

Every callback converted here keeps `@callback`/`app.callback` registration unchanged and ends up
with no blocking call left directly in its body. Where a call this PR doesn't convert is still
synchronous — an unconverted conesearch `find`/`find_closest`, an astroquery client
(`Vizier`/`MOCServerClass`/`Skybot`), or the `requests`-based extinction lookups (`csfd`/
`bayestar`) — it's wrapped in a bare `asyncio.to_thread`. The code itself carries no comment
explaining *why* it's a thread and not something else — see "Two kinds of `asyncio.to_thread`
here, and why neither is permanent" below for that, since it's a plan-level staging fact that goes
stale the moment a later PR lands, not a property of this code:

- `__main__.py`: `set_username`, `app_select_by_url`.
- `pages/viewer.py`: `get_layout`, `set_div_for_aladin`, `set_title`, `fit_lc` (`csfd.ebv` →
  thread), `set_akb_neighbours`, `set_akb_info`, `update_akb`,
  `get_antares_lc_option`/`get_gaia_lc_option`/`get_panstarrs_lc_option` (their conesearch
  `find_closest`/`closest_light_curve` calls → thread), `show_ref_mag_or_magerr`,
  `set_ref_mag_magerr`, `get_summary` (both catalog loops' `query.find` and `csfd.ebv`/`bayestar`
  → thread), `get_metadata`, `set_figure`, `find_neighbours`, `load_fits_for_graph_clicked`,
  `update_skybot_for_graph_clicked` (`SKYBOT_QUERY.find` → thread), `set_table` (registered once
  per catalog, `query.find` → thread), `set_vizier_url`, `set_vizier_list` (`find_vizier.find` and
  `vizier_catalog_details.description` → thread), `set_features_list`, `set_lc_table`.
- `pages/{search,login,tags,akb_table}.py`: `search.get_layout`, `login.do_login`,
  `tags.show_tags`/`set_save_status`, `akb_table.set_table_data`.

### Two kinds of `asyncio.to_thread` here, and why neither is permanent

Every `asyncio.to_thread` call added in this PR is interim staging, but for two unrelated
reasons, and it's worth keeping them apart:

1. **Sync third parties, awaiting per-upstream semaphores.** The conesearch `find`/`find_closest`
   calls, `Vizier`/`MOCServerClass`/`Skybot` (astroquery), and the `csfd`/`bayestar` extinction
   lookups are I/O-bound clients that stay synchronous on purpose (not rewritten to async
   clients) and are meant to eventually sit behind a per-upstream bounded semaphore, so one slow
   service can't exhaust the shared thread pool. That semaphore work is not done here — it's a
   later PR's job. A bare `asyncio.to_thread` is the documented interim per the plan's threading
   rule: no code path here builds a thread pool of its own, everything rides the one executor the
   entrypoint already owns.
2. **CPU-heavy work, awaiting the process-pool stack.** `_parse_fits` (`catalogs/ztf_ref.py`) and
   the PNG/Agg path of `figure.py`'s `plot_data`/`plot_folded_data` (see the correction below) are
   genuinely CPU-bound. A thread doesn't parallelize CPU work in CPython — it only keeps the event
   loop responsive while it runs — so a process pool is where this belongs long-term, and the plan
   says so explicitly. It isn't built here because no process pool exists yet and the threading
   rule forbids creating one before there's a single configured home for its size; `asyncio.to_thread`
   is the "still better than blocking the loop" interim until that stack lands.

Neither category is stated in a code comment: it's a fact about where the codebase is in the
plan's staging order, not about what the code does, and it would be stale as soon as either
follow-up PR lands.

## Boundary against the cone-search PR

`_BaseLightCurveQuery.closest_light_curve_by_oid` (`catalogs/conesearch/_base.py`) calls
`find_ztf_oid.get_coord`, so the ripple forces it to convert too — and so do its only callers,
`lc_data/plot_data.py`'s external light curves (`EXTERNAL_LC_DATA`, i.e. the closest Antares/Gaia/
Pan-STARRS light curve). That's the line drawn: `closest_light_curve_by_oid` awaits
`find_ztf_oid.get_coord`, then hands the still-sync `closest_light_curve` to a thread.
`_BaseCatalogQuery.find`, `_BaseCatalogApiQuery._api_query_region`, and
`_BaseNameResolverQuery.resolve_name` are untouched, left for the cone-search PR, along with the
sync `util.timeout()` and its one call site. The line held cleanly — nothing forced expansion past
that one method.

## Route-handler deviation

The six plain HTTP routes are meant to stay sync `def` (FastAPI threadpools them). Three don't:
**`response_csv`** (`pages/lc_csv.py`) and **`response_figure`/`response_figure_folded`**
(`pages/figure.py`) call `get_csv`/`get_plot_data`/`get_folded_plot_data`, which now await
`find_ztf_oid` — sync code can't await, so these three became `async def`. The other three routes
in those same files (Pan-STARRS/Gaia/Antares CSV) don't touch `find_ztf_oid` and stay sync. No
sync-to-async bridge (`asyncio.run`, a private executor) was introduced; the rendering work in the
converted handlers moved to a thread via `asyncio.to_thread` instead.

That rendering work is not uniformly CPU-bound, worth being precise about since it feeds into the
CPU-work category above: `save_fig` (`pages/figure.py:298`) branches on format. The **PNG** path
is real in-process matplotlib/Agg compute — genuinely CPU-bound, a process-pool candidate later.
The **PDF** path uses `FigureCanvasPgf`, which shells out to LaTeX as a **subprocess** — that path
is mostly waiting on a child process, not computing, so a thread already suits it fine and there's
no case for moving it to a process pool. `lc_csv.py`'s `_dfs_to_csv` (the pandas concat/sort) is
real in-process compute too, same category as the figure PNG path.

## Incidental fix — and where it actually lives

Converting these routes to `async def` is what first makes them actually reach the entrypoint's
shared `ThreadPoolExecutor` for real outbound `httpx` traffic (the old sync routes went through
FastAPI's own threadpool instead). That exposed a latent bug: `asyncio.run()`'s teardown shuts
down whatever object is set as a loop's default executor — the object itself, not just that loop's
use of it. `ztf_viewer.__main__._thread_pool` is one process-wide singleton, so the first of
several independent event loops sharing a process to finish (several in-process `TestClient`s in
one pytest run) kills it for every loop that runs afterward. This **never fires in production** —
one worker, one loop, one startup — it only broke the test suite once these routes started
depending on the shared pool for real.

Since it's purely a test-isolation problem, the fix lives in the tests, not in `__main__.py`: a
`reset_shared_thread_pool()` helper in `tests/conftest.py` gives the shared pool a fresh executor,
called from `test_golden_http.py`'s and `test_app.py`'s `client` fixtures right before each builds
its own `TestClient`. `ztf_viewer/__main__.py` is unchanged from what the entrypoint change
shipped — no private `ThreadPoolExecutor` attribute, no defensive branch in the startup path for
something that can't happen there.

This does touch `tests/test_golden_http.py` (its `client` fixture gains one line calling the new
helper) — the one file this PR otherwise leaves alone by design. No assertion or golden value in
that file changes; only how its shared `TestClient` fixture is built, which is what needed fixing.

## Reviewer map

Mechanical (signature + `await` propagation only):
`catalogs/ztf_dr.py`, `lc_features.py`, `akb.py`, `date_with_frac.py`,
`catalogs/conesearch/_base.py`, `lc_data/ztf_dr.py`, `lc_data/plot_data.py`,
`pages/{search,login,tags,akb_table}.py`, `__main__.py` (the routing/username callbacks),
`pages/viewer.py`.

Semantic (behavior or call-shape actually changes):
`model_fit.py` (`requests`→`httpx`, `print`→`logging`), `catalogs/ztf_ref.py` (in-memory FITS
parse), `pages/{figure,lc_csv}.py` (forced-async route handlers).

Tests: `tests/catalogs/test_ztf_ref.py`, `tests/pages/test_tags.py`, `tests/test_async_support.py`
updated for the new async signatures; `tests/test_async_offload.py` added (see below);
`tests/conftest.py`/`tests/test_golden_http.py`/`tests/test_app.py` carry the thread-pool
test-isolation fix, its own commit, described above.

## Testing

```
/Users/hombit/.virtualenvs/web/bin/python -m pytest --basetemp=/tmp/pytest -q
```

Exit code 0, no `FAILED`/`ERROR` lines (this environment doesn't print a final "N passed" line).
`tests/test_callbacks_shim.py` passes unchanged. `pre-commit run --all-files` is clean.

`tests/test_golden_http.py` is **not** byte-for-byte unchanged — see "Incidental fix" above for
why and exactly what changed (one line in its `client` fixture, no assertions or golden values
touched). Flagging this explicitly per that file's own stated acceptance criterion.

Added `tests/test_async_offload.py` for the F15-style guard the plan asks for: for every callback
this PR converts that still reaches a synchronous client, assert it's a coroutine function and
that the remaining blocking call is wrapped in `asyncio.to_thread`. A fully general version isn't
practical — telling "safe to call inline" apart from "blocking I/O" isn't recoverable from the AST
alone — so it's scoped to the specific call sites this PR touches, noted in the test's docstring.

## Contradicting the plan

- `pages/figure.py`'s two figure routes turned out to need the same forced-async treatment as
  `lc_csv.py`'s CSV route (both call `get_plot_data`/`get_folded_plot_data`, which now await
  `find_ztf_oid`), even though the plan's F5 finding and the `aio-snad-apis` section only flagged
  `lc_csv.py`'s route by name.
- `pages/viewer.py`'s `get_layout` was decorated `@lru_cache(maxsize=128)`, not mentioned in the
  plan. `lru_cache` on a coroutine function caches the coroutine object by identity, and a
  coroutine can only be awaited once — every cache hit past the first would have raised, so it
  could not be kept as-is. Dropped the decorator rather than replacing it with something
  async-aware.

  **This is a behaviour change, not just a technical necessity, and worth the reviewer's own
  judgment call rather than a fait accompli buried in the diff.** Before this PR, a repeat
  `GET` for the same `(pathname, search)` skipped rebuilding the whole page-layout tree (up to 128
  entries, process-local, unbounded lifetime); after this PR, every request rebuilds it. The
  network calls inside `get_layout` (`find_ztf_oid`, `light_curve_features`, `model_fit`) are
  still cached via `@cache()`, so this is not a regression back to hitting the DR/features/model
  APIs on every request — what's lost is memoization of Python-side layout assembly (building the
  `html.Div` tree, dropdown option lists, etc.) on top of that. No wall-clock number is attached
  here; if that assembly cost turns out to matter, an async-aware replacement (e.g. an
  `@cache()`-wrapped helper keyed the same way) is a natural follow-up, deliberately not attempted
  in this PR to keep this change to what the ripple forces.
- The thread-pool shutdown-reuse bug described above wasn't anticipated by the plan; it only
  became reachable once real routes started depending on the shared executor.
