### PR TITLE
aio-bench: fan-out latency harness with stub catalogs

### DIFF
--- a/plans/misc/fanout_bench.py
+++ b/plans/misc/fanout_bench.py
@@ -1,0 +1,94 @@
+"""Baseline for the `get_summary` per-catalog fan-out (`ztf_viewer/pages/viewer.py`).
+
+`get_summary` loops `for catalog, query in catalog_query_objects().items(): table = await
+query.find(...)`, serially awaiting each catalog's cone-search query. This harness reproduces
+that loop shape over **stub** catalogs -- each `find()` is `sleep(delay)` then return -- rather
+than a recording, because the delay is the point and should be explicit and tunable, not baked
+into a fixture. It is not a test: it prints a wall-clock number and makes no assertion. The
+assertion that concurrent elapsed is ~delay, not ~N*delay, belongs to the PR that makes it true
+by replacing this loop with `asyncio.gather`.
+
+Drives the loop shape rather than the real `get_summary`, because the latter also touches dust
+maps, light-curve fetches, and broker link building -- machinery unrelated to the fan-out and
+irrelevant to what this measures. The loop reproduced here is `get_summary`'s first pass (the one
+that builds the summary table); the second pass, over the same catalogs for ML classifications,
+hits `find()`'s `@cache()` and is nearly free in production, so it is not modeled here.
+
+An `asyncio.gather` run is included alongside the serial one purely as an illustrative reference
+for the size of the win -- it is not `aio-gather`'s implementation and proves nothing on its own.
+
+Run: python plans/misc/fanout_bench.py
+Run: python plans/misc/fanout_bench.py --catalogs 19 --delay 0.5
+"""
+
+import argparse
+import asyncio
+import time
+
+# ~19 mirrors today's catalog_query_objects(); see ztf_viewer/catalogs/conesearch/__init__.py.
+DEFAULT_CATALOGS = 19
+# Large enough that N*delay serial is obviously not delay concurrent, small enough to run fast.
+DEFAULT_DELAY = 0.5
+
+
+class _StubCatalogQuery:
+    """Stands in for a `_BaseCatalogQuery` instance: same `find(ra, dec, radius)` shape."""
+
+    def __init__(self, name, delay):
+        self.query_name = name
+        self._delay = delay
+
+    async def find(self, ra, dec, radius_arcsec):
+        await asyncio.sleep(self._delay)
+        return {"ra": ra, "dec": dec, "radius_arcsec": radius_arcsec, "catalog": self.query_name}
+
+
+def _stub_catalogs(n, delay):
+    return {f"stub-catalog-{i}": _StubCatalogQuery(f"Stub Catalog {i}", delay) for i in range(n)}
+
+
+async def _serial_fanout(catalogs, ra, dec, radius_arcsec):
+    """Mirrors `get_summary`'s current loop: await each catalog's `find()` in turn."""
+    results = {}
+    for name, query in catalogs.items():
+        results[name] = await query.find(ra, dec, radius_arcsec)
+    return results
+
+
+async def _concurrent_fanout(catalogs, ra, dec, radius_arcsec):
+    """Illustrative only -- the real conversion is a separate PR, not this harness."""
+    names = list(catalogs)
+    values = await asyncio.gather(*(catalogs[name].find(ra, dec, radius_arcsec) for name in names))
+    return dict(zip(names, values))
+
+
+def _timed(coro_factory):
+    async def run():
+        start = time.perf_counter()
+        await coro_factory()
+        return time.perf_counter() - start
+
+    return asyncio.run(run())
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    parser.add_argument("--catalogs", type=int, default=DEFAULT_CATALOGS, help="number of stub catalogs")
+    parser.add_argument("--delay", type=float, default=DEFAULT_DELAY, help="per-catalog find() delay, seconds")
+    args = parser.parse_args()
+
+    catalogs = _stub_catalogs(args.catalogs, args.delay)
+    ra, dec, radius_arcsec = 180.0, 0.0, 5.0
+
+    serial = _timed(lambda: _serial_fanout(catalogs, ra, dec, radius_arcsec))
+    concurrent = _timed(lambda: _concurrent_fanout(catalogs, ra, dec, radius_arcsec))
+
+    print(f"{args.catalogs} stub catalogs, {args.delay:.3f}s delay each\n")
+    print(f"{'mode':22s} {'elapsed':>10s} {'expected':>10s}")
+    print("-" * 46)
+    print(f"{'serial (today)':22s} {serial:9.3f}s {args.catalogs * args.delay:9.3f}s")
+    print(f"{'gather (reference)':22s} {concurrent:9.3f}s {args.delay:9.3f}s")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## What

A runnable harness (not a collected test) that reproduces the wall-clock shape of
`get_summary`'s per-catalog fan-out: `plans/misc/fanout_bench.py`, alongside `gil_bench.py`
following its docstring/argparse/table conventions.

## Baseline

```
$ ~/.virtualenvs/web/bin/python plans/misc/fanout_bench.py
19 stub catalogs, 0.500s delay each

mode                      elapsed   expected
----------------------------------------------
serial (today)             9.522s     9.500s
gather (reference)         0.504s     0.500s
```

19 catalogs matches `len(catalog_query_objects())` today. Default delay is 0.5s, large enough
to make the serial-vs-concurrent gap obvious while keeping the run fast; both are CLI args
(`--catalogs`, `--delay`).

## What it drives, and why not the real `get_summary`

I drove the fan-out *shape* `get_summary` contains, not `get_summary` itself. `get_summary`
(`ztf_viewer/pages/viewer.py:1393`) also touches dust maps (`csfd`/`bayestar`), light-curve
fetches (`get_plot_data`), and broker link building — none of that is the fan-out under test,
and stubbing it all out to call the real function would mean measuring mostly harness plumbing.
So the harness reimplements only the loop shape: `for catalog, query in catalogs.items(): table
= await query.find(ra, dec, radius)`, over stub catalogs whose `find()` is `sleep(delay)` then
return.

One more deliberate narrowing: `get_summary` loops over `catalog_query_objects()` *twice* — once
for the summary table, again for ML classifications. The second pass hits `find()`'s `@cache()`
in production and is therefore cheap; unconditionally delaying it again in the stub would
misrepresent today's actual latency. The harness models only the first pass.

The `asyncio.gather` number in the table is illustrative only — it is not `aio-gather`'s
implementation and asserts nothing. The real assertion (elapsed ~delay, not ~N·delay) belongs to
`aio-gather`, which will quote the serial number above as "before".

## Checks

- `~/.virtualenvs/web/bin/python -m pytest --basetemp=/tmp/pytest -q` — green (two pre-existing
  JS9-not-installed skips, unrelated).
- `pytest --collect-only` — `fanout_bench.py` is not collected (`testpaths = ["tests"]`, and the
  file lives under `plans/misc/`).
- `pre-commit run --all-files` — green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RNGE2vse7bLQ8dy8PTLamx
