### PR TITLE
aio-figures: move PNG and PDF figure rendering into the process pool

### DIFF
--- a/plans/misc/figure_pool_bench.py
+++ b/plans/misc/figure_pool_bench.py
@@ -1,0 +1,120 @@
+"""Does moving figure rendering off `asyncio.to_thread` and onto the process pool stop a
+concurrent figure flood from starving unrelated event-loop work?
+
+`plans/misc/gil_bench.py` already showed matplotlib Agg PNG barely scales on threads (1.25x
+on 4) while the PGF/LaTeX PDF path scales well (3.33x, because it waits on a LaTeX child
+process and releases the GIL). This script asks the follow-on question directly: while N
+concurrent figure renders are in flight, does an unrelated coroutine on the same loop keep
+making progress?
+
+The workload goes through the real render path, `ztf_viewer.figure_render.plot_data`, over a
+synthetic light curve shaped like `get_plot_data`'s output (only the keys the renderer reads),
+so no network or cache is needed to run this. Two offload strategies are compared per format:
+
+  - "thread"  -- `asyncio.to_thread`, the mechanism before this change.
+  - "process" -- `ztf_viewer.procpool.run_in_process`, this change.
+
+While the flood runs, a heartbeat coroutine repeatedly does `await asyncio.sleep(0)` on the
+same loop, standing in for "any other request being served concurrently". Its metric is the
+worst gap between two ticks: how long the loop went unresponsive because of the flood.
+
+Run: python plans/misc/figure_pool_bench.py
+Run: python plans/misc/figure_pool_bench.py --renders 4 --n-obs 800 --formats png,pdf
+"""
+
+import argparse
+import asyncio
+import sys
+import time
+from pathlib import Path
+
+# Run as a script, `ztf_viewer` would otherwise resolve through the venv's editable-install
+# pointer rather than this checkout -- put this repo root first, matching get_summary_bench.py.
+sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
+
+from ztf_viewer.figure_render import plot_data
+from ztf_viewer.procpool import run_in_process, shutdown_pool
+
+OID = 1
+FILTERS = ["zg", "zr", "zi"]
+
+
+def _synthetic_lc(n_obs: int) -> dict:
+    """A light curve shaped like one entry of `get_plot_data`'s output -- only the keys
+    `plot_data` actually reads."""
+    obs = [
+        {
+            "mjd": 58000.0 + i * 0.3,
+            "mag": 18.0 + 0.5 * ((i % 7) - 3),
+            "magerr": 0.05 + 0.01 * (i % 5),
+            "filter": FILTERS[i % len(FILTERS)],
+        }
+        for i in range(n_obs)
+    ]
+    return {OID: obs}
+
+
+async def _heartbeat(stop_event: asyncio.Event) -> list[float]:
+    """Ticks on the loop as fast as it's allowed to; records the gap since the last tick."""
+    gaps = []
+    last = time.perf_counter()
+    while not stop_event.is_set():
+        await asyncio.sleep(0)
+        now = time.perf_counter()
+        gaps.append(now - last)
+        last = now
+    return gaps
+
+
+async def _flood_thread(data: dict, fmt: str, n: int) -> None:
+    await asyncio.gather(*(asyncio.to_thread(plot_data, OID, data, fmt=fmt) for _ in range(n)))
+
+
+async def _flood_process(data: dict, fmt: str, n: int) -> None:
+    await asyncio.gather(*(run_in_process(plot_data, OID, data, fmt=fmt) for _ in range(n)))
+
+
+async def _measure(flood, data: dict, fmt: str, n: int) -> tuple[float, float, int]:
+    stop_event = asyncio.Event()
+    heartbeat_task = asyncio.create_task(_heartbeat(stop_event))
+    t0 = time.perf_counter()
+    await flood(data, fmt, n)
+    elapsed = time.perf_counter() - t0
+    stop_event.set()
+    gaps = await heartbeat_task
+    return elapsed, max(gaps) if gaps else 0.0, len(gaps)
+
+
+async def _run_all(n_obs: int, renders: int, formats: list[str]) -> None:
+    data = _synthetic_lc(n_obs)
+
+    # Warm up: first thread call pays interpreter/font-cache warmup, first process call pays
+    # the child's cold import, matplotlib rcParam setup -- neither should count against either
+    # strategy's flood measurement below.
+    await asyncio.to_thread(plot_data, OID, data, fmt="png")
+    await run_in_process(plot_data, OID, data, fmt="png")
+
+    print(f"{renders} concurrent renders, {n_obs} observations each\n")
+    print(f"{'format':6s} {'strategy':18s} {'flood':>10s} {'max heartbeat gap':>20s} {'heartbeat ticks':>16s}")
+    print("-" * 76)
+    for fmt in formats:
+        for label, flood in (("thread (before)", _flood_thread), ("process (after)", _flood_process)):
+            elapsed, max_gap, ticks = await _measure(flood, data, fmt, renders)
+            print(f"{fmt:6s} {label:18s} {elapsed:9.3f}s {max_gap * 1000:17.1f}ms {ticks:16d}")
+
+    shutdown_pool()
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    parser.add_argument("--renders", type=int, default=4, help="number of concurrent figure renders per strategy")
+    parser.add_argument("--n-obs", type=int, default=800, help="observations per synthetic light curve")
+    parser.add_argument("--formats", type=str, default="png,pdf", help="comma-separated formats to test")
+    args = parser.parse_args()
+
+    formats = [f.strip() for f in args.formats.split(",") if f.strip()]
+    asyncio.run(_run_all(args.n_obs, args.renders, formats))
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/pages/test_figure.py
+++ b/tests/pages/test_figure.py
@@ -1,0 +1,116 @@
+"""Unit tests for `ztf_viewer.pages.figure` and `ztf_viewer.figure_render`.
+
+`tests/test_golden_http.py`'s figure tests hit the real ZTF DR API and are network-marked, so
+they only assert the HTTP surface (status, mimetype, magic bytes) and skip cleanly when the
+network is unavailable. These tests cover what that one can't, without any network dependency:
+
+* the renderers against synthetic light curves, for both formats;
+* that `ztf_viewer.figure_render` -- the module the process pool re-imports in every spawned
+  child -- never builds the Dash app as an import side effect, the way `pages.figure` does;
+* that a crashed pool worker surfaces to the HTTP caller as a 500, not a hang, through the real
+  route and the real process pool (only `get_plot_data` and the renderer are stubbed).
+"""
+
+import shutil
+import subprocess
+import sys
+
+import pytest
+
+from ztf_viewer import config
+
+config.CACHE_TYPE = "memory"
+config.UNAVAILABLE_CATALOGS_CACHE_TYPE = "memory"
+
+from ztf_viewer.figure_render import plot_data, plot_folded_data
+
+_PNG_MAGIC = b"\x89PNG\r\n\x1a\n"
+_PDF_MAGIC = b"%PDF-"
+
+
+def _pgf_texsystem():
+    import matplotlib
+
+    return matplotlib.rcParams.get("pgf.texsystem", "xelatex")
+
+
+def _synthetic_lc(n=60):
+    filters = ["zg", "zr", "zi"]
+    return {
+        1: [
+            {"mjd": 58000.0 + i, "mag": 18.0 + 0.1 * (i % 5), "magerr": 0.05, "filter": filters[i % 3]}
+            for i in range(n)
+        ]
+    }
+
+
+def _synthetic_folded_lc(n=60, period=1.5):
+    lc = _synthetic_lc(n)
+    for obs_list in lc.values():
+        for obs in obs_list:
+            obs["folded_time"] = obs["mjd"] % period
+            obs["phase"] = obs["folded_time"] / period
+    return lc
+
+
+def test_plot_data_renders_png():
+    img = plot_data(1, _synthetic_lc(), fmt="png")
+    assert img.startswith(_PNG_MAGIC)
+
+
+def test_plot_data_renders_pdf():
+    texsystem = _pgf_texsystem()
+    if shutil.which(texsystem) is None:
+        pytest.skip(f"LaTeX ({texsystem}) is not available locally; PDF rendering shells out to it")
+    img = plot_data(1, _synthetic_lc(), fmt="pdf")
+    assert img.startswith(_PDF_MAGIC)
+
+
+def test_plot_folded_data_renders_png():
+    img = plot_folded_data(1, _synthetic_folded_lc(), period=1.5, fmt="png")
+    assert img.startswith(_PNG_MAGIC)
+
+
+def test_figure_render_import_has_no_app_side_effects():
+    """Spawn's re-import of a submitted function's module must stay cheap and side-effect-free:
+    a fresh interpreter that only imports `figure_render` must never pull in Dash or the app."""
+    code = (
+        "import sys; import ztf_viewer.figure_render; " "print('dash' in sys.modules, 'ztf_viewer.app' in sys.modules)"
+    )
+    result = subprocess.run([sys.executable, "-c", code], capture_output=True, text=True, check=True)
+    assert result.stdout.strip() == "False False"
+
+
+def _crash_render(*args, **kwargs):
+    import os
+
+    os._exit(1)
+
+
+async def _fake_get_plot_data(oid, dr, **kwargs):
+    return _synthetic_lc()
+
+
+def test_broken_pool_surfaces_as_500(monkeypatch):
+    """A worker killed mid-render must reach the caller as a 500, not a hang or a 200 with a
+    truncated body -- exercised through the real HTTP route and the real process pool.
+
+    Uses its own client with ``raise_server_exceptions=False``: the shared `client` fixture's
+    default (`True`) is a debug convenience that re-raises into the test instead of returning
+    the response a real ASGI server would send, which is exactly the behaviour under test here.
+    """
+    from fastapi.testclient import TestClient
+
+    import ztf_viewer.pages.figure as figure_module
+    from tests.conftest import reset_shared_thread_pool
+
+    monkeypatch.setattr(figure_module, "get_plot_data", _fake_get_plot_data)
+    monkeypatch.setattr(figure_module, "plot_data", _crash_render)
+
+    reset_shared_thread_pool()
+    import ztf_viewer.__main__ as main_module
+
+    with TestClient(main_module.app.server, raise_server_exceptions=False) as test_client:
+        response = test_client.get("/dr24/figure/1")
+
+    assert response.status_code == 500

--- a/ztf_viewer/figure_render.py
+++ b/ztf_viewer/figure_render.py
@@ -1,0 +1,224 @@
+"""Matplotlib rendering for the figure routes.
+
+Kept separate from `ztf_viewer.pages.figure` so it can run in the process pool: the pool's
+spawn start method re-imports a submitted function's module in the child, and
+`ztf_viewer.pages.figure` imports `ztf_viewer.app`, which builds the whole Dash app as an
+import side effect. This module only pulls in matplotlib and plain data, so importing it in a
+fresh worker is cheap and side-effect-free.
+"""
+
+from datetime import UTC, datetime
+from io import BytesIO
+
+import matplotlib
+import matplotlib.backends.backend_pgf
+import numpy as np
+from matplotlib.ticker import AutoMinorLocator
+
+from ztf_viewer.util import FILTER_COLORS, FILTERS_ORDER, ZTF_FILTERS, flip
+
+
+def plot_folded_data(oid, data, period, repeat=None, fmt="png", caption=True, title=None):
+    if repeat is None:
+        repeat = 2
+
+    usetex = fmt == "pdf"
+
+    if title is None:
+        title = str(oid)
+
+    lcs = {}
+    seen_filters = set()
+    for lc_oid, lc in data.items():
+        if len(lc) == 0:
+            continue
+        first_obs = lc[0]
+        fltr = first_obs["filter"]
+        lcs[lc_oid] = {
+            "filter": fltr,
+            "folded_time": np.array([obs["folded_time"] for obs in lc]),
+            "phase": np.array([obs["phase"] for obs in lc]),
+            "m": np.array([obs["mag"] for obs in lc]),
+            "err": np.array([obs["magerr"] for obs in lc]),
+            "color": FILTER_COLORS[fltr],
+            "marker_size": 24 if lc_oid == oid else 12,
+            "label": "" if fltr in seen_filters else fltr,
+            "marker": "o" if lc_oid == oid else "s",
+            "zorder": 2 if lc_oid == oid else 1,
+        }
+        seen_filters.add(fltr)
+
+    fig = matplotlib.figure.Figure(dpi=300, figsize=(6.4, 4.8), constrained_layout=True)
+    if caption:
+        fig.text(
+            0.50,
+            0.005,
+            f"Generated with the SNAD ZTF viewer on {datetime.now(tz=UTC).date()}",
+            ha="center",
+            fontdict={"size": 8, "color": "grey", "usetex": usetex},
+        )
+    ax = fig.subplots()
+    ax.invert_yaxis()
+    ax.set_title(f"{title}, P = {period:.6g} days", usetex=usetex)
+    ax.set_xlabel("phase", usetex=usetex)
+    ax.set_ylabel("magnitude", usetex=usetex)
+    ax.xaxis.set_minor_locator(AutoMinorLocator(2))
+    ax.yaxis.set_minor_locator(AutoMinorLocator(2))
+    ax.tick_params(which="major", direction="in", length=6, width=1.5)
+    ax.tick_params(which="minor", direction="in", length=4, width=1)
+    for lc_oid, lc in sorted(lcs.items(), key=lambda item: FILTERS_ORDER[item[1]["filter"]]):
+        for i in range(-1, repeat + 1):
+            label = ""
+            if i == 0:
+                label = lc["label"]
+            ax.errorbar(
+                lc["phase"] + i,
+                lc["m"],
+                lc["err"],
+                c=lc["color"],
+                label=label,
+                marker="",
+                zorder=lc["zorder"],
+                ls="",
+                alpha=0.7,
+            )
+            ax.scatter(
+                lc["phase"] + i,
+                lc["m"],
+                c=lc["color"],
+                label="",
+                marker=lc["marker"],
+                s=lc["marker_size"],
+                linewidths=0.5,
+                edgecolors="black",
+                zorder=lc["zorder"],
+                alpha=0.7,
+            )
+    ax.set_xlim([-0.1, repeat + 0.1])
+    secax = ax.secondary_xaxis("top", functions=(lambda x: x * period, lambda x: x / period))
+    secax.set_xlabel("Folded time, days")
+    secax.minorticks_on()
+    secax.tick_params(direction="in", which="both")
+    legend_anchor_y = -0.026 if usetex else -0.032
+    ax.legend(
+        bbox_to_anchor=(1, legend_anchor_y),
+        ncol=min(3, len(seen_filters)),
+        columnspacing=0.5,
+        frameon=False,
+        handletextpad=0.0,
+    )
+    bytes_io = save_fig(fig, fmt)
+    return bytes_io.getvalue()
+
+
+def plot_data(oid, data, fmt="png", caption=True, title=None):
+    usetex = fmt == "pdf"
+
+    if title is None:
+        title = str(oid)
+
+    lcs = {}
+    seen_filters = set()
+    for lc_oid, lc in data.items():
+        if len(lc) == 0:
+            continue
+        first_obs = lc[0]
+        fltr = first_obs["filter"]
+
+        marker = "s"
+        if lc_oid == oid:
+            marker = "o"
+        if fltr not in ZTF_FILTERS:
+            marker = "d"
+
+        marker_size = 12
+        if lc_oid == oid:
+            marker_size = 24
+        if fltr not in ZTF_FILTERS:
+            marker_size = 36
+
+        zorder = 1
+        if lc_oid == oid:
+            zorder = 2
+        if fltr not in ZTF_FILTERS:
+            zorder = 3
+
+        lcs[lc_oid] = {
+            "filter": fltr,
+            "t": [obs["mjd"] for obs in lc],
+            "m": [obs["mag"] for obs in lc],
+            "err": [obs["magerr"] for obs in lc],
+            "color": FILTER_COLORS[fltr],
+            "marker_size": marker_size,
+            "label_errorbar": "" if fltr in seen_filters or fltr not in ZTF_FILTERS else fltr,
+            "label_scatter": "" if fltr in seen_filters or fltr in ZTF_FILTERS else fltr,
+            "marker": marker,
+            "zorder": zorder,
+        }
+        seen_filters.add(fltr)
+
+    fig = matplotlib.figure.Figure(dpi=300, figsize=(6.4, 4.8), constrained_layout=True)
+    if caption:
+        fig.text(
+            0.50,
+            0.005,
+            f"Generated with the SNAD ZTF viewer on {datetime.now(tz=UTC).date()}",
+            ha="center",
+            fontdict={"size": 8, "color": "grey", "usetex": usetex},
+        )
+    ax = fig.subplots()
+    ax.invert_yaxis()
+    ax.set_title(title, usetex=usetex)
+    ax.set_xlabel("MJD", usetex=usetex)
+    ax.set_ylabel("magnitude", usetex=usetex)
+    ax.xaxis.set_minor_locator(AutoMinorLocator(2))
+    ax.yaxis.set_minor_locator(AutoMinorLocator(2))
+    ax.tick_params(which="major", direction="in", length=6, width=1.5)
+    ax.tick_params(which="minor", direction="in", length=4, width=1)
+    for lc in lcs.values():
+        ax.errorbar(
+            lc["t"],
+            lc["m"],
+            lc["err"],
+            c=lc["color"],
+            label=lc["label_errorbar"],
+            marker="",
+            zorder=lc["zorder"],
+            ls="",
+            alpha=0.7,
+        )
+        ax.scatter(
+            lc["t"],
+            lc["m"],
+            c=lc["color"],
+            label=lc["label_scatter"],
+            marker=lc["marker"],
+            s=lc["marker_size"],
+            linewidths=0.5,
+            edgecolors="black",
+            zorder=lc["zorder"],
+            alpha=0.7,
+        )
+    legend_anchor_y = -0.026 if usetex else -0.032
+    handles, labels = zip(*sorted(zip(*ax.get_legend_handles_labels()), key=lambda hl: FILTERS_ORDER[hl[1]]))
+    ax.legend(
+        list(flip(handles, 3)),
+        list(flip(labels, 3)),
+        bbox_to_anchor=(1, legend_anchor_y),
+        ncol=min(3, len(seen_filters)),
+        columnspacing=0.5,
+        frameon=False,
+        handletextpad=0.0,
+    )
+    bytes_io = save_fig(fig, fmt)
+    return bytes_io.getvalue()
+
+
+def save_fig(fig, fmt):
+    bytes_io = BytesIO()
+    if fmt == "pdf":
+        canvas = matplotlib.backends.backend_pgf.FigureCanvasPgf(fig)
+        canvas.print_pdf(bytes_io)
+    else:
+        fig.savefig(bytes_io, format=fmt)
+    return bytes_io

--- a/ztf_viewer/pages/figure.py
+++ b/ztf_viewer/pages/figure.py
@@ -1,23 +1,11 @@
-import asyncio
-from datetime import UTC, datetime
-from io import BytesIO
-
-import matplotlib
-import matplotlib.backends.backend_pgf
-import numpy as np
 from fastapi import Body, Request
 from immutabledict import immutabledict
-from matplotlib.ticker import AutoMinorLocator
 
 from ztf_viewer.app import app
+from ztf_viewer.figure_render import plot_data, plot_folded_data
 from ztf_viewer.lc_data.plot_data import get_folded_plot_data, get_plot_data
-from ztf_viewer.util import (
-    FILTER_COLORS,
-    FILTERS_ORDER,
-    ZTF_FILTERS,
-    flip,
-    parse_json_to_immutable,
-)
+from ztf_viewer.procpool import run_in_process
+from ztf_viewer.util import parse_json_to_immutable
 from ztf_viewer.web import binary_response, error_response, query_args
 
 MIMES = {
@@ -47,7 +35,7 @@ async def response_figure_folded(dr: str, oid: int, period: float, request: Requ
         repeat = int(repeat)
 
     data = await get_folded_plot_data(oid, dr, period=period, offset=offset, **kwargs)
-    img = await asyncio.to_thread(
+    img = await run_in_process(
         plot_folded_data, oid, data, period=period, repeat=repeat, fmt=fmt, caption=caption, title=title
     )
 
@@ -66,7 +54,7 @@ async def response_figure(dr: str, oid: int, request: Request, body: bytes = Bod
     title = kwargs.pop("title")
 
     data = await get_plot_data(oid, dr, **kwargs)
-    img = await asyncio.to_thread(plot_data, oid, data, fmt=fmt, caption=caption, title=title)
+    img = await run_in_process(plot_data, oid, data, fmt=fmt, caption=caption, title=title)
 
     return binary_response(img, mimetype=MIMES[fmt], filename=f"{oid}.{fmt}")
 
@@ -100,209 +88,3 @@ def parse_figure_args_helper(args, data=None):
         "additional_data": data,
         "title": title,
     }
-
-
-def plot_folded_data(oid, data, period, repeat=None, fmt="png", caption=True, title=None):
-    if repeat is None:
-        repeat = 2
-
-    usetex = fmt == "pdf"
-
-    if title is None:
-        title = str(oid)
-
-    lcs = {}
-    seen_filters = set()
-    for lc_oid, lc in data.items():
-        if len(lc) == 0:
-            continue
-        first_obs = lc[0]
-        fltr = first_obs["filter"]
-        lcs[lc_oid] = {
-            "filter": fltr,
-            "folded_time": np.array([obs["folded_time"] for obs in lc]),
-            "phase": np.array([obs["phase"] for obs in lc]),
-            "m": np.array([obs["mag"] for obs in lc]),
-            "err": np.array([obs["magerr"] for obs in lc]),
-            "color": FILTER_COLORS[fltr],
-            "marker_size": 24 if lc_oid == oid else 12,
-            "label": "" if fltr in seen_filters else fltr,
-            "marker": "o" if lc_oid == oid else "s",
-            "zorder": 2 if lc_oid == oid else 1,
-        }
-        seen_filters.add(fltr)
-
-    fig = matplotlib.figure.Figure(dpi=300, figsize=(6.4, 4.8), constrained_layout=True)
-    if caption:
-        fig.text(
-            0.50,
-            0.005,
-            f"Generated with the SNAD ZTF viewer on {datetime.now(tz=UTC).date()}",
-            ha="center",
-            fontdict={"size": 8, "color": "grey", "usetex": usetex},
-        )
-    ax = fig.subplots()
-    ax.invert_yaxis()
-    ax.set_title(f"{title}, P = {period:.6g} days", usetex=usetex)
-    ax.set_xlabel("phase", usetex=usetex)
-    ax.set_ylabel("magnitude", usetex=usetex)
-    ax.xaxis.set_minor_locator(AutoMinorLocator(2))
-    ax.yaxis.set_minor_locator(AutoMinorLocator(2))
-    ax.tick_params(which="major", direction="in", length=6, width=1.5)
-    ax.tick_params(which="minor", direction="in", length=4, width=1)
-    for lc_oid, lc in sorted(lcs.items(), key=lambda item: FILTERS_ORDER[item[1]["filter"]]):
-        for i in range(-1, repeat + 1):
-            label = ""
-            if i == 0:
-                label = lc["label"]
-            ax.errorbar(
-                lc["phase"] + i,
-                lc["m"],
-                lc["err"],
-                c=lc["color"],
-                label=label,
-                marker="",
-                zorder=lc["zorder"],
-                ls="",
-                alpha=0.7,
-            )
-            ax.scatter(
-                lc["phase"] + i,
-                lc["m"],
-                c=lc["color"],
-                label="",
-                marker=lc["marker"],
-                s=lc["marker_size"],
-                linewidths=0.5,
-                edgecolors="black",
-                zorder=lc["zorder"],
-                alpha=0.7,
-            )
-    ax.set_xlim([-0.1, repeat + 0.1])
-    secax = ax.secondary_xaxis("top", functions=(lambda x: x * period, lambda x: x / period))
-    secax.set_xlabel("Folded time, days")
-    secax.minorticks_on()
-    secax.tick_params(direction="in", which="both")
-    legend_anchor_y = -0.026 if usetex else -0.032
-    ax.legend(
-        bbox_to_anchor=(1, legend_anchor_y),
-        ncol=min(3, len(seen_filters)),
-        columnspacing=0.5,
-        frameon=False,
-        handletextpad=0.0,
-    )
-    bytes_io = save_fig(fig, fmt)
-    return bytes_io.getvalue()
-
-
-def plot_data(oid, data, fmt="png", caption=True, title=None):
-    usetex = fmt == "pdf"
-
-    if title is None:
-        title = str(oid)
-
-    lcs = {}
-    seen_filters = set()
-    for lc_oid, lc in data.items():
-        if len(lc) == 0:
-            continue
-        first_obs = lc[0]
-        fltr = first_obs["filter"]
-
-        marker = "s"
-        if lc_oid == oid:
-            marker = "o"
-        if fltr not in ZTF_FILTERS:
-            marker = "d"
-
-        marker_size = 12
-        if lc_oid == oid:
-            marker_size = 24
-        if fltr not in ZTF_FILTERS:
-            marker_size = 36
-
-        zorder = 1
-        if lc_oid == oid:
-            zorder = 2
-        if fltr not in ZTF_FILTERS:
-            zorder = 3
-
-        lcs[lc_oid] = {
-            "filter": fltr,
-            "t": [obs["mjd"] for obs in lc],
-            "m": [obs["mag"] for obs in lc],
-            "err": [obs["magerr"] for obs in lc],
-            "color": FILTER_COLORS[fltr],
-            "marker_size": marker_size,
-            "label_errorbar": "" if fltr in seen_filters or fltr not in ZTF_FILTERS else fltr,
-            "label_scatter": "" if fltr in seen_filters or fltr in ZTF_FILTERS else fltr,
-            "marker": marker,
-            "zorder": zorder,
-        }
-        seen_filters.add(fltr)
-
-    fig = matplotlib.figure.Figure(dpi=300, figsize=(6.4, 4.8), constrained_layout=True)
-    if caption:
-        fig.text(
-            0.50,
-            0.005,
-            f"Generated with the SNAD ZTF viewer on {datetime.now(tz=UTC).date()}",
-            ha="center",
-            fontdict={"size": 8, "color": "grey", "usetex": usetex},
-        )
-    ax = fig.subplots()
-    ax.invert_yaxis()
-    ax.set_title(title, usetex=usetex)
-    ax.set_xlabel("MJD", usetex=usetex)
-    ax.set_ylabel("magnitude", usetex=usetex)
-    ax.xaxis.set_minor_locator(AutoMinorLocator(2))
-    ax.yaxis.set_minor_locator(AutoMinorLocator(2))
-    ax.tick_params(which="major", direction="in", length=6, width=1.5)
-    ax.tick_params(which="minor", direction="in", length=4, width=1)
-    for lc in lcs.values():
-        ax.errorbar(
-            lc["t"],
-            lc["m"],
-            lc["err"],
-            c=lc["color"],
-            label=lc["label_errorbar"],
-            marker="",
-            zorder=lc["zorder"],
-            ls="",
-            alpha=0.7,
-        )
-        ax.scatter(
-            lc["t"],
-            lc["m"],
-            c=lc["color"],
-            label=lc["label_scatter"],
-            marker=lc["marker"],
-            s=lc["marker_size"],
-            linewidths=0.5,
-            edgecolors="black",
-            zorder=lc["zorder"],
-            alpha=0.7,
-        )
-    legend_anchor_y = -0.026 if usetex else -0.032
-    handles, labels = zip(*sorted(zip(*ax.get_legend_handles_labels()), key=lambda hl: FILTERS_ORDER[hl[1]]))
-    ax.legend(
-        list(flip(handles, 3)),
-        list(flip(labels, 3)),
-        bbox_to_anchor=(1, legend_anchor_y),
-        ncol=min(3, len(seen_filters)),
-        columnspacing=0.5,
-        frameon=False,
-        handletextpad=0.0,
-    )
-    bytes_io = save_fig(fig, fmt)
-    return bytes_io.getvalue()
-
-
-def save_fig(fig, fmt):
-    bytes_io = BytesIO()
-    if fmt == "pdf":
-        canvas = matplotlib.backends.backend_pgf.FigureCanvasPgf(fig)
-        canvas.print_pdf(bytes_io)
-    else:
-        fig.savefig(bytes_io, format=fmt)
-    return bytes_io


### PR DESCRIPTION
## Purpose

Moves `ztf_viewer/pages/figure.py`'s matplotlib rendering off `asyncio.to_thread` and onto the
process pool from #685, for **both PNG and PDF**. PNG is the default format and the common case,
and it is the one that benefits most: matplotlib Agg rendering barely scales on threads (the
`aio-profile` measurement table in the plan puts it at 1.25x on 4 threads, essentially GIL-bound),
while PDF's LaTeX child process already overlaps reasonably on threads (3.33x). Both move together
so `save_fig`'s format dispatch stays one code path instead of splitting pool/no-pool by format.

## Where the renderers live now, and why

New module: `ztf_viewer/figure_render.py`, holding `plot_data`, `plot_folded_data`, `save_fig`
(moved verbatim from `pages/figure.py`) plus their matplotlib/numpy/`ztf_viewer.util` imports.
`pages/figure.py` keeps only the route handlers and `parse_figure_args_helper`.

This split exists because of how `run_in_process` works: under spawn (macOS default), the child
re-imports the *module* the submitted function belongs to. `ztf_viewer.pages.figure` imports
`ztf_viewer.app`, which builds the whole Dash app as an import side effect — re-running that in
every spawned worker would be expensive and is not something to rely on being safe. Verified
empirically, not assumed: spawned a real child via `multiprocessing.get_context("spawn")`, called
`figure_render.plot_data` in it, and inspected `sys.modules` afterward. Only `ztf_viewer`,
`ztf_viewer.figure_render`, and `ztf_viewer.util` were imported — never `ztf_viewer.procpool`,
never `ztf_viewer.app`, never `dash`. `figure_render.py` only imports matplotlib and
`ztf_viewer.util` (astropy/numpy, no app machinery), so this holds regardless of how `procpool.py`
itself is refactored, as long as `run_in_process(fn, *args, **kwargs)`'s signature stays stable.

## Measurements

**Picklability** (plan claim: "inputs are already plain dicts/lists ... so pickling is cheap" —
confirmed, with numbers): fetched a real light curve via `get_plot_data` (633207400004730, dr24,
832 observations). `pickle.dumps` = 1.6 ms, `pickle.loads` = 0.7 ms, 183 KB. Note the
`additional_data` `immutabledict` the plan flagged never crosses the process boundary at all — it's
consumed inside `get_plot_data` (which stays on the event loop) and only that call's plain-dict
return value is what gets pickled to the child.

**Cold-start per worker** (spawn re-imports matplotlib from scratch): importing
`figure_render` + rendering the first PNG in a fresh spawned worker costs ~525 ms total (~525 ms
import, ~130-160 ms steady-state render after that on the same reused worker). That's paid once
per worker process, amortized over that worker's lifetime — not per request. Decided against
adding a pool `initializer=` for pre-warming: "several seconds" would have justified it, ~525 ms
one-time-per-worker doesn't. `procpool.py` is untouched here — this PR only depends on
`run_in_process(fn, *args, **kwargs)`, whose signature held across both of #685's reworks.

**LaTeX in a child**: confirmed working — both the direct smoke test and the real
`test_figure_pdf` golden test go through a spawned worker end-to-end and produce a valid PDF via
`FigureCanvasPgf.print_pdf`.

**Concurrent flood vs. unrelated event-loop work** (`plans/misc/figure_pool_bench.py`, real
`figure_render.plot_data` over a synthetic 800-observation light curve, 4 concurrent renders,
heartbeat = `await asyncio.sleep(0)` in a loop on the same event loop, standing in for "another
request being served concurrently"):

| format | strategy | flood wall time | max heartbeat gap | heartbeat ticks |
| --- | --- | --- | --- | --- |
| png | thread (before) | 0.412s | 38.9ms | 5,567 |
| png | process (after) | 0.445s | **9.6ms** | 29,311 |
| pdf | thread (before) | 2.313s | 30.3ms | 138,593 |
| pdf | process (after) | 2.079s | **0.6ms** | 144,495 |

Both formats show the loop staying far more responsive under process-pool offload: PNG's worst
stall drops ~4x (38.9ms → 9.6ms) and PDF's drops ~50x (30.3ms → 0.6ms), while flood wall time is
essentially unchanged (rendering itself isn't the thing the pool speeds up — it moves the GIL
contention off the loop). This matches the plan's F8 correction: PNG was the case that actually
needed the pool, and it's the one that shows the clearer relative improvement in loop
responsiveness even though its own render is cheaper than PDF's.

## Tests

- `tests/test_golden_http.py`'s three figure tests (`test_figure_png`, `test_figure_pdf`,
  `test_figure_folded`) are **unchanged** and pass, exercising the real route → real process pool
  → real LaTeX path end-to-end against a live object.
- New `tests/pages/test_figure.py`: renderer unit tests against synthetic data (no network) for
  both formats, an import-hygiene test that `figure_render` never pulls in Dash/`ztf_viewer.app`,
  and a test that a worker killed mid-render (`os._exit(1)`, via the real process pool) surfaces
  to the HTTP caller as a 500 — not a hang — through the real route.

Full suite: **425 passed, 2 skipped** (was 420 passed, 2 skipped on `procpool`; the 5 new
`test_figure.py` tests account for the difference). `pre-commit run --all-files` clean.

## Known limitations / left out

- No pool `initializer=` for pre-warming matplotlib — see the cold-start measurement above.
- `procpool.py` itself is untouched; this PR only depends on `run_in_process(fn, *args,
  **kwargs)`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---

**Rebased onto `procpool`'s current tip** (`16f0953`, the review rework plus lazy pool
construction). Two things the rebase had to carry, both from the ruff 0.16.4 autoupdate (#682)
landing on `master` underneath this branch:

- `parse_figure_args_helper`'s `return dict(...)` → dict literal (C408) — the one real conflict.
- The autoupdate also fixed `datetime.now()` → `datetime.now(tz=UTC)` and two `fontdict=dict(...)`
  literals *inside* `plot_data`/`plot_folded_data`. Those functions moved to `figure_render.py` in
  this PR, so git took the new file verbatim at its pre-autoupdate text and the fixes would have
  been silently dropped. Reapplied by hand; the three moved functions now compare AST-identical to
  their post-autoupdate form on the base.
- Ruff 0.16.4 also removed the `# noqa: E402` comments this branch added, as unused (RUF100).
  Verified that E402 genuinely does not fire on the `sys.path.insert` preamble under the repo's
  config, and that no `# noqa: E402` remains anywhere in the repo — the autoupdate had already
  stripped `master`'s own bench script.
