### PR TITLE
Pass host to redis.asyncio.Redis as a keyword

### DIFF
--- a/tests/test_cache_async.py
+++ b/tests/test_cache_async.py
@@ -28,6 +28,8 @@ import pytest
 import redis
 import redis.asyncio
 
+from ztf_viewer import config
+
 LONG_TTL = 3600
 SHORT_TTL = 1
 
@@ -379,3 +381,20 @@ def test_async_redis_backend_client_registry_survives_concurrent_threads():
 
     assert len({id(client) for client in clients}) == N_THREADS, "each loop gets its own client, never a shared one"
     assert all(isinstance(client, redis.asyncio.Redis) for client in clients)
+
+
+def test_production_async_redis_client_factories_build_a_client():
+    """``redis.asyncio.Redis`` takes ``host`` keyword-only; the sync ``StrictRedis`` takes it positionally.
+
+    Every other test here builds its client itself, with keywords, so a positional call left in
+    the production factories stays invisible until a real async ``@cache()`` call reaches Redis --
+    and then every one of them raises ``TypeError``. Constructing a client opens no connection,
+    so this needs no server.
+    """
+    from ztf_viewer.cache.redis import create_async_redis_client
+    from ztf_viewer.catalogs.unavailable_catalogs import _create_async_redis_client
+
+    for factory in (create_async_redis_client, _create_async_redis_client):
+        client = factory()
+        assert isinstance(client, redis.asyncio.Redis)
+        assert client.connection_pool.connection_kwargs["host"] == config.REDIS_HOSTNAME

--- a/ztf_viewer/cache/redis.py
+++ b/ztf_viewer/cache/redis.py
@@ -57,5 +57,10 @@ class AsyncRedisBackend:
         await self._clients.get().set(key, blob, ex=self._ttl)
 
 
+def create_async_redis_client():
+    # Keyword, not positional: `redis.asyncio.Redis` takes `host` keyword-only, unlike `StrictRedis`.
+    return redis.asyncio.Redis(host=config.REDIS_HOSTNAME)
+
+
 def create_async_redis_cache(ttl):
-    return make_async_cache(AsyncRedisBackend(lambda: redis.asyncio.Redis(config.REDIS_HOSTNAME), ttl=ttl))
+    return make_async_cache(AsyncRedisBackend(create_async_redis_client, ttl=ttl))

--- a/ztf_viewer/catalogs/unavailable_catalogs.py
+++ b/ztf_viewer/catalogs/unavailable_catalogs.py
@@ -29,11 +29,14 @@ def _get_unavailable_catalogs():
 unavailable_catalogs = _get_unavailable_catalogs()
 
 
+def _create_async_redis_client():
+    # Keyword, not positional: `redis.asyncio.Redis` takes `host` keyword-only, unlike `StrictRedis`.
+    return redis.asyncio.Redis(host=REDIS_HOSTNAME)
+
+
 def _create_async_redis():
     # No client at construction time: AsyncRedisTTLStringSet builds one lazily, per running loop.
-    return AsyncRedisTTLStringSet(
-        TTL, client_factory=lambda: redis.asyncio.Redis(REDIS_HOSTNAME), prefix="unavailable_catalogs"
-    )
+    return AsyncRedisTTLStringSet(TTL, client_factory=_create_async_redis_client, prefix="unavailable_catalogs")
 
 
 ASYNC_CREATORS = {


### PR DESCRIPTION
## What's broken

`redis.asyncio.Redis.__init__` is **keyword-only** (`def __init__(self, *, host='localhost', ...)`), unlike the sync `StrictRedis`, which takes `host` positionally. Both async client factories passed it positionally:

```python
redis.asyncio.Redis(config.REDIS_HOSTNAME)   # ztf_viewer/cache/redis.py
redis.asyncio.Redis(REDIS_HOSTNAME)          # ztf_viewer/catalogs/unavailable_catalogs.py
```

so the first async cache lookup against the redis backend raises:

```
TypeError: Redis.__init__() takes 1 positional argument but 2 were given
```

## Why it's invisible on master

Nothing takes those paths here yet — every `@cache()`-decorated function on master is still sync, so only `create_redis_cache`/`StrictRedis` ever runs. **Production is unaffected.**

It fires the moment a real async `@cache()` call reaches redis, which is #665 (`aio-snad-apis`): there `find_ztf_oid.find` and friends become `async def`, every one of them raises on the cache lookup, and https://pr665.ztf.snad.space/dr24/view/633207400004730 renders an empty page. Confirmed against the deployed previews:

| preview | `POST /_dash-update-component` |
| --- | --- |
| pr664 | 200 |
| pr665 | **500** |

## Why the tests missed it

Every existing async-redis test builds its own client with keywords (`host=...`, `unix_socket_path=...`), so none of them ever calls the production factory. The two factories are now named at module level, and `test_production_async_redis_client_factories_build_a_client` calls them and asserts the configured host lands in `connection_pool.connection_kwargs`. Constructing a client opens no connection, so the test needs no server.

Verified the test fails without the fix (`TypeError`) and passes with it.

## Testing

- `pytest -q --basetemp=/tmp/pytest` — exit 0, no `FAILED`/`ERROR`.
- `pre-commit run --all-files` — clean.
- End-to-end: ran the #665 branch with this fix against a real redis (`CACHE_TYPE=redis`), loaded `/dr24/view/633207400004730` in a browser — full page renders (light curve, Summary, Neighbours, Metadata, Aladin, all cross-match tables). Same request 500s without the fix.

## Follow-up

#665 and #668 need a rebase onto master once this merges to pick it up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RNGE2vse7bLQ8dy8PTLamx