### PR TITLE
Measure whether threads help the offloaded CPU work

### DIFF
--- a/misc/gil_bench.py
+++ b/misc/gil_bench.py
@@ -1,0 +1,204 @@
+"""Does a thread actually help the CPU-heavy work the viewer offloads?
+
+Runs each workload as K identical tasks serially, then the same K tasks on K threads,
+and reports the speedup. Two controls bracket the range: `time.sleep` must reach ~K
+(the harness works), pure Python arithmetic must stay ~1 (the GIL is held throughout).
+A workload near the arithmetic control gains nothing from a thread and belongs in a
+process pool; one near the sleep control is already overlapping fine.
+
+The workloads mirror the real call sites rather than reproducing them, so this stays a
+standalone script with no import of the app.
+
+Run: python misc/gil_bench.py
+"""
+
+import io
+import time
+from concurrent.futures import ThreadPoolExecutor
+
+import matplotlib
+import numpy as np
+import pandas as pd
+from astropy.io import fits
+from astropy.table import Table
+
+matplotlib.use("Agg")
+
+import matplotlib.backends.backend_pgf  # noqa: E402
+import matplotlib.figure  # noqa: E402
+
+K = 4
+REPEATS = 5
+
+ABZPMAG_JY = 8.9
+LN10_04 = 0.9210340371976184
+
+
+def _fits_bytes(nrows):
+    table = Table(
+        {
+            "sourceid": np.arange(nrows, dtype=np.int64),
+            "ra": np.random.uniform(0, 360, nrows),
+            "dec": np.random.uniform(-90, 90, nrows),
+            "mag": np.random.uniform(15, 22, nrows),
+            "magerr": np.random.uniform(0.01, 0.5, nrows),
+        }
+    )
+    buf = io.BytesIO()
+    table.write(buf, format="fits")
+    return buf.getvalue()
+
+
+def _lc_frames(n_frames, n_rows):
+    return [
+        pd.DataFrame(
+            {
+                "oid": np.full(n_rows, i, dtype=np.int64),
+                "mjd": np.random.uniform(58000, 60000, n_rows),
+                "mag": np.random.uniform(15, 22, n_rows),
+                "magerr": np.random.uniform(0.01, 0.5, n_rows),
+                "filter": np.random.choice(["zg", "zr", "zi"], n_rows),
+            }
+        )
+        for i in range(n_frames)
+    ]
+
+
+def _series(n_series, n_epochs):
+    return [
+        {
+            "mjd": np.sort(np.random.uniform(58000, 60000, n_epochs)),
+            "mag": np.random.uniform(15, 22, n_epochs),
+            "magerr": np.random.uniform(0.01, 0.5, n_epochs),
+        }
+        for _ in range(n_series)
+    ]
+
+
+FITS_BYTES = _fits_bytes(2_000_000)
+LC_FRAMES = _lc_frames(8, 40_000)
+PNG_SERIES = _series(6, 3_000)
+PDF_SERIES = _series(3, 400)
+LC_OBS = [
+    {"mjd": float(t), "mag": float(m), "magerr": float(e), "oid": 1}
+    for t, m, e in zip(
+        np.random.uniform(58000, 60000, 120_000),
+        np.random.uniform(15, 22, 120_000),
+        np.random.uniform(0.01, 0.5, 120_000),
+    )
+]
+
+
+def w_sleep():
+    """Control: pure wait. Must reach ~K, or the harness is broken."""
+    time.sleep(0.15)
+
+
+def w_arithmetic():
+    """Control: pure Python. Must stay ~1x -- the GIL is never released."""
+    total = 0
+    for i in range(3_000_000):
+        total += i * i
+    return total
+
+
+def w_fits_parse():
+    """catalogs/ztf_ref.py: parse a reference-catalog FITS payload from memory."""
+    with fits.open(io.BytesIO(FITS_BYTES)) as hdul:
+        table = Table(hdul[1].data)
+    return float(table["mag"].sum()) + float(table["ra"].std())
+
+
+def w_pandas_csv():
+    """pages/lc_csv.py: concat the per-OID frames, sort, serialise."""
+    df = pd.concat(LC_FRAMES, ignore_index=True).sort_values(["oid", "mjd"])
+    buf = io.StringIO()
+    df.to_csv(buf, index=False)
+    return len(buf.getvalue())
+
+
+def _figure(series):
+    fig = matplotlib.figure.Figure(dpi=300, figsize=(6.4, 4.8), constrained_layout=True)
+    ax = fig.subplots()
+    for s in series:
+        ax.errorbar(s["mjd"], s["mag"], yerr=s["magerr"], ls="", marker="o", ms=1)
+    ax.invert_yaxis()
+    ax.set_xlabel("MJD")
+    ax.set_ylabel("mag")
+    return fig
+
+
+def w_png():
+    """pages/figure.py save_fig, Agg branch."""
+    buf = io.BytesIO()
+    _figure(PNG_SERIES).savefig(buf, format="png")
+    return len(buf.getvalue())
+
+
+def w_pdf():
+    """pages/figure.py save_fig, PGF branch -- shells out to LaTeX."""
+    fig = _figure(PDF_SERIES)
+    fig.canvas = matplotlib.backends.backend_pgf.FigureCanvasPgf(fig)
+    buf = io.BytesIO()
+    fig.savefig(buf, format="pdf")
+    return len(buf.getvalue())
+
+
+def w_python_loop():
+    """lc_data/plot_data.py: the per-observation loop."""
+    out = []
+    for obs in LC_OBS:
+        o = dict(obs)
+        ref_flux = 10 ** (-0.4 * (25.0 - ABZPMAG_JY))
+        o["flux"] = 10 ** (-0.4 * (o["mag"] - ABZPMAG_JY)) - ref_flux
+        o["fluxerr"] = err = LN10_04 * o["flux"] * o["magerr"]
+        o["snr"] = o["flux"] / err if err else 0.0
+        out.append(o)
+    return len(out)
+
+
+WORKLOADS = [
+    ("time.sleep (control: pure wait)", w_sleep),
+    ("python arithmetic (control: GIL-bound)", w_arithmetic),
+    ("astropy FITS parse, 2M rows", w_fits_parse),
+    ("pandas concat+sort+to_csv", w_pandas_csv),
+    ("matplotlib Agg PNG", w_png),
+    ("matplotlib PGF/LaTeX PDF", w_pdf),
+    ("per-observation python loop", w_python_loop),
+]
+
+
+def _best(run, fn, n):
+    return min(run(fn, n) for _ in range(REPEATS))
+
+
+def _serial(fn, n):
+    start = time.perf_counter()
+    for _ in range(n):
+        fn()
+    return time.perf_counter() - start
+
+
+def _threaded(fn, n):
+    with ThreadPoolExecutor(max_workers=n) as pool:
+        start = time.perf_counter()
+        list(pool.map(lambda _: fn(), range(n)))
+        return time.perf_counter() - start
+
+
+def main():
+    for name, fn in WORKLOADS:
+        if fn is not w_sleep:
+            fn()  # warm up font caches, lazy imports, first-touch allocations
+
+    print(f"{K} tasks, {K} threads, best of {REPEATS}\n")
+    print(f"{'workload':40s} {'serial':>9s} {'threaded':>9s} {'speedup':>8s}")
+    print("-" * 70)
+    for name, fn in WORKLOADS:
+        serial = _best(_serial, fn, K)
+        threaded = _best(_threaded, fn, K)
+        print(f"{name:40s} {serial:8.3f}s {threaded:8.3f}s {serial / threaded:7.2f}x")
+
+
+if __name__ == "__main__":
+    main()

--- a/plans/001_async_dash.md
+++ b/plans/001_async_dash.md
@@ -1343,6 +1343,13 @@ memory.
   it is the default format (`figure.py:68`), so it is what most users actually hit.
 - Treating them the same also keeps one code path: `save_fig` dispatches on `fmt` internally,
   so splitting PNG and PDF across pool/no-pool would mean fragmenting it for no benefit.
+- **Correction to "differ in cost but not in kind": under threads they differ in kind, and the
+  cheaper format is the more hostile one.** *(Noted while reviewing `aio-snad-apis`, which put both
+  renderers on `asyncio.to_thread`.)* PDF's cost is dominated by **waiting on the LaTeX child
+  process**, and waiting on a subprocess releases the GIL — so on a thread a PDF request already
+  overlaps with everything else. PNG is in-process Agg rendering, which does not. So the case for
+  a process pool rests more on PNG, the *common* format, than on the expensive one, and the
+  "pool both" decision above stands for the code-path reason rather than the cost ordering.
 - The routes become `async def` and `await loop.run_in_executor(pool, ...)`; inputs are
   already plain dicts/lists (`get_plot_data` output), so pickling is cheap.
 - **Accept:** `aio-golden-http`'s figure assertions unchanged for both formats; measure both — a concurrent
@@ -1355,6 +1362,26 @@ Measure before moving; each may be cheaper to leave on a thread:
 - `ztf_viewer/pages/lc_csv.py` pandas assembly,
 - `ztf_viewer/catalogs/ztf_ref.py:41` FITS parse (after `aio-snad-apis` makes the fetch async),
 - plotly figure construction in `set_figure` (`ztf_viewer/pages/viewer.py:1606`).
+
+**The question here is promotion, not introduction.** `aio-snad-apis` had to put the FITS parse,
+the pandas CSV assembly and both matplotlib renderers behind `asyncio.to_thread` the moment their
+callers became coroutines — a thread was the only offload available, since no process pool exists
+until `aio-procpool`. So this section inherits work that is already *off the loop* and asks a
+narrower question: does moving it further, to a process, earn the pickling and the child-process
+memory? Answer it per site, with a measurement.
+
+The GIL is what makes that question non-obvious, and it does not rank the candidates the way
+"CPU-bound" would suggest. Work that spends its time in C that releases the GIL — numpy, much of
+pandas, astropy's FITS reader — already overlaps with the loop on a thread and has the weakest
+case for a process. Pure-Python loops have the strongest. That is why `lc_data/plot_data.py:18`
+heads this list and why vectorizing it may beat pooling it outright.
+
+**Rule that came out of reviewing `aio-snad-apis`: none of this reasoning belongs in a code
+comment.** A comment that labels work "CPU-bound" next to an `asyncio.to_thread` call states a
+classification and pairs it with the mechanism that does not follow from it, and a comment that
+says a call is "out of scope here" is describing a PR boundary that is stale as soon as the next
+PR lands. Both facts live in this plan, which is versioned, and in the PR description, which is
+dated. `await asyncio.to_thread(x)` needs no gloss.
 
 ---
 

--- a/plans/001_async_dash.md
+++ b/plans/001_async_dash.md
@@ -1375,7 +1375,7 @@ memory? Answer it per site, with a measurement.
 
 **Measured, not assumed: a thread buys these workloads almost nothing.** It is tempting to argue
 that numpy/pandas/astropy spend their time in C that releases the GIL, so threads are enough. That
-argument was made during review and is **wrong**. `misc/gil_bench.py` runs each workload as 4
+argument was made during review and is **wrong**. `plans/misc/gil_bench.py` runs each workload as 4
 tasks on 4 threads against the same 4 run serially, on the interpreter we ship (CPython 3.14, GIL
 enabled), with two controls to bracket the range:
 
@@ -1426,7 +1426,7 @@ dated. `await asyncio.to_thread(x)` needs no gloss.
   def` for the rest, and either drop the callbacks-are-coroutines guard or replace it with the
   narrower rule that actually matters: no callback performs blocking I/O.
 - Update `README.md`, `AGENTS.md` (run command, dev stack), `CHANGELOG.md`.
-- Add a small load-test script (`misc/`) so the concurrency claims stay verifiable.
+- Add a small load-test script (`plans/misc/`) so the concurrency claims stay verifiable.
 
 ---
 

--- a/plans/001_async_dash.md
+++ b/plans/001_async_dash.md
@@ -1344,12 +1344,15 @@ memory.
 - Treating them the same also keeps one code path: `save_fig` dispatches on `fmt` internally,
   so splitting PNG and PDF across pool/no-pool would mean fragmenting it for no benefit.
 - **Correction to "differ in cost but not in kind": under threads they differ in kind, and the
-  cheaper format is the more hostile one.** *(Noted while reviewing `aio-snad-apis`, which put both
-  renderers on `asyncio.to_thread`.)* PDF's cost is dominated by **waiting on the LaTeX child
-  process**, and waiting on a subprocess releases the GIL — so on a thread a PDF request already
-  overlaps with everything else. PNG is in-process Agg rendering, which does not. So the case for
-  a process pool rests more on PNG, the *common* format, than on the expensive one, and the
-  "pool both" decision above stands for the code-path reason rather than the cost ordering.
+  cheaper format is the more hostile one.** *(Measured while reviewing `aio-snad-apis`, which put
+  both renderers on `asyncio.to_thread`; numbers in the `aio-profile` table.)* PDF's cost is
+  dominated by **waiting on the LaTeX child process**, which releases the GIL — four concurrent PDF
+  renders on four threads come out at **3.33x**, i.e. they already overlap. PNG is in-process Agg
+  rendering and manages **1.25x**, barely above the GIL-bound control. So the process pool is
+  needed for PNG — the *default* format (`figure.py:68`), and therefore the common one — while PDF,
+  the expensive one, is the case a thread already handles. This inverts F8's cost ordering as a
+  guide to what needs pooling, and it means the "pool both formats" decision rests on the
+  one-code-path argument alone, not on PDF being worse.
 - The routes become `async def` and `await loop.run_in_executor(pool, ...)`; inputs are
   already plain dicts/lists (`get_plot_data` output), so pickling is cheap.
 - **Accept:** `aio-golden-http`'s figure assertions unchanged for both formats; measure both — a concurrent
@@ -1370,11 +1373,32 @@ until `aio-procpool`. So this section inherits work that is already *off the loo
 narrower question: does moving it further, to a process, earn the pickling and the child-process
 memory? Answer it per site, with a measurement.
 
-The GIL is what makes that question non-obvious, and it does not rank the candidates the way
-"CPU-bound" would suggest. Work that spends its time in C that releases the GIL — numpy, much of
-pandas, astropy's FITS reader — already overlaps with the loop on a thread and has the weakest
-case for a process. Pure-Python loops have the strongest. That is why `lc_data/plot_data.py:18`
-heads this list and why vectorizing it may beat pooling it outright.
+**Measured, not assumed: a thread buys these workloads almost nothing.** It is tempting to argue
+that numpy/pandas/astropy spend their time in C that releases the GIL, so threads are enough. That
+argument was made during review and is **wrong**. `misc/gil_bench.py` runs each workload as 4
+tasks on 4 threads against the same 4 run serially, on the interpreter we ship (CPython 3.14, GIL
+enabled), with two controls to bracket the range:
+
+| workload | serial | threaded | speedup |
+| --- | --- | --- | --- |
+| `time.sleep` — control, pure wait | 0.612 s | 0.154 s | **3.98x** |
+| Python arithmetic — control, GIL-bound | 0.390 s | 0.399 s | **0.98x** |
+| astropy FITS parse, 2M rows (`ztf_ref`) | 0.058 s | 0.035 s | **1.65x** |
+| pandas concat + sort + `to_csv` (`lc_csv`) | 2.826 s | 2.594 s | **1.09x** |
+| matplotlib Agg PNG (`figure`) | 1.146 s | 0.916 s | **1.25x** |
+| matplotlib PGF → LaTeX PDF (`figure`) | 5.111 s | 1.533 s | **3.33x** |
+| per-observation loop (`plot_data`) | 0.209 s | 0.220 s | **0.95x** |
+
+pandas and Agg sit at the GIL-bound control, not near the parallel one. The per-observation loop is
+*slower* on threads than serially — thread overhead on top of no parallelism at all. The FITS parse
+does release partially, but 57 ms for 2M rows is negligible against a real reference catalog.
+
+**So the destination for this work is a process, and the `to_thread` calls `aio-snad-apis` had to
+introduce are keeping the loop responsive, nothing more.** The one real exception is the LaTeX/PDF
+path, which parallelizes because it waits on a child process — see the correction under
+`aio-figures`. `lc_data/plot_data.py:18` still heads the list, and vectorizing it with numpy may
+still beat pooling it, but that is now a claim about *that* loop rather than about C extensions in
+general.
 
 **Rule that came out of reviewing `aio-snad-apis`: none of this reasoning belongs in a code
 comment.** A comment that labels work "CPU-bound" next to an `asyncio.to_thread` call states a

--- a/plans/misc/gil_bench.py
+++ b/plans/misc/gil_bench.py
@@ -9,7 +9,7 @@ process pool; one near the sleep control is already overlapping fine.
 The workloads mirror the real call sites rather than reproducing them, so this stays a
 standalone script with no import of the app.
 
-Run: python misc/gil_bench.py
+Run: python plans/misc/gil_bench.py
 """
 
 import io


### PR DESCRIPTION
## What

Plan + one benchmark script. Came out of reviewing #665, which had to introduce `asyncio.to_thread` at several CPU-heavy sites and wrote the reasoning into code comments — the location was wrong, and on inspection so was part of the reasoning.

## The claim that failed

Review of #665 argued that numpy/pandas/astropy spend their time in C that releases the GIL, so a thread is enough for these workloads and the process pool is a nice-to-have. **That is wrong**, and `plans/misc/gil_bench.py` (added here) shows it. Each workload runs as 4 tasks serially, then the same 4 on 4 threads, on the interpreter we ship — CPython 3.14, GIL enabled — with two controls bracketing the range:

| workload | serial | threaded | speedup |
| --- | --- | --- | --- |
| `time.sleep` — control, pure wait | 0.612 s | 0.154 s | **3.98x** |
| Python arithmetic — control, GIL-bound | 0.390 s | 0.399 s | **0.98x** |
| astropy FITS parse, 2M rows | 0.058 s | 0.035 s | **1.65x** |
| pandas concat + sort + `to_csv` | 2.826 s | 2.594 s | **1.09x** |
| matplotlib Agg PNG | 1.146 s | 0.916 s | **1.25x** |
| matplotlib PGF → LaTeX PDF | 5.111 s | 1.533 s | **3.33x** |
| per-observation Python loop | 0.209 s | 0.220 s | **0.95x** |

pandas and Agg sit on the GIL-bound control, not near the parallel one. The per-observation loop is *slower* threaded than serial — thread overhead on top of no parallelism. The FITS parse releases partially, but 58 ms for 2M rows is negligible against a real reference catalog.

**Conclusion: a process pool is the right destination for this work**, and the `to_thread` calls #665 introduced keep the loop responsive and nothing more.

## The one exception, and it inverts F8

The LaTeX/PDF path reaches **3.33x** — it waits on a child process, which does release the GIL. PNG manages **1.25x**. So:

- **PDF** is the expensive format and the one a thread already handles.
- **PNG** is cheaper, is the default (`figure.py:68`) and therefore the common case, and is the one that serializes.

F8 ranks PDF above PNG by cost, which is correct, but cost is not the right guide to what needs pooling. `aio-figures`' "pool both formats" decision stands — on the one-code-path argument (`save_fig` dispatches on `fmt` internally), not on PDF being worse.

## `aio-profile`: promotion, not introduction

Three of its four listed candidates are already off the loop on threads as of #665, which had no choice once their callers became coroutines. The section's question narrows accordingly: not "should this leave the loop" but "does a process earn the pickling and the child-process memory". `lc_data/plot_data.py:18` still heads the list, and vectorizing it with numpy may still beat pooling it — but that is now a claim about that loop, not about C extensions in general.

## A rule, stated once

None of this belongs in a code comment. A comment labelling work "CPU-bound" next to an `asyncio.to_thread` call asserts a classification and pairs it with the mechanism that does not follow from it; "out of scope here" describes a PR boundary that goes stale as soon as the next PR lands. Both facts live in this plan, which is versioned, and in the PR description, which is dated. #665 has been stripped of those comments.

## Reproducing

```
python plans/misc/gil_bench.py
```

Needs a LaTeX install for the PDF row (the repo image already carries one). Numbers above are from a 12-core machine; the ratios are what matter, not the absolute times.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RNGE2vse7bLQ8dy8PTLamx
