### PR TITLE
aio-gather: concurrent fan-out for get_summary and related I/O

### DIFF
--- a/plans/misc/get_summary_bench.py
+++ b/plans/misc/get_summary_bench.py
@@ -1,0 +1,100 @@
+"""Cold `get_summary` wall-clock, against real upstreams -- not stubs.
+
+`plans/misc/fanout_bench.py` times the loop *shape* over sleep stubs and imports nothing from
+`ztf_viewer`; it cannot measure the real change. This script calls the real, unwrapped
+`ztf_viewer.pages.viewer.get_summary` for a real object, against the real ~19 cone-search
+catalogs, the real light-curve-features API, and the real dust maps -- the same call a page load
+makes.
+
+"Cold" means the in-memory cache is cleared before every timed call (`CACHE_TYPE=memory` is forced
+below so there is a cache to clear without a Redis instance). It does not flush any upstream's own
+cache/CDN.
+
+Run each timed sample as its **own process**, not via `--runs N>1` in one process: a failing
+catalog gets recorded in the in-memory `unavailable_catalogs` set on its first failure, so a
+second call in the same process skips it near-instantly instead of retrying it -- fast, but no
+longer cold for that catalog. `--runs` exists for a quick illustrative range, not for the
+comparison number.
+
+Compare before/after by running this script once per checkout, each as a fresh process: check out
+the pre-change code for a "before" measurement, the post-change code for "after". Both must be run
+with the same OID, DR, radius and catalog set -- only the loop should differ.
+
+Run: python plans/misc/get_summary_bench.py
+Run: python plans/misc/get_summary_bench.py --oid 633207400004730 --dr dr24 --runs 1
+"""
+
+import argparse
+import asyncio
+import inspect
+import statistics
+import sys
+import time
+from pathlib import Path
+
+# Run as a script, `ztf_viewer` would otherwise resolve through the venv's editable-install
+# pointer (whatever checkout it was `pip install -e`d from) rather than this checkout -- put this
+# repo root first so the code under test is actually the one being edited.
+sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
+
+from ztf_viewer import config  # noqa: E402
+
+# Force the in-memory cache backend before any `ztf_viewer` submodule imports it, the same way
+# tests/pages/test_viewer.py does -- a Redis-backed cache would carry a hit across "cold" runs.
+config.CACHE_TYPE = "memory"
+config.UNAVAILABLE_CATALOGS_CACHE_TYPE = "memory"
+
+DEFAULT_OID = "633207400004730"  # the app's own placeholder example (ztf_viewer/__main__.py)
+DEFAULT_DR = "dr24"
+DEFAULT_RADIUS_ARCSEC = 10.0
+
+
+async def _time_one_call(get_summary, oid, dr, radius_ids, radius_values):
+    from ztf_viewer import cache
+
+    cache.clear_memory_caches()
+    start = time.perf_counter()
+    await get_summary(
+        oid=oid,
+        dr=dr,
+        different_filter=None,
+        different_field=None,
+        radius_ids=radius_ids,
+        radius_values=radius_values,
+    )
+    return time.perf_counter() - start
+
+
+async def _run(oid, dr, radius_arcsec, n_runs):
+    from ztf_viewer.catalogs.conesearch import catalog_query_objects
+    from ztf_viewer.pages import viewer
+
+    get_summary = inspect.unwrap(viewer.get_summary)
+    catalogs = list(catalog_query_objects())
+    radius_ids = [dict(type="search-radius", index=name) for name in catalogs]
+    radius_values = [radius_arcsec] * len(catalogs)
+
+    print(f"oid={oid} dr={dr} catalogs={len(catalogs)} radius_arcsec={radius_arcsec} runs={n_runs}\n")
+
+    elapsed = []
+    for i in range(n_runs):
+        t = await _time_one_call(get_summary, oid, dr, radius_ids, radius_values)
+        elapsed.append(t)
+        print(f"run {i + 1}/{n_runs}: {t:.3f}s")
+
+    print(f"\nmin={min(elapsed):.3f}s  median={statistics.median(elapsed):.3f}s  max={max(elapsed):.3f}s")
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    parser.add_argument("--oid", default=DEFAULT_OID)
+    parser.add_argument("--dr", default=DEFAULT_DR)
+    parser.add_argument("--radius-arcsec", type=float, default=DEFAULT_RADIUS_ARCSEC)
+    parser.add_argument("--runs", type=int, default=1)
+    args = parser.parse_args()
+
+    asyncio.run(_run(args.oid, args.dr, args.radius_arcsec, args.runs))
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/lc_data/test_plot_data.py
+++ b/tests/lc_data/test_plot_data.py
@@ -12,7 +12,15 @@ from unittest.mock import patch
 
 import pytest
 
-from ztf_viewer.lc_data import plot_data as plot_data_module
+from ztf_viewer import config
+
+# `ztf_viewer.catalogs` builds `unavailable_catalogs` at import time, against Redis unless the
+# config says otherwise. Force the in-memory backend before that import happens at all --
+# `tests/conftest.py`'s per-test hook runs too late for a module-level import during collection.
+config.CACHE_TYPE = "memory"
+config.UNAVAILABLE_CATALOGS_CACHE_TYPE = "memory"
+
+from ztf_viewer.lc_data import plot_data as plot_data_module  # noqa: E402
 
 DELAY = 0.2
 

--- a/tests/lc_data/test_plot_data.py
+++ b/tests/lc_data/test_plot_data.py
@@ -1,0 +1,52 @@
+"""`get_plot_data`'s fan-out over the current OID, neighbour OIDs and external light curves.
+
+The three groups of upstream calls (the current OID's ZTF light curve, each neighbour OID's, and
+each external source's -- antares/gaia/panstarrs) are independent of one another and are now
+gathered concurrently. These tests pin that the fan-out actually overlaps in wall time and that a
+failure in one upstream still propagates (nothing here swallows exceptions).
+"""
+
+import asyncio
+import time
+from unittest.mock import patch
+
+import pytest
+
+from ztf_viewer.lc_data import plot_data as plot_data_module
+
+DELAY = 0.2
+
+
+async def test_get_plot_data_fanout_is_concurrent():
+    other_oids = frozenset(["2", "3", "4"])
+
+    async def fake_ztf_dr_lc(oid, dr):
+        await asyncio.sleep(DELAY)
+        return [{"mjd": 58000.0, "mag": 18.0, "magerr": 0.05, "filter": "zg", "oid": oid}]
+
+    async def fake_external(oid, dr, **kwargs):
+        await asyncio.sleep(DELAY)
+        return [{"mjd": 58000.0, "mag": 18.0, "magerr": 0.05, "filter": "zg", "oid": oid}]
+
+    with (
+        patch.object(plot_data_module, "ztf_dr_lc", fake_ztf_dr_lc),
+        patch.dict(plot_data_module.EXTERNAL_LC_DATA, {"antares": fake_external}, clear=True),
+    ):
+        start = time.perf_counter()
+        await plot_data_module.get_plot_data.__wrapped__(
+            "1", "dr24", other_oids=other_oids, external_data={"antares": {}}
+        )
+        elapsed = time.perf_counter() - start
+    # Serial (1 current + 3 neighbours + 1 external) would take 5 * DELAY.
+    assert elapsed < 5 * DELAY / 2
+
+
+async def test_get_plot_data_propagates_upstream_failure():
+    async def fake_ztf_dr_lc(oid, dr):
+        if oid == "2":
+            raise ValueError("neighbour upstream boom")
+        return [{"mjd": 58000.0, "mag": 18.0, "magerr": 0.05, "filter": "zg", "oid": oid}]
+
+    with patch.object(plot_data_module, "ztf_dr_lc", fake_ztf_dr_lc):
+        with pytest.raises(ValueError, match="neighbour upstream boom"):
+            await plot_data_module.get_plot_data.__wrapped__("1", "dr24", other_oids=frozenset(["2"]))

--- a/tests/pages/test_lc_csv.py
+++ b/tests/pages/test_lc_csv.py
@@ -12,8 +12,16 @@ from unittest.mock import patch
 
 import pytest
 
-from ztf_viewer.exceptions import CatalogUnavailable, NotFound
-from ztf_viewer.pages import lc_csv
+from ztf_viewer import config
+
+# `ztf_viewer.catalogs` builds `unavailable_catalogs` at import time, against Redis unless the
+# config says otherwise. Force the in-memory backend before that import happens at all --
+# `tests/conftest.py`'s per-test hook runs too late for a module-level import during collection.
+config.CACHE_TYPE = "memory"
+config.UNAVAILABLE_CATALOGS_CACHE_TYPE = "memory"
+
+from ztf_viewer.exceptions import CatalogUnavailable, NotFound  # noqa: E402
+from ztf_viewer.pages import lc_csv  # noqa: E402
 
 OIDS = ["1", "2", "3", "4", "5"]
 DELAY = 0.2

--- a/tests/pages/test_lc_csv.py
+++ b/tests/pages/test_lc_csv.py
@@ -1,0 +1,103 @@
+"""`get_csv`'s per-OID fan-out: concurrency and exception-filtering semantics.
+
+`get_csv` gathers `find_ztf_oid.get_lc`/`get_meta` and `ztf_ref.get` across every requested OID.
+These tests pin two things a rewrite of that fan-out could silently break: the per-OID work
+actually overlaps in wall time, and only `NotFound`/`CatalogUnavailable` from `ztf_ref.get` are
+swallowed -- everything else must propagate.
+"""
+
+import asyncio
+import time
+from unittest.mock import patch
+
+import pytest
+
+from ztf_viewer.exceptions import CatalogUnavailable, NotFound
+from ztf_viewer.pages import lc_csv
+
+OIDS = ["1", "2", "3", "4", "5"]
+DELAY = 0.2
+
+
+def _lc(oid):
+    return [{"mjd": 58000.0, "mag": 18.0, "magerr": 0.05, "clrcoeff": -0.1}]
+
+
+async def test_get_csv_per_oid_fanout_is_concurrent():
+    async def fake_get_lc(oid, dr, min_mjd=None, max_mjd=None):
+        await asyncio.sleep(DELAY)
+        return _lc(oid)
+
+    async def fake_get_meta(oid, dr):
+        return {"filter": "zg"}
+
+    async def fake_ref_get(oid, dr):
+        raise NotFound
+
+    with (
+        patch.object(lc_csv.find_ztf_oid, "get_lc", fake_get_lc),
+        patch.object(lc_csv.find_ztf_oid, "get_meta", fake_get_meta),
+        patch.object(lc_csv.ztf_ref, "get", fake_ref_get),
+    ):
+        start = time.perf_counter()
+        await lc_csv.get_csv("dr24", OIDS)
+        elapsed = time.perf_counter() - start
+    # Serial would take len(OIDS) * DELAY; concurrent should stay close to one DELAY.
+    assert elapsed < len(OIDS) * DELAY / 2
+
+
+async def test_get_csv_swallows_ref_not_found_and_catalog_unavailable():
+    async def fake_get_lc(oid, dr, min_mjd=None, max_mjd=None):
+        return _lc(oid)
+
+    async def fake_get_meta(oid, dr):
+        return {"filter": "zg"}
+
+    async def fake_ref_get(oid, dr):
+        raise CatalogUnavailable("stub: boom")
+
+    with (
+        patch.object(lc_csv.find_ztf_oid, "get_lc", fake_get_lc),
+        patch.object(lc_csv.find_ztf_oid, "get_meta", fake_get_meta),
+        patch.object(lc_csv.ztf_ref, "get", fake_ref_get),
+    ):
+        csv = await lc_csv.get_csv("dr24", ["1"])
+    assert ",,\r\n" in csv or csv.strip().endswith(",")
+
+
+async def test_get_csv_unexpected_ref_exception_is_not_swallowed():
+    async def fake_get_lc(oid, dr, min_mjd=None, max_mjd=None):
+        return _lc(oid)
+
+    async def fake_get_meta(oid, dr):
+        return {"filter": "zg"}
+
+    async def fake_ref_get(oid, dr):
+        raise ValueError("not one of the swallowed types")
+
+    with (
+        patch.object(lc_csv.find_ztf_oid, "get_lc", fake_get_lc),
+        patch.object(lc_csv.find_ztf_oid, "get_meta", fake_get_meta),
+        patch.object(lc_csv.ztf_ref, "get", fake_ref_get),
+    ):
+        with pytest.raises(ValueError, match="not one of the swallowed types"):
+            await lc_csv.get_csv("dr24", ["1"])
+
+
+async def test_get_csv_raises_not_found_when_lc_is_missing():
+    async def fake_get_lc(oid, dr, min_mjd=None, max_mjd=None):
+        return None
+
+    async def fake_get_meta(oid, dr):
+        return {"filter": "zg"}
+
+    async def fake_ref_get(oid, dr):
+        raise NotFound
+
+    with (
+        patch.object(lc_csv.find_ztf_oid, "get_lc", fake_get_lc),
+        patch.object(lc_csv.find_ztf_oid, "get_meta", fake_get_meta),
+        patch.object(lc_csv.ztf_ref, "get", fake_ref_get),
+    ):
+        with pytest.raises(NotFound):
+            await lc_csv.get_csv("dr24", ["1"])

--- a/tests/pages/test_viewer.py
+++ b/tests/pages/test_viewer.py
@@ -232,6 +232,21 @@ async def test_get_summary_propagates_exception_not_in_the_swallow_list(summary_
             await _run_get_summary(["stub"], summary_upstreams)
 
 
+async def test_get_summary_skips_catalog_with_no_radius_input(summary_upstreams):
+    """Not every registered catalog has a search-radius input in the layout, so `radii` is missing
+    keys for those -- they must be skipped like any other per-catalog failure, not blow up the
+    whole summary. Guards against the radius lookup escaping the swallow list."""
+    catalogs = {"other": _other_succeeding_catalog(), "no-radius": _other_succeeding_catalog()}
+    with patch.object(viewer, "catalog_query_objects", lambda: catalogs):
+        with_missing = await _run_get_summary(["other"], summary_upstreams)
+
+    only_other = {"other": _other_succeeding_catalog()}
+    with patch.object(viewer, "catalog_query_objects", lambda: only_other):
+        without = await _run_get_summary(["other"], summary_upstreams)
+
+    assert _dump(with_missing) == _dump(without)
+
+
 async def test_get_summary_mixed_success_and_failures(summary_upstreams):
     catalogs = {
         "not-found": _StubCatalogQuery("Not Found Catalog", exc=NotFound()),

--- a/tests/pages/test_viewer.py
+++ b/tests/pages/test_viewer.py
@@ -20,9 +20,11 @@ data. Anything Simbad-derived would have unstable column order (set iteration, p
 is out of scope for exactly that reason.
 """
 
+import asyncio
 import contextlib
 import inspect
 import json
+import time
 from unittest.mock import AsyncMock, patch
 
 import pytest
@@ -267,6 +269,47 @@ async def test_get_summary_mixed_success_and_failures(summary_upstreams):
         ],
         ["Coordinates", ": ", "Eq 10.00000 +20.00000", ", ", "Gal 00h40m00s +20d00m00s"],
     ]
+
+
+# ---------------------------------------------------------------------------------------------
+# get_summary -- the catalog loop is now a concurrent gather, not a serial for-loop.
+# ---------------------------------------------------------------------------------------------
+
+
+class _SleepingCatalogQuery(_StubCatalogQuery):
+    """Records call count and sleeps, to prove the catalog loop overlaps in wall time."""
+
+    def __init__(self, name, *, delay=0.0, **kwargs):
+        super().__init__(name, **kwargs)
+        self._delay = delay
+        self.call_count = 0
+
+    async def find(self, ra, dec, radius_arcsec):
+        self.call_count += 1
+        await asyncio.sleep(self._delay)
+        return await super().find(ra, dec, radius_arcsec)
+
+
+async def test_get_summary_catalog_fanout_is_concurrent(summary_upstreams):
+    delay = 0.2
+    n_catalogs = 5
+    catalogs = {
+        f"stub-{i}": _SleepingCatalogQuery(f"Stub {i}", delay=delay, table=_stub_table()) for i in range(n_catalogs)
+    }
+    with patch.object(viewer, "catalog_query_objects", lambda: catalogs):
+        start = time.perf_counter()
+        await _run_get_summary(list(catalogs), summary_upstreams)
+        elapsed = time.perf_counter() - start
+    # Serial would take n_catalogs * delay; concurrent should stay close to one delay.
+    assert elapsed < n_catalogs * delay / 2
+
+
+async def test_get_summary_queries_each_catalog_once(summary_upstreams):
+    """The summary and ML-classification passes must reuse one gather, not query twice."""
+    stub = _SleepingCatalogQuery("Stub", table=_stub_table())
+    with patch.object(viewer, "catalog_query_objects", lambda: {"stub": stub}):
+        await _run_get_summary(["stub"], summary_upstreams)
+    assert stub.call_count == 1
 
 
 # ---------------------------------------------------------------------------------------------

--- a/ztf_viewer/lc_data/plot_data.py
+++ b/ztf_viewer/lc_data/plot_data.py
@@ -1,3 +1,4 @@
+import asyncio
 import math as m
 
 import numpy as np
@@ -113,29 +114,21 @@ async def get_plot_data(
         ...
     }
     """
-    lcs = {
-        cur_oid: plot_data(
-            await ztf_dr_lc(cur_oid, dr),
-            mark_size=3,
-            min_mjd=min_mjd,
-            max_mjd=max_mjd,
-            ref_mag=ref_mag,
-            ref_magerr=ref_magerr,
-        ),
-    }
-    for oid in sorted(other_oids, key=int):
-        lcs[oid] = plot_data(
+    other_oids_sorted = sorted(other_oids, key=int)
+    external_items = list(external_data.items())
+
+    async def _ztf_lc(oid, mark_size):
+        return plot_data(
             await ztf_dr_lc(oid, dr),
-            mark_size=1,
+            mark_size=mark_size,
             min_mjd=min_mjd,
             max_mjd=max_mjd,
             ref_mag=ref_mag,
             ref_magerr=ref_magerr,
         )
-    for id, lc in add_id_to_obs(additional_data).items():
-        lcs[id] = plot_data(lc, mark_size=3, min_mjd=min_mjd, max_mjd=max_mjd, ref_mag=ref_mag, ref_magerr=ref_magerr)
-    for source, kwargs in external_data.items():
-        lcs[source] = plot_data(
+
+    async def _external_lc(source, kwargs):
+        return plot_data(
             await EXTERNAL_LC_DATA[source](cur_oid, dr, **kwargs),
             mark_size=1,
             min_mjd=min_mjd,
@@ -143,6 +136,20 @@ async def get_plot_data(
             ref_mag=ref_mag,
             ref_magerr=ref_magerr,
         )
+
+    cur_lc, *rest = await asyncio.gather(
+        _ztf_lc(cur_oid, mark_size=3),
+        *(_ztf_lc(oid, mark_size=1) for oid in other_oids_sorted),
+        *(_external_lc(source, kwargs) for source, kwargs in external_items),
+    )
+    other_lcs = rest[: len(other_oids_sorted)]
+    external_lcs = rest[len(other_oids_sorted) :]
+
+    lcs = {cur_oid: cur_lc}
+    lcs.update(zip(other_oids_sorted, other_lcs))
+    for id, lc in add_id_to_obs(additional_data).items():
+        lcs[id] = plot_data(lc, mark_size=3, min_mjd=min_mjd, max_mjd=max_mjd, ref_mag=ref_mag, ref_magerr=ref_magerr)
+    lcs.update((source, lc) for (source, _), lc in zip(external_items, external_lcs))
     return lcs
 
 

--- a/ztf_viewer/pages/lc_csv.py
+++ b/ztf_viewer/pages/lc_csv.py
@@ -19,29 +19,37 @@ from ztf_viewer.catalogs.conesearch import ANTARES_QUERY, GAIA_DR3, PANSTARRS_DR
 from ztf_viewer.web import csv_response, error_response, query_args
 
 
+async def _get_oid_df(oid, dr, min_mjd, max_mjd):
+    lc, meta, ref_result = await asyncio.gather(
+        find_ztf_oid.get_lc(oid, dr, min_mjd=min_mjd, max_mjd=max_mjd),
+        find_ztf_oid.get_meta(oid, dr),
+        ztf_ref.get(oid, dr),
+        return_exceptions=True,
+    )
+    if isinstance(lc, BaseException):
+        raise lc
+    if isinstance(meta, BaseException):
+        raise meta
+    if lc is None:
+        raise NotFound
+    oid_df = pd.DataFrame.from_records(lc)
+    oid_df["oid"] = oid
+    oid_df["filter"] = meta["filter"]
+
+    if isinstance(ref_result, BaseException):
+        if not isinstance(ref_result, (NotFound, CatalogUnavailable)):
+            raise ref_result
+        oid_df["ref"] = [None] * oid_df.shape[0]
+        oid_df["ref_err"] = [None] * oid_df.shape[0]
+    else:
+        oid_df["ref"] = ref_result["mag"] + ref_result["magzp"]
+        oid_df["ref_err"] = ref_result["sigmag"]
+
+    return oid_df
+
+
 async def get_csv(dr, oids, min_mjd=None, max_mjd=None):
-    dfs = []
-    for oid in oids:
-        lc = await find_ztf_oid.get_lc(oid, dr, min_mjd=min_mjd, max_mjd=max_mjd)
-        if lc is None:
-            raise NotFound
-        meta = await find_ztf_oid.get_meta(oid, dr)
-        oid_df = pd.DataFrame.from_records(lc)
-        oid_df["oid"] = oid
-        oid_df["filter"] = meta["filter"]
-
-        try:
-            ref = await ztf_ref.get(oid, dr)
-        except NotFound, CatalogUnavailable:
-            oid_df["ref"] = [None] * oid_df.shape[0]
-            oid_df["ref_err"] = [None] * oid_df.shape[0]
-        else:
-            ref_mag = ref["mag"] + ref["magzp"]
-            ref_err = ref["sigmag"]
-            oid_df["ref"] = ref_mag
-            oid_df["ref_err"] = ref_err
-
-        dfs.append(oid_df)
+    dfs = await asyncio.gather(*(_get_oid_df(oid, dr, min_mjd, max_mjd) for oid in oids))
     return await asyncio.to_thread(_dfs_to_csv, dfs)
 
 

--- a/ztf_viewer/pages/viewer.py
+++ b/ztf_viewer/pages/viewer.py
@@ -1397,12 +1397,21 @@ async def get_summary(oid, dr, different_filter, different_field, radius_ids, ra
     ra, dec = await find_ztf_oid.get_coord(oid, dr)
     coord = await find_ztf_oid.get_sky_coord(oid, dr)
 
+    catalogs = catalog_query_objects()
+    catalog_results = await asyncio.gather(
+        *(query.find(ra, dec, radii[catalog]) for catalog, query in catalogs.items()),
+        return_exceptions=True,
+    )
+    catalog_tables = OrderedDict()
+    for (catalog, query), result in zip(catalogs.items(), catalog_results):
+        if isinstance(result, BaseException):
+            if isinstance(result, (NotFound, CatalogUnavailable, KeyError)):
+                continue
+            raise result
+        catalog_tables[catalog] = (query, result)
+
     elements = OrderedDict()
-    for catalog, query in catalog_query_objects().items():
-        try:
-            table = await query.find(ra, dec, radii[catalog])
-        except NotFound, CatalogUnavailable, KeyError:
-            continue
+    for catalog, (query, table) in catalog_tables.items():
         idx = np.argmin(table["separation"])
         row = table[idx]
         for table_field, display_name in SUMMARY_FIELDS.items():
@@ -1465,11 +1474,7 @@ async def get_summary(oid, dr, different_filter, different_field, radius_ids, ra
         pass
 
     ml_classifications = []
-    for catalog, query in catalog_query_objects().items():
-        try:
-            table = await query.find(ra, dec, radii[catalog])
-        except NotFound, CatalogUnavailable, KeyError:
-            continue
+    for catalog, (query, table) in catalog_tables.items():
         if len(table) == 0:
             continue
         idx = np.argmin(table["separation"])
@@ -1561,17 +1566,26 @@ async def get_summary(oid, dr, different_filter, different_field, radius_ids, ra
     [Input("oid", "children"), Input("dr", "children")],
 )
 async def get_metadata(oid, dr):
-    meta = (await find_ztf_oid.get_meta(oid, dr)).copy()
-    meta["coord_string"] = await find_ztf_oid.get_coord_string(oid, dr)
+    meta_result, coord_string, ref_result = await asyncio.gather(
+        find_ztf_oid.get_meta(oid, dr),
+        find_ztf_oid.get_coord_string(oid, dr),
+        ztf_ref.get(oid, dr),
+        return_exceptions=True,
+    )
+    if isinstance(meta_result, BaseException):
+        raise meta_result
+    if isinstance(coord_string, BaseException):
+        raise coord_string
+    meta = meta_result.copy()
+    meta["coord_string"] = coord_string
 
-    try:
-        ref = await ztf_ref.get(oid, dr)
-    except NotFound, CatalogUnavailable:
-        pass
+    if isinstance(ref_result, BaseException):
+        if not isinstance(ref_result, (NotFound, CatalogUnavailable)):
+            raise ref_result
     else:
-        meta["ref_mag"] = ref["mag"] + ref["magzp"]
-        meta["ref_magerr"] = ref["sigmag"]
-        meta["ref_flags"] = ref["flags"]
+        meta["ref_mag"] = ref_result["mag"] + ref_result["magzp"]
+        meta["ref_magerr"] = ref_result["sigmag"]
+        meta["ref_flags"] = ref_result["flags"]
 
     items = [f"**{k}**: {to_str(meta[k])}" for k in METADATA_FIELDS if k in meta]
     column_width = max(map(len, items)) - 2
@@ -1901,9 +1915,11 @@ async def find_neighbours(radius, center_oid, dr, different):
         return html.P("No radius is specified")
     if float(radius) <= 0:
         return html.P("Radius should be positive")
-    ra, dec = await find_ztf_oid.get_coord(center_oid, dr)
+    (ra, dec), meta = await asyncio.gather(
+        find_ztf_oid.get_coord(center_oid, dr),
+        find_ztf_oid.get_meta(center_oid, dr),
+    )
     kwargs = dict(ra=ra, dec=dec, radius_arcsec=radius, dr=dr)
-    meta = await find_ztf_oid.get_meta(center_oid, dr)
     fltr = meta["filter"]
     fieldid = meta["fieldid"]
     j = await find_ztf_circle.find(**kwargs)

--- a/ztf_viewer/pages/viewer.py
+++ b/ztf_viewer/pages/viewer.py
@@ -1397,9 +1397,14 @@ async def get_summary(oid, dr, different_filter, different_field, radius_ids, ra
     ra, dec = await find_ztf_oid.get_coord(oid, dr)
     coord = await find_ztf_oid.get_sky_coord(oid, dr)
 
+    async def find_in_catalog(catalog, query):
+        # radii is keyed by the radius inputs the layout renders, which don't cover every
+        # registered catalog -- the lookup has to fail inside the task so gather returns it.
+        return await query.find(ra, dec, radii[catalog])
+
     catalogs = catalog_query_objects()
     catalog_results = await asyncio.gather(
-        *(query.find(ra, dec, radii[catalog]) for catalog, query in catalogs.items()),
+        *(find_in_catalog(catalog, query) for catalog, query in catalogs.items()),
         return_exceptions=True,
     )
     catalog_tables = OrderedDict()


### PR DESCRIPTION
## Summary

Replaces the serial per-catalog loops in `get_summary`, plus related sequential awaits in
`get_metadata`, `find_neighbours`, `get_plot_data`, and `lc_csv.get_csv`, with
`asyncio.gather`. Per-catalog exception filtering (`NotFound`/`CatalogUnavailable`/`KeyError`
skipped, everything else propagates) is preserved exactly — verified by the inherited
characterization tests from #679, which are unchanged, plus new tests added here.

- `get_summary` (`ztf_viewer/pages/viewer.py`): the two per-catalog loops (summary fields, then
  ML classifications) become one `asyncio.gather(..., return_exceptions=True)`, computed once and
  reused for both passes instead of querying every catalog twice.
- `get_metadata`: `get_meta`/`get_coord_string`/`ztf_ref.get` fetched concurrently.
- `find_neighbours`: `get_coord`/`get_meta` fetched concurrently.
- `get_plot_data` (`ztf_viewer/lc_data/plot_data.py`): the current-OID light curve, every
  neighbour-OID light curve, and every external (antares/gaia/panstarrs) light curve are now
  fetched concurrently.
- `lc_csv.get_csv`: per-OID `get_lc`/`get_meta`/`ztf_ref.get` fetched concurrently, and OIDs
  fan out concurrently too.

## Tests

- `tests/pages/test_viewer.py`: unchanged inherited tests (from #679) all still pass, including
  `test_get_summary_propagates_exception_not_in_the_swallow_list`, which the plan calls out as
  the load-bearing test for this PR's `return_exceptions=True` (a two-loop structure can mask a
  blanket `except`; a consolidated gather cannot). Added `test_get_summary_catalog_fanout_is_concurrent`
  (wall-clock proof the fan-out overlaps) and `test_get_summary_queries_each_catalog_once` (proves
  the second pass reuses the first gather instead of re-querying).
- `tests/pages/test_lc_csv.py` (new): concurrency and exception-filtering tests for `get_csv`.
- `tests/lc_data/test_plot_data.py` (new): concurrency and exception-propagation tests for
  `get_plot_data`.

## Measured wall-clock: cold `get_summary`, real upstreams

Methodology: `plans/misc/get_summary_bench.py` calls the real, unwrapped `get_summary` for
OID `633207400004730`, DR `dr24` (the app's own placeholder example), radius 10″ for all ~19
catalogs, against real upstreams — no stubs. "Cold" means `CACHE_TYPE=memory` with the cache
cleared before the call; each timed sample is its own fresh process, because a catalog that fails
gets recorded in the in-memory `unavailable_catalogs` circuit breaker, so a second call in the same
process would skip it near-instantly rather than retrying it cold. 3 runs each, before (serial
loop, this commit reverted) vs after (this PR):

| | run 1 | run 2 | run 3 | median |
|---|---|---|---|---|
| before (serial) | 18.275s | 18.671s | 18.148s | 18.27s |
| after (gather) | 11.778s | 11.674s | 11.711s | 11.71s |

**~1.56x** on this OID from this machine. Caveats, stated plainly:

- This machine cannot reach CDS (Vizier/Simbad) reliably — confirmed with a plain, non-concurrent
  `requests.get()` to `vizier.cds.unistra.fr` failing at the socket level (`OSError: [Errno 9] Bad
  file descriptor`), independent of any concurrency in this code. 7 of the 19 catalogs are
  Vizier-backed and fail fast (~0.2–0.7s each) via `CatalogUnavailable` in both configurations, so
  they don't bias the *comparison* much, but the catalog data returned is incomplete relative to
  real production traffic.
- SIMBAD is the dominant single-catalog cost in most runs (~10s, hitting this code's own
  `async_timeout` ceiling) — consistent with the plan's own note that "Vizier and Simbad are
  regular offenders." That ~10s cost is paid **once**, absorbed into the concurrent max, in the
  "after" case, and paid **serially**, added to everything else, in the "before" case — which is
  exactly the effect this PR exists to produce. The absolute numbers above are almost certainly
  inflated relative to a host with full CDS reachability; the *shape* of the win (a slow catalog no
  longer serializes the rest) is the transferable result.
- `aio-bench` (`plans/misc/fanout_bench.py`, #674) is **not** used for this number — it drives
  sleep-stubs and imports nothing from `ztf_viewer`, so it can only regress against itself, per
  the plan's own note. **Decided: not converting it into a pytest assertion.** Doing so would only
  assert that `asyncio.gather` beats a serial loop over `asyncio.sleep()`, a language-level fact
  needing no test in this suite. The tests that actually matter — that the gather over the real
  catalog loop overlaps, and that the exception filtering isn't a blanket catch — are the ones
  added to `tests/pages/test_viewer.py`, `test_lc_csv.py`, and `test_plot_data.py` in this PR,
  exercising the real code paths instead of a synthetic harness.

## Two inherited questions — reviewer, decide these

`aio-offload-threads` was dropped (#676/#677), so this is the first PR to fan out ~19 catalogs
with no per-upstream bound underneath it. Two things it was carrying land here:

1. **Should `THREAD_POOL_SIZE` (default 16) change?** I did not find a load-bearing reason to
   change it from this measurement. The bottleneck observed here is upstream latency/reachability
   (SIMBAD's 10s timeout, CDS unreachable from this sandbox), not thread-pool contention — the
   catalogs that do answer quickly (Vizier-backed failures, most JSON APIs) return in well under a
   second each, and 19 fanned-out tasks against a 16-thread pool only queues 3 of them briefly
   behind whichever finish first. I have not run a real concurrent-multi-page-load test, which is
   what would actually stress the pool width (fan-out-width × concurrent pages, per the plan's own
   framing) — that test doesn't exist yet and building it is out of this PR's scope. Leaving it at
   16 for now; if a future load test shows contention, the number lives in one place
   (`config.py`) to change.
2. **Upstream-hammering risk.** Going from serial to 19-way concurrent does mean Vizier/Simbad/etc.
   now all get hit at once per page load instead of one at a time. I did not build a custom
   concurrency primitive to bound this — the plan already rejected `asyncio.Semaphore`,
   `anyio.CapacityLimiter`, and `threading.Semaphore` for this exact problem, with reasons recorded
   in the dropped `aio-offload-threads` entry (unverifiable correctness, cross-loop bound
   breakage, and thread starvation respectively). The real exposure, per the plan's own risk table,
   is CDS-specific: SIMBAD bans an IP for a minute above 10 queries/s and for an hour above 400 in
   10s, and VizieR/MOCServer/Sesame share that origin — and since master plus every `pr<N>` preview
   are separate containers on one host, the number that matters is per-IP, not per-process, so no
   in-process bound could have covered it regardless. This PR does not change that exposure's
   *nature*, only its *timing* (concurrent instead of serial hits, per page load). If it bites in
   practice, per the plan, rate limiting belongs outside the async layer.

## What I found that wasn't in the plan

- **`origin/golden-callbacks` (#679) merged and its branch was deleted while this PR was in
  progress**, along with #680 rewriting the Progress entry. The golden-JSON snapshots this PR was
  originally told to preserve unchanged (`tests/golden/pages_viewer/*.json`) were themselves
  removed in that PR, in favor of relational/projection assertions — see the updated
  `aio-golden-callbacks` Progress entry for why. This branch was rebased onto `master` after that
  landed and now targets `master` directly rather than stacking on a since-merged branch;
  `gh stack link` does not apply for the same reason (there is no longer an open PR to stack onto).
- **A real reachability gap in this sandbox, not in the code**: `vizier.cds.unistra.fr` fails at
  the socket level even for a single, non-concurrent request from this machine. Confirmed this is
  not a concurrency-induced defect (a plain sequential `requests.get()` reproduces it) before
  reading anything into the benchmark numbers.