### PR TITLE
aio-conesearch: convert the cone-search catalogs to async

### DIFF
--- a/tests/catalogs/conesearch/test_antares.py
+++ b/tests/catalogs/conesearch/test_antares.py
@@ -2,13 +2,13 @@ from astropy.coordinates import SkyCoord
 from numpy.testing import assert_allclose
 
 
-def test_regression_get_object_by_id():
+async def test_regression_get_object_by_id():
     from ztf_viewer.catalogs.conesearch.antares import AntaresQuery
 
     id = "ZTF18aagrczj"
     expected = SkyCoord(ra=230.71268, dec=41.05182, unit="deg")
     antares_query = AntaresQuery("Test Antares")
-    actual = antares_query.resolve_name(id)
+    actual = await antares_query.resolve_name(id)
     assert isinstance(actual, SkyCoord)
     assert_allclose(actual.ra.deg, expected.ra.deg, atol=1e-4)
     assert_allclose(actual.dec.deg, expected.dec.deg, atol=1e-4)

--- a/tests/catalogs/conesearch/test_ogle.py
+++ b/tests/catalogs/conesearch/test_ogle.py
@@ -3,7 +3,7 @@ from xml.etree import ElementTree as ET
 from numpy.testing import assert_allclose
 
 
-def test_cone_search():
+async def test_cone_search():
     """Regression test against the real OGLE-III mirror server.
 
     OGLE-BLG-RRLYR-04010 is a known RR Lyrae star (coordinates from the OGLE-III
@@ -15,7 +15,7 @@ def test_cone_search():
     ogle_query = OgleQuery("Test OGLE")
     # 17:50:17.82 -22:12:52.2, converted to decimal degrees
     ra, dec = 267.574250, -22.214500
-    table = ogle_query._api_query_region(ra, dec, radius_arcsec=5.0)
+    table = await ogle_query._api_query_region(ra, dec, radius_arcsec=5.0)
 
     assert table is not None
     assert len(table) > 0
@@ -38,7 +38,7 @@ def test_cone_search():
     assert "data:image/png;base64," in light_curve_html
 
 
-def test_rendered_html_is_well_formed():
+async def test_rendered_html_is_well_formed():
     """Regression test for two real bugs found in this exact rendering path.
 
     OGLE's table cells are the only ones in the app built from a <form>+<input> (the
@@ -57,7 +57,7 @@ def test_rendered_html_is_well_formed():
 
     ogle_query = OgleQuery("Test OGLE 3")
     ra, dec = 267.574250, -22.214500
-    table = ogle_query.find(ra, dec, radius_arcsec=5.0)
+    table = await ogle_query.find(ra, dec, radius_arcsec=5.0)
 
     html = html_from_astropy_table(table, ogle_query.columns, html_columns=ogle_query.html_columns)
     try:
@@ -66,7 +66,7 @@ def test_rendered_html_is_well_formed():
         raise AssertionError(f"Rendered OGLE table is not well-formed HTML/JSX: {e}\n{html}") from e
 
 
-def test_cone_search_not_found():
+async def test_cone_search_not_found():
     """Non-detection: a tiny radius far from any known OGLE-III field returns nothing."""
     import pytest
     from ztf_viewer.catalogs.conesearch.ogle import OgleQuery
@@ -74,4 +74,4 @@ def test_cone_search_not_found():
 
     ogle_query = OgleQuery("Test OGLE 2")
     with pytest.raises(NotFound):
-        ogle_query.find(ra=0.0, dec=60.0, radius_arcsec=1.0)
+        await ogle_query.find(ra=0.0, dec=60.0, radius_arcsec=1.0)

--- a/tests/catalogs/conesearch/test_otter.py
+++ b/tests/catalogs/conesearch/test_otter.py
@@ -1,7 +1,7 @@
 from numpy.testing import assert_allclose
 
 
-def test_cone_search():
+async def test_cone_search():
     """Regression test against the real Otter server.
 
     Coordinates taken from the example in
@@ -18,7 +18,7 @@ def test_cone_search():
 
     otter_query = OtterQuery("Test Otter")
     # 1-degree cone around the example coordinates
-    table = otter_query._api_query_region(ra=185.0, dec=12.0, radius_arcsec=3600.0)
+    table = await otter_query._api_query_region(ra=185.0, dec=12.0, radius_arcsec=3600.0)
 
     assert table is not None
     assert len(table) > 0
@@ -44,7 +44,7 @@ def test_get_url():
     assert url == "https://otter.idies.jhu.edu/transient/CSS071216:122109+125434"
 
 
-def test_cone_search_not_found():
+async def test_cone_search_not_found():
     """Non-detection: 1-arcsec radius around the example coordinates returns nothing."""
     import pytest
     from ztf_viewer.catalogs.conesearch.otter import OtterQuery
@@ -52,4 +52,4 @@ def test_cone_search_not_found():
 
     otter_query = OtterQuery("Test Otter 3")
     with pytest.raises(NotFound):
-        otter_query._api_query_region(ra=185.0, dec=12.0, radius_arcsec=1.0)
+        await otter_query._api_query_region(ra=185.0, dec=12.0, radius_arcsec=1.0)

--- a/tests/catalogs/conesearch/test_panstarrs.py
+++ b/tests/catalogs/conesearch/test_panstarrs.py
@@ -10,11 +10,14 @@ _RADIUS_DEG = 0.05
 
 @pytest.fixture(scope="module")
 def stack_table():
-    import requests as req
+    import asyncio
+
     from ztf_viewer.catalogs.conesearch.panstarrs import _panstarrs_request
 
-    with req.Session() as session:
-        return _panstarrs_request(session, "dr2", "stack", ra=_RA, dec=_DEC, radius=_RADIUS_DEG)
+    async def fetch():
+        return await _panstarrs_request("dr2", "stack", ra=_RA, dec=_DEC, radius=_RADIUS_DEG)
+
+    return asyncio.run(fetch())
 
 
 def test_stack_returns_rows(stack_table):
@@ -48,7 +51,7 @@ def test_stack_missing_values_are_masked_not_string(stack_table):
     assert all(isinstance(v, float) for v in unmasked), "unmasked pmra values should be float"
 
 
-def test_query_region():
+async def test_query_region():
     """End-to-end test through PanstarrsDr2StackedQuery._query_region.
 
     The base class passes radius as a string of arcseconds, e.g. "180.0s".
@@ -58,6 +61,6 @@ def test_query_region():
 
     q = PanstarrsDr2StackedQuery("test")
     coord = SkyCoord(ra=_RA, dec=_DEC, unit="deg")
-    table = q._query_region(coord, f"{_RADIUS_DEG * 3600}s")
+    table = await q._query_region(coord, f"{_RADIUS_DEG * 3600}s")
     assert len(table) > 0
     assert "raMean" in table.colnames

--- a/tests/catalogs/conesearch/test_tns.py
+++ b/tests/catalogs/conesearch/test_tns.py
@@ -2,13 +2,13 @@ from astropy.coordinates import SkyCoord
 from numpy.testing import assert_allclose
 
 
-def test_regression_get_object_by_id():
+async def test_regression_get_object_by_id():
     from ztf_viewer.catalogs.conesearch.tns import TnsQuery
 
     id = "2018lwh"
     expected = SkyCoord(ra=247.45543, dec=24.77282, unit="deg")
     tns_query = TnsQuery("Test TNS")
-    actual = tns_query.resolve_name(id)
+    actual = await tns_query.resolve_name(id)
     assert isinstance(actual, SkyCoord)
     assert_allclose(actual.ra.deg, expected.ra.deg)
     assert_allclose(actual.dec.deg, expected.dec.deg)

--- a/tests/test_async_offload.py
+++ b/tests/test_async_offload.py
@@ -23,20 +23,13 @@ from ztf_viewer import config
 config.CACHE_TYPE = "memory"
 config.UNAVAILABLE_CATALOGS_CACHE_TYPE = "memory"
 
-from ztf_viewer.catalogs.conesearch._base import _BaseLightCurveQuery  # noqa: E402
 from ztf_viewer.pages import viewer  # noqa: E402
 
 # function (or unbound method) -> a substring of the sync call it must route through a thread
 CALLBACKS_WITH_REMAINING_BLOCKING_CALLS = {
     viewer.fit_lc: "csfd.ebv",
-    viewer.get_antares_lc_option: "ANTARES_QUERY.find_closest",
-    viewer.get_gaia_lc_option: "GAIA_DR3.find_closest",
-    viewer.get_panstarrs_lc_option: "PANSTARRS_DR2_QUERY.find_closest",
-    viewer.get_summary: "query.find",
     viewer.update_skybot_for_graph_clicked: "SKYBOT_QUERY.find",
-    viewer.set_table: "query.find",
     viewer.set_vizier_list: "find_vizier.find",
-    _BaseLightCurveQuery.closest_light_curve_by_oid: "self.closest_light_curve",
 }
 
 

--- a/ztf_viewer/__main__.py
+++ b/ztf_viewer/__main__.py
@@ -265,7 +265,7 @@ def oid_from_input(s: str):
     return s
 
 
-def sky_coord_from_str(s):
+async def sky_coord_from_str(s):
     s = s.strip()
     if s.upper().startswith("SNAD"):
         try:
@@ -281,7 +281,7 @@ def sky_coord_from_str(s):
     if s.upper().startswith("AT") or s.upper().startswith("SN"):
         s = s.removeprefix("AT").removeprefix("at").removeprefix("SN").removeprefix("sn").strip()
         try:
-            return TNS_QUERY.resolve_name(s)
+            return await TNS_QUERY.resolve_name(s)
         except NotFound, CatalogUnavailable:
             pass
 
@@ -289,12 +289,13 @@ def sky_coord_from_str(s):
         # make cases right
         s = "ZTF" + s.lower().removeprefix("ztf")
         try:
-            return ANTARES_QUERY.resolve_name(s)
+            return await ANTARES_QUERY.resolve_name(s)
         except NotFound, CatalogUnavailable:
             pass
 
     try:
-        return get_icrs_coordinates(s)
+        # `get_icrs_coordinates` is a still-sync Sesame lookup; offload to a thread.
+        return await asyncio.to_thread(get_icrs_coordinates, s)
     except NameResolveError:
         pass
 
@@ -541,7 +542,7 @@ archivePrefix = {arXiv},
     ):
         coord_or_name = urllib.parse.unquote(search_match["coord_or_name"])
         try:
-            coordinates = sky_coord_from_str(coord_or_name)
+            coordinates = await sky_coord_from_str(coord_or_name)
         except ValueError:
             return [
                 html.Div(

--- a/ztf_viewer/catalogs/__init__.py
+++ b/ztf_viewer/catalogs/__init__.py
@@ -1,2 +1,2 @@
-from .unavailable_catalogs import unavailable_catalogs
+from .unavailable_catalogs import unavailable_catalogs, unavailable_catalogs_async
 from .ztf_dr import find_ztf_circle, find_ztf_oid

--- a/ztf_viewer/catalogs/conesearch/_base.py
+++ b/ztf_viewer/catalogs/conesearch/_base.py
@@ -1,12 +1,13 @@
 import asyncio
 import dataclasses
+import inspect
 import logging
 import urllib.parse
 from functools import partial
 from typing import Dict, List, Optional
 
+import httpx
 import pandas as pd
-import requests
 from astropy.coordinates import SkyCoord
 from astropy.cosmology import FlatLambdaCDM
 from astropy.table import Table
@@ -15,11 +16,29 @@ from astroquery.vizier import Vizier
 from requests import RequestException
 
 from ztf_viewer.cache import cache
-from ztf_viewer.catalogs import find_ztf_oid, unavailable_catalogs
+from ztf_viewer.catalogs import find_ztf_oid, unavailable_catalogs, unavailable_catalogs_async
+from ztf_viewer.config import TIMEOUT_CONESEARCH_API
 from ztf_viewer.exceptions import CatalogUnavailable, NotFound
-from ztf_viewer.util import compose_plus_minus_expression, safe_link, to_str, timeout
+from ztf_viewer.http import get_client
+from ztf_viewer.util import async_timeout, compose_plus_minus_expression, safe_link, to_str
 
 COSMO = FlatLambdaCDM(H0=70, Om0=0.3)
+
+
+def _ensure_coroutine(func):
+    """Wrap a sync callable in ``asyncio.to_thread``; pass an already-async one through unchanged.
+
+    Lets ``find()`` await ``_query_region`` uniformly regardless of whether a given catalog's
+    implementation is genuine async I/O or a still-sync third-party client (astroquery, an
+    unconverted ``requests`` call). Mirrors ``ztf_viewer.callbacks._to_coroutine_function``.
+    """
+    if inspect.iscoroutinefunction(func):
+        return func
+
+    async def wrapper(*args, **kwargs):
+        return await asyncio.to_thread(func, *args, **kwargs)
+
+    return wrapper
 
 
 @dataclasses.dataclass
@@ -106,7 +125,7 @@ class _BaseCatalogQuery:
 
     def __init__(self, query_name):
         self.__query_name = query_name
-        self._timeout_decorator = timeout(
+        self._timeout_decorator = async_timeout(
             seconds=10.0,
             exception=CatalogUnavailable,
             exception_kwargs=dict(catalog=self),
@@ -153,15 +172,20 @@ class _BaseCatalogQuery:
         if self.query_name in unavailable_catalogs:
             raise CatalogUnavailable(self.query_name, prolongate=False)
 
+    async def _raise_if_unavailable_async(self):
+        if await unavailable_catalogs_async.contains(self.query_name):
+            raise CatalogUnavailable(self.query_name, prolongate=False)
+
     @cache()
-    def find(self, ra, dec, radius_arcsec):
-        self._raise_if_unavailable()
+    async def find(self, ra, dec, radius_arcsec):
+        await self._raise_if_unavailable_async()
         coord = SkyCoord(ra, dec, unit="deg", frame="icrs")
         radius = f"{radius_arcsec}s"
         logging.info(f"Querying ra={ra}, dec={dec}, r={radius_arcsec}")
+        query_region = self._timeout_decorator(_ensure_coroutine(self._query_region))
         try:
-            table = self._timeout_decorator(self._query_region)(coord, radius=radius)
-        except RequestException as e:  # this gives a good chance to catch network or service problem
+            table = await query_region(coord, radius=radius)
+        except (RequestException, httpx.HTTPError) as e:  # a good chance to catch network or service problems
             logging.warning(str(e))
             raise CatalogUnavailable(catalog=self)
         if table is None:
@@ -177,8 +201,8 @@ class _BaseCatalogQuery:
         table.sort("separation")
         return table
 
-    def find_closest(self, ra, dec, radius_arcsec, has_light_curve=True):
-        table = self.find(ra, dec, radius_arcsec)
+    async def find_closest(self, ra, dec, radius_arcsec, has_light_curve=True):
+        table = await self.find(ra, dec, radius_arcsec)
         return table[0]
 
     def add_additional_columns(self, table):
@@ -259,10 +283,11 @@ class _BaseLightCurveQuery:
     def _empty_light_curve():
         return Table(dict.fromkeys(["oid", "mjd", "mag", "magerr", "filter"], []))
 
-    def closest_light_curve(self, ra, dec, radius_arcsec, fail_on_empty=True, fail_on_unavailable=True):
+    async def closest_light_curve(self, ra, dec, radius_arcsec, fail_on_empty=True, fail_on_unavailable=True):
         try:
-            row = self.find_closest(ra, dec, radius_arcsec, has_light_curve=True)
-            return self.light_curve(row[self.id_column], row=row)
+            row = await self.find_closest(ra, dec, radius_arcsec, has_light_curve=True)
+            light_curve = _ensure_coroutine(self.light_curve)
+            return await light_curve(row[self.id_column], row=row)
         except NotFound:
             if fail_on_empty:
                 raise
@@ -274,13 +299,9 @@ class _BaseLightCurveQuery:
 
     async def closest_light_curve_by_oid(self, oid, dr, radius_arcsec, fail_on_empty=True, fail_on_unavailable=True):
         ra, dec = await find_ztf_oid.get_coord(oid, dr)
-        return await asyncio.to_thread(
-            self.closest_light_curve,
-            ra,
-            dec,
-            radius_arcsec,
-            fail_on_empty=fail_on_empty,
-            fail_on_unavailable=fail_on_unavailable,
+        closest_light_curve = _ensure_coroutine(self.closest_light_curve)
+        return await closest_light_curve(
+            ra, dec, radius_arcsec, fail_on_empty=fail_on_empty, fail_on_unavailable=fail_on_unavailable
         )
 
 
@@ -289,8 +310,9 @@ class _BaseNameResolverQuery:
         raise NotImplementedError
 
     @cache()
-    def resolve_name(self, id) -> SkyCoord:
-        obj = self.get_record_by_id(id)
+    async def resolve_name(self, id) -> SkyCoord:
+        get_record_by_id = _ensure_coroutine(self.get_record_by_id)
+        obj = await get_record_by_id(id)
         return self._construct_coord(obj)
 
 
@@ -299,30 +321,26 @@ class _BaseCatalogApiQuery(_BaseCatalogQuery):
     def _base_api_url(self):
         raise NotImplementedError
 
-    def __init__(self, *args, **kwargs):
-        super().__init__(*args, **kwargs)
-        self._api_session = requests.Session()
-
     def _raise_if_not_ok(self, response):
         if response.status_code != 200:
             logging.warning(response.text)
             raise CatalogUnavailable(response.text, catalog=self)
 
-    def _api_query_region(self, ra, dec, radius_arcsec):
+    async def _api_query_region(self, ra, dec, radius_arcsec):
         query = {"ra": ra, "dec": dec, "radius_arcsec": radius_arcsec}
-        response = self._api_session.get(self._get_api_url(query), timeout=10)
+        response = await get_client().get(self._get_api_url(query), timeout=TIMEOUT_CONESEARCH_API)
         self._raise_if_not_ok(response)
         j = response.json()
         table = Table.from_pandas(pd.DataFrame.from_records(j))
         return table
 
-    def _query_region(self, coord, radius):
+    async def _query_region(self, coord, radius):
         ra = coord.ra.to_value("deg")
         dec = coord.dec.to_value("deg")
         if not (isinstance(radius, str) and radius.endswith("s")):
             raise ValueError('radius argument should be a string that ends with "s" letter')
         radius_arcsec = float(radius[:-1])
-        return self._api_query_region(ra, dec, radius_arcsec)
+        return await self._api_query_region(ra, dec, radius_arcsec)
 
     def _get_api_url(self, query):
         query_string = urllib.parse.urlencode(query)

--- a/ztf_viewer/catalogs/conesearch/antares.py
+++ b/ztf_viewer/catalogs/conesearch/antares.py
@@ -1,3 +1,4 @@
+import asyncio
 import logging
 
 import antares_client.search
@@ -110,6 +111,6 @@ class AntaresQuery(_BaseCatalogApiQuery, _BaseLightCurveQuery, _BaseNameResolver
         return locus
 
     @cache()
-    def resolve_name(self, id) -> SkyCoord:
-        locus = self.get_record_by_id(id)
+    async def resolve_name(self, id) -> SkyCoord:
+        locus = await asyncio.to_thread(self.get_record_by_id, id)
         return locus.coordinates

--- a/ztf_viewer/catalogs/conesearch/astrocats.py
+++ b/ztf_viewer/catalogs/conesearch/astrocats.py
@@ -1,10 +1,12 @@
 from io import BytesIO
+from json import JSONDecodeError
 
 import astropy.io.ascii
 from markupsafe import Markup, escape
-from requests.exceptions import JSONDecodeError
 
 from ztf_viewer.catalogs.conesearch._base import _BaseCatalogApiQuery
+from ztf_viewer.config import TIMEOUT_CONESEARCH_API
+from ztf_viewer.http import get_client
 from ztf_viewer.util import safe_link
 
 
@@ -29,8 +31,8 @@ class AstrocatsQuery(_BaseCatalogApiQuery):
     _base_api_url = f"{__root_api_url}/all"
     _declared_html_columns = frozenset({"references"})  # get_link() below returns plain text
 
-    def _get_sources(self, id):
-        response = self._api_session.get(f"{self.__root_api_url}/{id}/sources", timeout=10)
+    async def _get_sources(self, id):
+        response = await get_client().get(f"{self.__root_api_url}/{id}/sources", timeout=TIMEOUT_CONESEARCH_API)
         self._raise_if_not_ok(response)
         data = response.json()
         return data[id]["sources"]
@@ -47,9 +49,9 @@ class AstrocatsQuery(_BaseCatalogApiQuery):
             return ads_link if bibcode == name else escape(name) + " (" + ads_link + ")"
         return escape(name)
 
-    def _api_query_region(self, ra, dec, radius_arcsec):
+    async def _api_query_region(self, ra, dec, radius_arcsec):
         query = {"ra": ra, "dec": dec, "radius": radius_arcsec, "format": "csv", "item": 0}
-        response = self._api_session.get(self._get_api_url(query), timeout=10)
+        response = await get_client().get(self._get_api_url(query), timeout=TIMEOUT_CONESEARCH_API)
         self._raise_if_not_ok(response)
         # If nothing is found a single-line JSON response coming:
         # {"message": "No objects found within specified search region."}
@@ -59,9 +61,8 @@ class AstrocatsQuery(_BaseCatalogApiQuery):
         except JSONDecodeError:
             pass
         table = astropy.io.ascii.read(BytesIO(response.content), format="csv", guess=False)
-        table["references"] = [
-            Markup(", ").join(map(self._format_source, sources)) for sources in map(self._get_sources, table["event"])
-        ]
+        sources = [await self._get_sources(event) for event in table["event"]]
+        table["references"] = [Markup(", ").join(map(self._format_source, s)) for s in sources]
         return table
 
     def get_link(self, id, name, row=None):

--- a/ztf_viewer/catalogs/conesearch/colibri.py
+++ b/ztf_viewer/catalogs/conesearch/colibri.py
@@ -3,7 +3,9 @@ from astropy.table import Table
 from astropy.time import Time
 
 from ztf_viewer.catalogs.conesearch._base import _BaseCatalogApiQuery
+from ztf_viewer.config import TIMEOUT_CONESEARCH_API
 from ztf_viewer.exceptions import NotFound
+from ztf_viewer.http import get_client
 from ztf_viewer.util import safe_link
 
 
@@ -28,10 +30,10 @@ class ColibriQuery(_BaseCatalogApiQuery):
     _base_api_url = f"{__root_api_url}/cone_search"
     _declared_html_columns = frozenset({"simbad_url"})  # get_link() below returns plain text
 
-    def _api_query_region(self, ra, dec, radius_arcsec):
+    async def _api_query_region(self, ra, dec, radius_arcsec):
         radius_deg = radius_arcsec / 3600.0
         query = {"cone": f"[{ra},{dec},{radius_deg}]", "datemin": 0, "datemax": ((1 << 31) - 1) * 1000}
-        response = self._api_session.get(self._get_api_url(query), timeout=10)
+        response = await get_client().get(self._get_api_url(query), timeout=TIMEOUT_CONESEARCH_API)
         self._raise_if_not_ok(response)
         data = response.json()
         vo_events = data["voevents"]

--- a/ztf_viewer/catalogs/conesearch/fink.py
+++ b/ztf_viewer/catalogs/conesearch/fink.py
@@ -5,7 +5,9 @@ import pandas as pd
 from astropy.table import Table
 
 from ztf_viewer.catalogs.conesearch._base import _BaseCatalogApiQuery
+from ztf_viewer.config import TIMEOUT_CONESEARCH_API
 from ztf_viewer.exceptions import NotFound
+from ztf_viewer.http import get_client
 
 
 class FinkQuery(_BaseCatalogApiQuery):
@@ -43,7 +45,7 @@ class FinkQuery(_BaseCatalogApiQuery):
     _api_url = urljoin(_base_url, "/api/v1/conesearch")
     _api_url_objects = urljoin(_base_url, "/api/v1/objects")
 
-    def _get_classifications(self, object_ids) -> pd.DataFrame:
+    async def _get_classifications(self, object_ids) -> pd.DataFrame:
         time_column = "i:jd"
         columns = [time_column, self.id_column] + list(c for c in self.columns if c.startswith("d:"))
         json_dict = {
@@ -51,7 +53,7 @@ class FinkQuery(_BaseCatalogApiQuery):
             "columns": ",".join(columns),
             "output-format": "json",
         }
-        response = self._api_session.post(self._api_url_objects, json=json_dict, timeout=10)
+        response = await get_client().post(self._api_url_objects, json=json_dict, timeout=TIMEOUT_CONESEARCH_API)
         self._raise_if_not_ok(response)
         df = pd.read_json(BytesIO(response.content))
         # Select the latest classification for each object
@@ -59,19 +61,19 @@ class FinkQuery(_BaseCatalogApiQuery):
         del df[time_column]
         return df.reset_index(drop=True)
 
-    def _api_query_region(self, ra, dec, radius_arcsec):
+    async def _api_query_region(self, ra, dec, radius_arcsec):
         json_dict = {
             "ra": ra,
             "dec": dec,
             "radius": radius_arcsec,
             "output-format": "json",
         }
-        response = self._api_session.post(self._api_url, json=json_dict, timeout=10)
+        response = await get_client().post(self._api_url, json=json_dict, timeout=TIMEOUT_CONESEARCH_API)
         self._raise_if_not_ok(response)
         df = pd.read_json(BytesIO(response.content))
         if len(df) == 0:
             raise NotFound
-        classifications = self._get_classifications(df[self.id_column])
+        classifications = await self._get_classifications(df[self.id_column])
         df = df.join(
             classifications.reset_index(drop=True).set_index(self.id_column),
             on=self.id_column,

--- a/ztf_viewer/catalogs/conesearch/gaia_dr3.py
+++ b/ztf_viewer/catalogs/conesearch/gaia_dr3.py
@@ -91,8 +91,8 @@ class GaiaDr3Query(_BaseVizierQuery, _BaseLightCurveQuery):
         super().__init__(query_name)
         self.gaia = GaiaClass()
 
-    def find_closest(self, ra, dec, radius_arcsec, has_light_curve: bool = False):
-        table = self.find(ra, dec, radius_arcsec)
+    async def find_closest(self, ra, dec, radius_arcsec, has_light_curve: bool = False):
+        table = await self.find(ra, dec, radius_arcsec)
         if has_light_curve:
             table = table[table["EpochPh"] == 1]
             if len(table) == 0:

--- a/ztf_viewer/catalogs/conesearch/ogle.py
+++ b/ztf_viewer/catalogs/conesearch/ogle.py
@@ -3,10 +3,10 @@ from base64 import b64encode
 from io import BytesIO
 
 import astropy.io.ascii
-import requests
 
 from ztf_viewer.catalogs.conesearch._base import _BaseCatalogApiQuery
-from ztf_viewer.config import OGLE_III_API_URL
+from ztf_viewer.config import OGLE_III_API_URL, TIMEOUT_CONESEARCH_API, TIMEOUT_OGLE_LIGHT_CURVE
+from ztf_viewer.http import get_client
 from ztf_viewer.util import anchor_form
 
 
@@ -58,28 +58,24 @@ class OgleQuery(_BaseCatalogApiQuery):
         "pagelen": "50",
     }
 
-    def __init__(self, *args, **kwargs):
-        super().__init__(*args, **kwargs)
-        self._light_curve_session = requests.Session()
-
-    def _download_light_curve(self, id):
+    async def _download_light_curve(self, id):
         basepath = f"{id[-2:]}/{id}"
         paths = [basepath + ".png", basepath + "_1.png"]
         light_curve_urls = [urllib.parse.urljoin(self._base_light_curve_url, path) for path in paths]
         for url in light_curve_urls:
-            response = self._light_curve_session.get(url, timeout=60)
+            response = await get_client().get(url, timeout=TIMEOUT_OGLE_LIGHT_CURVE)
             if response.status_code == 200:
                 data = b64encode(response.content).decode()
                 # JSX (used by dcc.Markdown's HTML renderer) needs attribute values quoted.
                 return f'<a href="{url}"><img src="data:image/png;base64,{data}" width="200px" /></a>'
         return ""
 
-    def _api_query_region(self, ra, dec, radius_arcsec):
+    async def _api_query_region(self, ra, dec, radius_arcsec):
         query = {"ra": ra, "dec": dec, "radius_arcsec": radius_arcsec, "format": "tsv"}
-        response = self._api_session.get(self._get_api_url(query), timeout=10)
+        response = await get_client().get(self._get_api_url(query), timeout=TIMEOUT_CONESEARCH_API)
         self._raise_if_not_ok(response)
         table = astropy.io.ascii.read(BytesIO(response.content), format="tab", guess=False)
-        table["light_curve"] = [self._download_light_curve(row[self.id_column]) for row in table]
+        table["light_curve"] = [await self._download_light_curve(row[self.id_column]) for row in table]
         return table
 
     def get_link(self, id, name, row=None):

--- a/ztf_viewer/catalogs/conesearch/otter.py
+++ b/ztf_viewer/catalogs/conesearch/otter.py
@@ -1,10 +1,12 @@
 import math
 
 import astropy.table
-from requests.exceptions import RequestException
+import httpx
 
 from ztf_viewer.catalogs.conesearch._base import _BaseCatalogApiQuery
+from ztf_viewer.config import TIMEOUT_CONESEARCH_API
 from ztf_viewer.exceptions import CatalogUnavailable, NotFound
+from ztf_viewer.http import get_client
 
 
 class OtterQuery(_BaseCatalogApiQuery):
@@ -26,10 +28,10 @@ class OtterQuery(_BaseCatalogApiQuery):
     _api_auth = ("user-guest", "test")
 
     def _raise_if_not_ok(self, response):
-        if not response.ok:
+        if not response.is_success:
             raise CatalogUnavailable(response.text, catalog=self)
 
-    def _api_query_region(self, ra, dec, radius_arcsec):
+    async def _api_query_region(self, ra, dec, radius_arcsec):
         radius_deg = radius_arcsec / 3600.0
         # Pre-filter box, see https://github.com/astro-otter/otter/issues/45#issuecomment-4188199127
         # Use cos(|dec| + sep) as the RA scaling factor — the smallest cos over the cone's dec range,
@@ -54,14 +56,14 @@ class OtterQuery(_BaseCatalogApiQuery):
             "bindVars": bind_vars,
         }
         try:
-            response = self._api_session.post(
+            response = await get_client().post(
                 self._base_api_url,
                 json=query,
                 auth=self._api_auth,
-                timeout=10,
+                timeout=TIMEOUT_CONESEARCH_API,
             )
             self._raise_if_not_ok(response)
-        except RequestException as e:
+        except httpx.HTTPError as e:
             raise CatalogUnavailable(str(e), catalog=self)
 
         results = response.json().get("result", [])

--- a/ztf_viewer/catalogs/conesearch/panstarrs.py
+++ b/ztf_viewer/catalogs/conesearch/panstarrs.py
@@ -1,19 +1,20 @@
 import logging
 from itertools import count
 
+import httpx
 import numpy as np
-import requests
 from astropy.coordinates import EarthLocation, SkyCoord
 from astropy.table import MaskedColumn, Table
 from astropy.time import Time
-from requests import RequestException
 
 from ztf_viewer.catalogs.conesearch._base import (
     ValueWithUncertaintyColumn,
     _BaseCatalogQuery,
     _BaseLightCurveQuery,
 )
+from ztf_viewer.config import TIMEOUT_PANSTARRS
 from ztf_viewer.exceptions import CatalogUnavailable, NotFound
+from ztf_viewer.http import get_client
 from ztf_viewer.util import ABZPMAG_JY, LGE_25
 
 HALEAKALA = EarthLocation(lon=-156.169, lat=20.71552, height=3048.0)  # EarthLocation.of_site('Haleakala')
@@ -73,14 +74,14 @@ def _mast_json_to_table(json_obj):
     return data_table
 
 
-def _panstarrs_request(session, release, table, **params):
+async def _panstarrs_request(release, table, **params):
     """POST to the MAST PanSTARRS catalog API and return an astropy Table."""
     url = f"{_PANSTARRS_API}/{release}/{table}.json"
-    response = session.post(
+    response = await get_client().post(
         url,
         json=params,
         headers={"Content-Type": "application/json", "Accept": "application/json"},
-        timeout=600,
+        timeout=TIMEOUT_PANSTARRS,
     )
     response.raise_for_status()
     return _mast_json_to_table(response.json())
@@ -113,10 +114,6 @@ class PanstarrsDr2StackedQuery(_BaseCatalogQuery, _BaseLightCurveQuery):
         ValueWithUncertaintyColumn(value=f"{b}PSFMag", uncertainty=f"{b}PSFMagErr") for b in _bands
     ]
 
-    def __init__(self, query_name):
-        super().__init__(query_name)
-        self._session = requests.Session()
-
     def __apply_groups(self, df):
         """Averaging stacked objects
 
@@ -144,17 +141,15 @@ class PanstarrsDr2StackedQuery(_BaseCatalogQuery, _BaseLightCurveQuery):
 
         return row
 
-    def _query_region(self, coord, radius):
+    async def _query_region(self, coord, radius):
         # radius comes from the base class as a string like "18.0s" (arcseconds)
         if isinstance(radius, str) and radius.endswith("s"):
             radius_deg = float(radius[:-1]) / 3600.0
         else:
             radius_deg = float(radius.deg)
         try:
-            table = _panstarrs_request(
-                self._session, "dr2", "stack", ra=coord.ra.deg, dec=coord.dec.deg, radius=radius_deg
-            )
-        except RequestException as e:
+            table = await _panstarrs_request("dr2", "stack", ra=coord.ra.deg, dec=coord.dec.deg, radius=radius_deg)
+        except httpx.HTTPError as e:
             logging.warning(e)
             raise CatalogUnavailable(catalog=self)
         if len(table) == 0:
@@ -193,11 +188,11 @@ class PanstarrsDr2StackedQuery(_BaseCatalogQuery, _BaseLightCurveQuery):
             for row in table
         ]
 
-    def light_curve(self, id, row=None):
-        self._raise_if_unavailable()
+    async def light_curve(self, id, row=None):
+        await self._raise_if_unavailable_async()
         try:
-            table = _panstarrs_request(self._session, "dr2", "detection", objID=int(row["objID"]))
-        except RequestException as e:
+            table = await _panstarrs_request("dr2", "detection", objID=int(row["objID"]))
+        except httpx.HTTPError as e:
             logging.info(str(e))
             raise CatalogUnavailable(catalog=self)
         if len(table) == 0:

--- a/ztf_viewer/catalogs/conesearch/sdss.py
+++ b/ztf_viewer/catalogs/conesearch/sdss.py
@@ -39,8 +39,8 @@ class SdssQuasarsQuery(_BaseVizierQuery):
     _vizier_catalog = "VII/289/superset"
 
     @cache()
-    def find(self, ra, dec, radius_arcsec):
-        table = super().find(ra, dec, radius_arcsec)
+    async def find(self, ra, dec, radius_arcsec):
+        table = await super().find(ra, dec, radius_arcsec)
         table["__type"] = table["Class"] = [self._class_map[c] for c in table["Class"]]
         return table
 

--- a/ztf_viewer/catalogs/conesearch/tns.py
+++ b/ztf_viewer/catalogs/conesearch/tns.py
@@ -3,6 +3,7 @@ from ztf_viewer.catalogs.conesearch._base import (
     _BaseNameResolverQuery,
 )
 from ztf_viewer.config import TNS_API_URL
+from ztf_viewer.http import get_client
 
 
 class TnsQuery(_BaseCatalogApiQuery, _BaseNameResolverQuery):
@@ -28,15 +29,15 @@ class TnsQuery(_BaseCatalogApiQuery, _BaseNameResolverQuery):
     def get_url(self, id, row=None):
         return f"//www.wis-tns.org/object/{id}"
 
-    def _api_query_region(self, ra, dec, radius_arcsec):
-        table = super()._api_query_region(ra, dec, radius_arcsec)
+    async def _api_query_region(self, ra, dec, radius_arcsec):
+        table = await super()._api_query_region(ra, dec, radius_arcsec)
         table["fullname"] = [f'{row["name_prefix"] or ""}{row["name"]}' for row in table]
         return table
 
     _resolve_api_url = f"{TNS_API_URL}/api/v1/object"
 
-    def get_record_by_id(self, id):
+    async def get_record_by_id(self, id):
         """id is something like 2018lwh, not AT2018lwh"""
-        response = self._api_session.get(self._resolve_api_url, params={"name": id}, timeout=1)
+        response = await get_client().get(self._resolve_api_url, params={"name": id}, timeout=1)
         self._raise_if_not_ok(response)
         return response.json()

--- a/ztf_viewer/http.py
+++ b/ztf_viewer/http.py
@@ -9,9 +9,6 @@ The client-level timeout (``config.HTTP_DEFAULT_TIMEOUT``) is a backstop, not th
 upstreams disagree by two orders of magnitude on how long they need, so a caller is expected to
 pass its own ``timeout=`` per request (``config.py``'s ``TIMEOUT_*`` constants) and this default
 only catches the case where one forgets to.
-
-Nothing in the app calls :func:`get_client` yet — this module only builds the client and wires
-its shutdown, ready for callers to adopt incrementally.
 """
 
 import asyncio

--- a/ztf_viewer/pages/lc_csv.py
+++ b/ztf_viewer/pages/lc_csv.py
@@ -67,10 +67,10 @@ def _lc_to_csv_response(lc, filename):
 
 
 @app.server.api_route("/panstarrs/csv/{obj_id}")
-def response_panstarrs_csv(obj_id: int):
+async def response_panstarrs_csv(obj_id: int):
     """Download Pan-STARRS DR2 light curve for a given objID as CSV."""
     try:
-        lc = PANSTARRS_DR2_QUERY.light_curve(id=None, row={"objID": obj_id})
+        lc = await PANSTARRS_DR2_QUERY.light_curve(id=None, row={"objID": obj_id})
     except NotFound, CatalogUnavailable:
         return error_response("", 404)
     return _lc_to_csv_response(lc, f"panstarrs_{obj_id}.csv")

--- a/ztf_viewer/pages/viewer.py
+++ b/ztf_viewer/pages/viewer.py
@@ -1187,9 +1187,7 @@ async def get_antares_lc_option(oid, dr, old):
     option = old.copy()
     ra, dec = await find_ztf_oid.get_coord(oid, dr)
     try:
-        row = await asyncio.to_thread(
-            ANTARES_QUERY.find_closest, ra, dec, radius_arcsec=ADDITIONAL_LC_SEARCH_RADIUS_ARCSEC
-        )
+        row = await ANTARES_QUERY.find_closest(ra, dec, radius_arcsec=ADDITIONAL_LC_SEARCH_RADIUS_ARCSEC)
     except NotFound:
         option["label"] = f"Antares object (not found in {ADDITIONAL_LC_SEARCH_RADIUS_ARCSEC}″)"
         option["disabled"] = True
@@ -1212,12 +1210,8 @@ async def get_gaia_lc_option(oid, dr, old):
     option = old.copy()
     ra, dec = await find_ztf_oid.get_coord(oid, dr)
     try:
-        row = await asyncio.to_thread(
-            GAIA_DR3.find_closest,
-            ra,
-            dec,
-            radius_arcsec=ADDITIONAL_LC_SEARCH_RADIUS_ARCSEC,
-            has_light_curve=True,
+        row = await GAIA_DR3.find_closest(
+            ra, dec, radius_arcsec=ADDITIONAL_LC_SEARCH_RADIUS_ARCSEC, has_light_curve=True
         )
     except NotFound:
         option["label"] = f"Gaia object (not found in {ADDITIONAL_LC_SEARCH_RADIUS_ARCSEC}″)"
@@ -1233,8 +1227,7 @@ async def get_gaia_lc_option(oid, dr, old):
         option["disabled"] = False
     # Check if we can load data
     try:
-        _ = await asyncio.to_thread(
-            GAIA_DR3.closest_light_curve,
+        _ = await GAIA_DR3.closest_light_curve(
             ra,
             dec,
             radius_arcsec=ADDITIONAL_LC_SEARCH_RADIUS_ARCSEC,
@@ -1251,9 +1244,7 @@ async def get_panstarrs_lc_option(oid, dr, old):
     option = old.copy()
     ra, dec = await find_ztf_oid.get_coord(oid, dr)
     try:
-        row = await asyncio.to_thread(
-            PANSTARRS_DR2_QUERY.find_closest, ra, dec, radius_arcsec=ADDITIONAL_LC_SEARCH_RADIUS_ARCSEC
-        )
+        row = await PANSTARRS_DR2_QUERY.find_closest(ra, dec, radius_arcsec=ADDITIONAL_LC_SEARCH_RADIUS_ARCSEC)
     except NotFound:
         option["label"] = f"Pan-STARRS object (not found in {ADDITIONAL_LC_SEARCH_RADIUS_ARCSEC}″)"
         option["disabled"] = True
@@ -1409,7 +1400,7 @@ async def get_summary(oid, dr, different_filter, different_field, radius_ids, ra
     elements = OrderedDict()
     for catalog, query in catalog_query_objects().items():
         try:
-            table = await asyncio.to_thread(query.find, ra, dec, radii[catalog])
+            table = await query.find(ra, dec, radii[catalog])
         except NotFound, CatalogUnavailable, KeyError:
             continue
         idx = np.argmin(table["separation"])
@@ -1476,7 +1467,7 @@ async def get_summary(oid, dr, different_filter, different_field, radius_ids, ra
     ml_classifications = []
     for catalog, query in catalog_query_objects().items():
         try:
-            table = await asyncio.to_thread(query.find, ra, dec, radii[catalog])
+            table = await query.find(ra, dec, radii[catalog])
         except NotFound, CatalogUnavailable, KeyError:
             continue
         if len(table) == 0:
@@ -1533,7 +1524,7 @@ async def get_summary(oid, dr, different_filter, different_field, radius_ids, ra
     except CatalogUnavailable:
         pass
     try:
-        table = await asyncio.to_thread(get_catalog_query("Gaia EDR3 Distances").find, ra, dec, 1)
+        table = await get_catalog_query("Gaia EDR3 Distances").find(ra, dec, 1)
         row = QTable(table[np.argmin(table["separation"])])
 
         distance = row["__distance"]
@@ -2051,7 +2042,7 @@ async def set_table(radius, oid, dr, catalog):
         return html.P("Radius should be positive")
     query = get_catalog_query(catalog)
     try:
-        table = await asyncio.to_thread(query.find, ra, dec, radius)
+        table = await query.find(ra, dec, radius)
     except NotFound:
         return html.P(
             f'No {catalog.replace("-", " ")} objects within {format_sep(radius, 0, 0)} from {ra:.5f}, {dec:.5f}'


### PR DESCRIPTION
## Scope

PR 3 of the async-I/O chain, on top of #665. Converts the cone-search layer per the plan's `aio-conesearch`:

- `_BaseCatalogQuery.find`, `_BaseCatalogApiQuery._api_query_region` and `_BaseNameResolverQuery.resolve_name` become coroutines on the shared `httpx` client.
- Per-catalog follow-ups: `astrocats`, `colibri`, `fink`, `gaia_dr3`, `otter`, `sdss`, `tns`, plus `ogle` and `panstarrs`, which each carried their own `requests.Session` for a bespoke endpoint.
- The callbacks and routes that reached a catalog through `asyncio.to_thread` now `await` it directly.

## `_ensure_coroutine` — the one new idea

`_BaseCatalogQuery.find` is shared between the JSON-API catalogs (converted here) and `_BaseVizierQuery`/astroquery (deliberately never converted, per F9). `find()` therefore has to await a `_query_region` that may or may not be a coroutine function. `_ensure_coroutine` passes a coroutine function through and wraps a sync one in `asyncio.to_thread`, mirroring `ztf_viewer.callbacks._to_coroutine_function`.

It is used at three sites: `_query_region`, `closest_light_curve`, and `get_record_by_id`. The alternative — converting every catalog including the astroquery ones — is exactly what F9 rules out.

**The per-upstream bounded semaphores are not here.** Astroquery, alerce and antares still reach a bare `asyncio.to_thread`; fairness between them is `aio-offload-threads`, the next PR.

## `util.timeout()` now has no callers

`_base.py` was its only call site and now uses `async_timeout`. That retires the per-call `ThreadPoolExecutor(max_workers=1)` the plan calls out as the one pre-existing violation of the threading rule — it was spawned on **every** cone-search query. The helper itself is left in place; removing it belongs to the cleanup stack.

## Two things the plan did not anticipate

- **`httpx.Response` has no `.ok`.** `otter.py` overrode `_raise_if_not_ok` using it; it now checks `is_success`. Worth knowing for anything else ported off `requests`.
- **Converting Pan-STARRS reaches further than the cone search.** Its `light_curve()` shares `_panstarrs_request` with `_query_region`, so it converts too — which makes `_BaseLightCurveQuery.closest_light_curve` and the `/panstarrs/csv/{obj_id}` route async. Handled via `_ensure_coroutine` rather than by leaving a half-converted module.

## The offload guard

`tests/test_async_offload.py` drops the six entries whose calls are now awaited and keeps the three that remain genuinely sync: `csfd.ebv` (extinction), `SKYBOT_QUERY.find` and `find_vizier.find` (astroquery).

## Testing

```
python -m pytest --basetemp=/tmp/pytest -q   # exit 0, no FAILED/ERROR
```

`tests/test_golden_http.py` passes unchanged. Catalog tests that call a converted method are now `async def` — `asyncio_mode = "auto"` means no decorator is needed. `pre-commit run --all-files` clean.

## Provenance

The first draft of this branch was written by an agent that was interrupted partway through; the work was recovered from its worktree, rebased onto the current #665, finished, and the history regrouped into the four commits here. Reviewing commit by commit should still read cleanly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RNGE2vse7bLQ8dy8PTLamx
