### PR TITLE
Vectorize plot_data's loop; promote lc_csv to the process pool

### DIFF
--- a/tests/lc_data/test_plot_data_vectorized.py
+++ b/tests/lc_data/test_plot_data_vectorized.py
@@ -1,0 +1,136 @@
+"""Pins `plot_data`'s numpy-vectorized rewrite against the per-observation loop it replaced.
+
+`plans/misc/profile_candidates_bench.py` measured the loop as the single largest contributor to
+wall time in this module (dominated by constructing one `astropy.time.Time` per observation) and
+about 10x slower than a batched, vectorized version at realistic sizes. `_plot_data_loop_reference`
+below is that original loop, kept here only as a correctness oracle -- the module itself no longer
+has two implementations to choose between.
+"""
+
+import math
+
+import numpy as np
+
+from ztf_viewer.lc_data.plot_data import MJD_OFFSET, plot_data
+from ztf_viewer.util import ABZPMAG_JY, FILTERS_ORDER, LN10_04, immutabledefaultdict
+
+
+def _plot_data_loop_reference(lc, mark_size=1, min_mjd=None, max_mjd=None, ref_mag=None, ref_magerr=None):
+    if ref_mag is None:
+        ref_mag = immutabledefaultdict(lambda: np.inf)
+    if ref_magerr is None:
+        ref_magerr = immutabledefaultdict(float)
+    if min_mjd is None:
+        min_mjd = -np.inf
+    if max_mjd is None:
+        max_mjd = np.inf
+
+    from astropy.time import Time
+
+    data = []
+    for obs in lc:
+        if not min_mjd <= obs["mjd"] <= max_mjd:
+            continue
+
+        obs["mark_size"] = mark_size
+
+        ref_flux = 10 ** (-0.4 * (ref_mag[obs["oid"]] - ABZPMAG_JY))
+        ref_fluxerr = LN10_04 * ref_flux * ref_magerr[obs["oid"]]
+
+        obs["flux_Jy"] = 10 ** (-0.4 * (obs["mag"] - ABZPMAG_JY))
+        obs["fluxerr_Jy"] = LN10_04 * obs["flux_Jy"] * obs["magerr"]
+
+        obs["diffflux_Jy"] = obs["flux_Jy"] - ref_flux
+        obs["difffluxerr_Jy"] = np.hypot(obs["fluxerr_Jy"], ref_fluxerr)
+        obs["ref_flux"] = ref_flux
+
+        if obs["diffflux_Jy"] <= 0 or obs["diffflux_Jy"] < obs["difffluxerr_Jy"]:
+            obs["diffmag"] = np.inf
+            obs["diffmagerr_plus"] = np.inf
+            obs["diffmagerr_minus"] = np.inf
+        else:
+            obs["diffmag"] = ABZPMAG_JY - 2.5 * math.log10(obs["diffflux_Jy"])
+            obs["diffmagerr_plus"] = -2.5 * math.log10(1 - obs["difffluxerr_Jy"] / obs["diffflux_Jy"])
+            obs["diffmagerr_minus"] = 2.5 * math.log10(1 + obs["difffluxerr_Jy"] / obs["diffflux_Jy"])
+
+        obs[f"mjd_{MJD_OFFSET}"] = obs["mjd"] - MJD_OFFSET
+        time = Time(obs["mjd"], format="mjd")
+        obs["date"] = time.strftime("%Y-%m-%d")
+
+        data.append(obs)
+
+    return sorted(data, key=lambda obs: (FILTERS_ORDER[obs["filter"]], obs["mjd"]))
+
+
+def _assert_same_result(loop_out, vec_out):
+    assert len(loop_out) == len(vec_out)
+    for a, b in zip(loop_out, vec_out):
+        assert a.keys() == b.keys()
+        for key, av in a.items():
+            bv = b[key]
+            if isinstance(av, float):
+                assert (math.isinf(av) and math.isinf(bv) and (av > 0) == (bv > 0)) or math.isclose(
+                    av, bv, rel_tol=1e-9, abs_tol=1e-12
+                ), (key, av, bv)
+            else:
+                assert av == bv, (key, av, bv)
+
+
+def _random_lc(n, seed, n_oids=1, filters=("zg", "zr", "zi")):
+    rng = np.random.default_rng(seed)
+    return [
+        {
+            "mjd": float(58000 + rng.uniform(0, 2000)),
+            "mag": float(rng.uniform(14, 22)),
+            "magerr": float(rng.uniform(0.005, 0.5)),
+            "filter": filters[int(rng.integers(0, len(filters)))],
+            "oid": int(rng.integers(1, n_oids + 1)),
+        }
+        for _ in range(n)
+    ]
+
+
+def test_plot_data_matches_reference_loop_on_realistic_random_input():
+    lc = _random_lc(2000, seed=1, n_oids=3)
+    ref_mag = immutabledefaultdict(lambda: np.inf, {1: 19.5, 2: 18.2, 3: 20.1})
+    ref_magerr = immutabledefaultdict(float, {1: 0.02, 2: 0.05, 3: 0.01})
+
+    loop_out = _plot_data_loop_reference(
+        [dict(o) for o in lc], mark_size=3, min_mjd=58200.0, max_mjd=59800.0, ref_mag=ref_mag, ref_magerr=ref_magerr
+    )
+    vec_out = plot_data(
+        [dict(o) for o in lc], mark_size=3, min_mjd=58200.0, max_mjd=59800.0, ref_mag=ref_mag, ref_magerr=ref_magerr
+    )
+    assert len(vec_out) > 0
+    _assert_same_result(loop_out, vec_out)
+
+
+def test_plot_data_matches_reference_loop_with_default_ref_mag():
+    """Default ref_mag/ref_magerr (no reference catalog match) drives ref_flux to zero."""
+    lc = _random_lc(500, seed=2)
+    loop_out = _plot_data_loop_reference([dict(o) for o in lc])
+    vec_out = plot_data([dict(o) for o in lc])
+    _assert_same_result(loop_out, vec_out)
+
+
+def test_plot_data_matches_reference_loop_on_negative_diffflux():
+    """Observations fainter than the reference flip diffflux_Jy negative -- the inf branch."""
+    lc = [
+        {"mjd": 58500.0 + i, "mag": 25.0, "magerr": 0.3, "filter": "zg", "oid": 1}  # much fainter than ref
+        for i in range(20)
+    ]
+    ref_mag = immutabledefaultdict(lambda: np.inf, {1: 15.0})
+    ref_magerr = immutabledefaultdict(float, {1: 0.01})
+    loop_out = _plot_data_loop_reference([dict(o) for o in lc], ref_mag=ref_mag, ref_magerr=ref_magerr)
+    vec_out = plot_data([dict(o) for o in lc], ref_mag=ref_mag, ref_magerr=ref_magerr)
+    assert all(math.isinf(obs["diffmag"]) for obs in vec_out)
+    _assert_same_result(loop_out, vec_out)
+
+
+def test_plot_data_empty_input():
+    assert plot_data([]) == []
+
+
+def test_plot_data_all_observations_filtered_out_by_mjd_range():
+    lc = _random_lc(10, seed=3)
+    assert plot_data([dict(o) for o in lc], min_mjd=1.0, max_mjd=2.0) == []

--- a/tests/lc_data/test_plot_data_vectorized.py
+++ b/tests/lc_data/test_plot_data_vectorized.py
@@ -10,6 +10,7 @@ has two implementations to choose between.
 import math
 
 import numpy as np
+from astropy.time import Time
 
 from ztf_viewer.lc_data.plot_data import MJD_OFFSET, plot_data
 from ztf_viewer.util import ABZPMAG_JY, FILTERS_ORDER, LN10_04, immutabledefaultdict
@@ -24,8 +25,6 @@ def _plot_data_loop_reference(lc, mark_size=1, min_mjd=None, max_mjd=None, ref_m
         min_mjd = -np.inf
     if max_mjd is None:
         max_mjd = np.inf
-
-    from astropy.time import Time
 
     data = []
     for obs in lc:

--- a/tests/lc_data/test_plot_data_vectorized.py
+++ b/tests/lc_data/test_plot_data_vectorized.py
@@ -1,135 +1,153 @@
-"""Pins `plot_data`'s numpy-vectorized rewrite against the per-observation loop it replaced.
+"""`plot_data`'s output contract: the photometry it derives, the ordering, and the mutation.
 
-`plans/misc/profile_candidates_bench.py` measured the loop as the single largest contributor to
-wall time in this module (dominated by constructing one `astropy.time.Time` per observation) and
-about 10x slower than a batched, vectorized version at realistic sizes. `_plot_data_loop_reference`
-below is that original loop, kept here only as a correctness oracle -- the module itself no longer
-has two implementations to choose between.
+`plot_data` derives everything from AB magnitudes, so with `ABZPMAG_JY = 8.9` the magnitudes
+below convert to exact round fluxes and the expected values can be written as literals.
 """
 
-import math
-
 import numpy as np
-from astropy.time import Time
+import pytest
 
 from ztf_viewer.lc_data.plot_data import MJD_OFFSET, plot_data
-from ztf_viewer.util import ABZPMAG_JY, FILTERS_ORDER, LN10_04, immutabledefaultdict
+from ztf_viewer.util import ABZPMAG_JY, immutabledefaultdict
+
+MAG_1_JY = ABZPMAG_JY
+MAG_1E4_JY = 18.9
+MAG_1E5_JY = 21.4
+
+DERIVED_KEYS = {
+    "mark_size",
+    "flux_Jy",
+    "fluxerr_Jy",
+    "diffflux_Jy",
+    "difffluxerr_Jy",
+    "ref_flux",
+    "diffmag",
+    "diffmagerr_plus",
+    "diffmagerr_minus",
+    f"mjd_{MJD_OFFSET}",
+    "date",
+}
 
 
-def _plot_data_loop_reference(lc, mark_size=1, min_mjd=None, max_mjd=None, ref_mag=None, ref_magerr=None):
-    if ref_mag is None:
-        ref_mag = immutabledefaultdict(lambda: np.inf)
-    if ref_magerr is None:
-        ref_magerr = immutabledefaultdict(float)
-    if min_mjd is None:
-        min_mjd = -np.inf
-    if max_mjd is None:
-        max_mjd = np.inf
-
-    data = []
-    for obs in lc:
-        if not min_mjd <= obs["mjd"] <= max_mjd:
-            continue
-
-        obs["mark_size"] = mark_size
-
-        ref_flux = 10 ** (-0.4 * (ref_mag[obs["oid"]] - ABZPMAG_JY))
-        ref_fluxerr = LN10_04 * ref_flux * ref_magerr[obs["oid"]]
-
-        obs["flux_Jy"] = 10 ** (-0.4 * (obs["mag"] - ABZPMAG_JY))
-        obs["fluxerr_Jy"] = LN10_04 * obs["flux_Jy"] * obs["magerr"]
-
-        obs["diffflux_Jy"] = obs["flux_Jy"] - ref_flux
-        obs["difffluxerr_Jy"] = np.hypot(obs["fluxerr_Jy"], ref_fluxerr)
-        obs["ref_flux"] = ref_flux
-
-        if obs["diffflux_Jy"] <= 0 or obs["diffflux_Jy"] < obs["difffluxerr_Jy"]:
-            obs["diffmag"] = np.inf
-            obs["diffmagerr_plus"] = np.inf
-            obs["diffmagerr_minus"] = np.inf
-        else:
-            obs["diffmag"] = ABZPMAG_JY - 2.5 * math.log10(obs["diffflux_Jy"])
-            obs["diffmagerr_plus"] = -2.5 * math.log10(1 - obs["difffluxerr_Jy"] / obs["diffflux_Jy"])
-            obs["diffmagerr_minus"] = 2.5 * math.log10(1 + obs["difffluxerr_Jy"] / obs["diffflux_Jy"])
-
-        obs[f"mjd_{MJD_OFFSET}"] = obs["mjd"] - MJD_OFFSET
-        time = Time(obs["mjd"], format="mjd")
-        obs["date"] = time.strftime("%Y-%m-%d")
-
-        data.append(obs)
-
-    return sorted(data, key=lambda obs: (FILTERS_ORDER[obs["filter"]], obs["mjd"]))
+def _obs(mjd=58000.0, mag=MAG_1E4_JY, magerr=0.1, band="zg", oid=1):
+    return {"mjd": mjd, "mag": mag, "magerr": magerr, "filter": band, "oid": oid}
 
 
-def _assert_same_result(loop_out, vec_out):
-    assert len(loop_out) == len(vec_out)
-    for a, b in zip(loop_out, vec_out):
-        assert a.keys() == b.keys()
-        for key, av in a.items():
-            bv = b[key]
-            if isinstance(av, float):
-                assert (math.isinf(av) and math.isinf(bv) and (av > 0) == (bv > 0)) or math.isclose(
-                    av, bv, rel_tol=1e-9, abs_tol=1e-12
-                ), (key, av, bv)
-            else:
-                assert av == bv, (key, av, bv)
+def _ref(mag=None, magerr=None):
+    ref_mag = immutabledefaultdict(lambda: np.inf, {} if mag is None else {1: mag})
+    ref_magerr = immutabledefaultdict(float, {} if magerr is None else {1: magerr})
+    return {"ref_mag": ref_mag, "ref_magerr": ref_magerr}
 
 
-def _random_lc(n, seed, n_oids=1, filters=("zg", "zr", "zi")):
-    rng = np.random.default_rng(seed)
-    return [
-        {
-            "mjd": float(58000 + rng.uniform(0, 2000)),
-            "mag": float(rng.uniform(14, 22)),
-            "magerr": float(rng.uniform(0.005, 0.5)),
-            "filter": filters[int(rng.integers(0, len(filters)))],
-            "oid": int(rng.integers(1, n_oids + 1)),
-        }
-        for _ in range(n)
-    ]
+@pytest.mark.parametrize("mag, flux_Jy", [(MAG_1_JY, 1.0), (MAG_1E4_JY, 1e-4), (MAG_1E5_JY, 1e-5)])
+def test_flux_is_the_ab_magnitude_in_janskys(mag, flux_Jy):
+    (obs,) = plot_data([_obs(mag=mag)])
+    assert obs["flux_Jy"] == pytest.approx(flux_Jy)
 
 
-def test_plot_data_matches_reference_loop_on_realistic_random_input():
-    lc = _random_lc(2000, seed=1, n_oids=3)
-    ref_mag = immutabledefaultdict(lambda: np.inf, {1: 19.5, 2: 18.2, 3: 20.1})
-    ref_magerr = immutabledefaultdict(float, {1: 0.02, 2: 0.05, 3: 0.01})
-
-    loop_out = _plot_data_loop_reference(
-        [dict(o) for o in lc], mark_size=3, min_mjd=58200.0, max_mjd=59800.0, ref_mag=ref_mag, ref_magerr=ref_magerr
-    )
-    vec_out = plot_data(
-        [dict(o) for o in lc], mark_size=3, min_mjd=58200.0, max_mjd=59800.0, ref_mag=ref_mag, ref_magerr=ref_magerr
-    )
-    assert len(vec_out) > 0
-    _assert_same_result(loop_out, vec_out)
+def test_flux_uncertainty_scales_with_flux_and_magerr():
+    (obs,) = plot_data([_obs(mag=MAG_1E4_JY, magerr=0.1)])
+    assert obs["fluxerr_Jy"] == pytest.approx(9.210340371976186e-06)
 
 
-def test_plot_data_matches_reference_loop_with_default_ref_mag():
-    """Default ref_mag/ref_magerr (no reference catalog match) drives ref_flux to zero."""
-    lc = _random_lc(500, seed=2)
-    loop_out = _plot_data_loop_reference([dict(o) for o in lc])
-    vec_out = plot_data([dict(o) for o in lc])
-    _assert_same_result(loop_out, vec_out)
+def test_without_a_reference_match_diffmag_is_the_input_magnitude():
+    """An unmatched oid gets `ref_mag = inf`, i.e. zero reference flux, so nothing is subtracted."""
+    (obs,) = plot_data([_obs(mag=MAG_1E4_JY)])
+    assert obs["ref_flux"] == 0.0
+    assert obs["diffflux_Jy"] == pytest.approx(1e-4)
+    assert obs["diffmag"] == pytest.approx(MAG_1E4_JY)
 
 
-def test_plot_data_matches_reference_loop_on_negative_diffflux():
-    """Observations fainter than the reference flip diffflux_Jy negative -- the inf branch."""
+def test_reference_flux_is_subtracted_from_the_observation():
+    (obs,) = plot_data([_obs(mag=MAG_1E4_JY)], **_ref(mag=MAG_1E5_JY))
+    assert obs["ref_flux"] == pytest.approx(1e-5)
+    assert obs["diffflux_Jy"] == pytest.approx(9e-5)
+    assert obs["diffmag"] == pytest.approx(19.014393726401686)
+
+
+def test_reference_uncertainty_enters_the_error_in_quadrature():
+    (obs,) = plot_data([_obs(mag=MAG_1E4_JY, magerr=0.1)], **_ref(mag=MAG_1E5_JY, magerr=0.1))
+    assert obs["difffluxerr_Jy"] == pytest.approx(9.256277516654899e-06)
+
+
+def test_reference_is_looked_up_per_oid():
+    """One light curve can carry several oids -- see `get_antares_lc`."""
+    ref_mag = immutabledefaultdict(lambda: np.inf, {1: MAG_1E5_JY, 2: MAG_1_JY})
+    first, second = plot_data([_obs(oid=1), _obs(oid=2, mjd=58001.0)], ref_mag=ref_mag)
+    assert first["ref_flux"] == pytest.approx(1e-5)
+    assert second["ref_flux"] == pytest.approx(1.0)
+
+
+def test_an_observation_fainter_than_its_reference_has_no_difference_magnitude():
+    (obs,) = plot_data([_obs(mag=MAG_1E5_JY)], **_ref(mag=MAG_1E4_JY))
+    assert obs["diffflux_Jy"] < 0
+    assert obs["diffmag"] == np.inf
+    assert obs["diffmagerr_plus"] == np.inf
+    assert obs["diffmagerr_minus"] == np.inf
+
+
+def test_a_difference_flux_below_its_own_uncertainty_has_no_difference_magnitude():
+    """`magerr = 2` puts the flux error above the flux itself, the other branch into `inf`."""
+    (obs,) = plot_data([_obs(mag=MAG_1E4_JY, magerr=2.0)])
+    assert obs["diffflux_Jy"] > 0
+    assert obs["diffflux_Jy"] < obs["difffluxerr_Jy"]
+    assert obs["diffmag"] == np.inf
+    assert obs["diffmagerr_plus"] == np.inf
+    assert obs["diffmagerr_minus"] == np.inf
+
+
+@pytest.mark.parametrize("mjd, date", [(58000.0, "2017-09-04"), (58200.5, "2018-03-23"), (59000.0, "2020-05-31")])
+def test_date_and_offset_mjd_come_from_the_observation_mjd(mjd, date):
+    (obs,) = plot_data([_obs(mjd=mjd)])
+    assert obs["date"] == date
+    assert obs[f"mjd_{MJD_OFFSET}"] == pytest.approx(mjd - MJD_OFFSET)
+
+
+def test_mjd_range_bounds_are_inclusive():
+    lc = [_obs(mjd=mjd) for mjd in (57999.0, 58000.0, 58001.0, 58002.0)]
+    out = plot_data(lc, min_mjd=58000.0, max_mjd=58001.0)
+    assert [obs["mjd"] for obs in out] == [58000.0, 58001.0]
+
+
+def test_output_is_sorted_by_filter_then_mjd():
     lc = [
-        {"mjd": 58500.0 + i, "mag": 25.0, "magerr": 0.3, "filter": "zg", "oid": 1}  # much fainter than ref
-        for i in range(20)
+        _obs(mjd=58002.0, band="zr"),
+        _obs(mjd=58001.0, band="zg"),
+        _obs(mjd=58000.0, band="zr"),
+        _obs(mjd=58003.0, band="zg"),
     ]
-    ref_mag = immutabledefaultdict(lambda: np.inf, {1: 15.0})
-    ref_magerr = immutabledefaultdict(float, {1: 0.01})
-    loop_out = _plot_data_loop_reference([dict(o) for o in lc], ref_mag=ref_mag, ref_magerr=ref_magerr)
-    vec_out = plot_data([dict(o) for o in lc], ref_mag=ref_mag, ref_magerr=ref_magerr)
-    assert all(math.isinf(obs["diffmag"]) for obs in vec_out)
-    _assert_same_result(loop_out, vec_out)
+    out = plot_data(lc)
+    assert [(obs["filter"], obs["mjd"]) for obs in out] == [
+        ("zg", 58001.0),
+        ("zg", 58003.0),
+        ("zr", 58000.0),
+        ("zr", 58002.0),
+    ]
 
 
-def test_plot_data_empty_input():
+def test_mark_size_is_recorded_on_every_observation():
+    out = plot_data([_obs(), _obs(mjd=58001.0)], mark_size=3)
+    assert [obs["mark_size"] for obs in out] == [3, 3]
+
+
+def test_the_input_dicts_are_mutated_in_place_and_returned():
+    obs = _obs()
+    (out,) = plot_data([obs])
+    assert out is obs
+    assert DERIVED_KEYS <= set(obs)
+
+
+def test_derived_values_are_plain_python_scalars():
+    """They are serialized to the browser, where numpy scalars do not survive the round trip."""
+    (obs,) = plot_data([_obs()])
+    for key in DERIVED_KEYS - {"mark_size", "date"}:
+        assert type(obs[key]) is float, key
+    assert type(obs["date"]) is str
+
+
+def test_empty_input():
     assert plot_data([]) == []
 
 
-def test_plot_data_all_observations_filtered_out_by_mjd_range():
-    lc = _random_lc(10, seed=3)
-    assert plot_data([dict(o) for o in lc], min_mjd=1.0, max_mjd=2.0) == []
+def test_all_observations_filtered_out_by_mjd_range():
+    assert plot_data([_obs(mjd=58000.0)], min_mjd=1.0, max_mjd=2.0) == []

--- a/tests/pages/test_lc_csv.py
+++ b/tests/pages/test_lc_csv.py
@@ -42,10 +42,16 @@ async def test_get_csv_per_oid_fanout_is_concurrent():
     async def fake_ref_get(oid, dr):
         raise NotFound
 
+    # This assertion is about the I/O fan-out, not the CSV-render pool round trip that follows
+    # it -- stub that out so a cold process-pool spawn on a slow runner can't blow the budget.
+    async def fake_run_in_process(fn, *args, **kwargs):
+        return fn(*args, **kwargs)
+
     with (
         patch.object(lc_csv.find_ztf_oid, "get_lc", fake_get_lc),
         patch.object(lc_csv.find_ztf_oid, "get_meta", fake_get_meta),
         patch.object(lc_csv.ztf_ref, "get", fake_ref_get),
+        patch.object(lc_csv, "run_in_process", fake_run_in_process),
     ):
         start = time.perf_counter()
         await lc_csv.get_csv("dr24", OIDS)

--- a/tests/test_csv_render.py
+++ b/tests/test_csv_render.py
@@ -1,0 +1,55 @@
+"""Unit tests for `ztf_viewer.csv_render`, the module a pool worker re-imports for `get_csv`.
+
+Split out of `ztf_viewer.pages.lc_csv` so that re-import stays cheap: `lc_csv.py` pulls in the
+astroquery-backed catalog clients for its own routes, which costs seconds to import, while this
+module only needs pandas.
+"""
+
+import subprocess
+import sys
+
+import pandas as pd
+
+from ztf_viewer.csv_render import dfs_to_csv
+
+
+def _df(oid, n=3):
+    return pd.DataFrame(
+        {
+            "oid": oid,
+            "filter": ["zg"] * n,
+            "mjd": [58000.0 + oid + i for i in range(n)],
+            "mag": [18.0] * n,
+            "magerr": [0.05] * n,
+            "clrcoeff": [0.1] * n,
+            "ref": [17.5] * n,
+            "ref_err": [0.02] * n,
+        }
+    )
+
+
+def test_dfs_to_csv_concatenates_and_sorts_by_mjd():
+    csv = dfs_to_csv([_df(2), _df(1)])
+    lines = csv.strip().splitlines()
+    assert lines[0] == "oid,filter,mjd,mag,magerr,clrcoeff,ref,ref_err"
+    mjds = [float(line.split(",")[2]) for line in lines[1:]]
+    assert mjds == sorted(mjds)
+
+
+def test_dfs_to_csv_keeps_only_the_expected_columns():
+    df = _df(1)
+    df["extra_column"] = "not in the csv"
+    csv = dfs_to_csv([df])
+    header = csv.strip().splitlines()[0]
+    assert "extra_column" not in header
+
+
+def test_csv_render_import_has_no_catalog_or_app_side_effects():
+    """Spawn's re-import of a submitted function's module must stay cheap: a fresh interpreter
+    that only imports `csv_render` must never pull in Dash, the app, or astroquery."""
+    code = (
+        "import sys; import ztf_viewer.csv_render; "
+        "print('dash' in sys.modules, 'ztf_viewer.app' in sys.modules, 'astroquery' in sys.modules)"
+    )
+    result = subprocess.run([sys.executable, "-c", code], capture_output=True, text=True, check=True)
+    assert result.stdout.strip() == "False False False"

--- a/ztf_viewer/csv_render.py
+++ b/ztf_viewer/csv_render.py
@@ -1,0 +1,20 @@
+"""Light-curve CSV assembly, split out so it can run in the process pool.
+
+Kept separate from `ztf_viewer.pages.lc_csv` so a pool worker importing this module doesn't also
+pull in the astroquery-backed catalog clients `lc_csv.py` needs for its own routes -- that chain
+costs seconds to import, this module only needs pandas.
+"""
+
+from io import StringIO
+
+import pandas as pd
+
+
+def dfs_to_csv(dfs):
+    df = pd.concat(dfs, axis="index")
+    df.sort_values(by="mjd", inplace=True)
+    df = df[["oid", "filter", "mjd", "mag", "magerr", "clrcoeff", "ref", "ref_err"]]
+
+    string_io = StringIO()
+    df.to_csv(string_io, index=False)
+    return string_io.getvalue()

--- a/ztf_viewer/lc_data/plot_data.py
+++ b/ztf_viewer/lc_data/plot_data.py
@@ -1,5 +1,4 @@
 import asyncio
-import math as m
 
 import numpy as np
 from astropy.time import Time
@@ -31,45 +30,55 @@ def plot_data(
         min_mjd = -np.inf
     if max_mjd is None:
         max_mjd = np.inf
+    if not lc:
+        return []
 
-    data = []
-    for obs in lc:
-        if not min_mjd <= obs["mjd"] <= max_mjd:
-            continue
+    mjd_all = np.array([obs["mjd"] for obs in lc])
+    idx = np.nonzero((mjd_all >= min_mjd) & (mjd_all <= max_mjd))[0]
+    if idx.size == 0:
+        return []
+    data = [lc[i] for i in idx]
+    mjd = mjd_all[idx]
+    mag = np.array([obs["mag"] for obs in data])
+    magerr = np.array([obs["magerr"] for obs in data])
+    # Normally we have a single oid for the light curve, but it could not
+    # be a case, see get_antares_lc for an example
+    ref_mag_arr = np.array([ref_mag[obs["oid"]] for obs in data])
+    ref_magerr_arr = np.array([ref_magerr[obs["oid"]] for obs in data])
 
+    ref_flux = 10 ** (-0.4 * (ref_mag_arr - ABZPMAG_JY))
+    ref_fluxerr = LN10_04 * ref_flux * ref_magerr_arr
+    flux_Jy = 10 ** (-0.4 * (mag - ABZPMAG_JY))
+    fluxerr_Jy = LN10_04 * flux_Jy * magerr
+    diffflux_Jy = flux_Jy - ref_flux
+    difffluxerr_Jy = np.hypot(fluxerr_Jy, ref_fluxerr)
+
+    # we do both for a weird case of negative error
+    bad = (diffflux_Jy <= 0) | (diffflux_Jy < difffluxerr_Jy)
+    with np.errstate(divide="ignore", invalid="ignore"):
+        diffmag = np.where(bad, np.inf, ABZPMAG_JY - 2.5 * np.log10(diffflux_Jy))
+        # for smaller flux
+        diffmagerr_plus = np.where(bad, np.inf, -2.5 * np.log10(1 - difffluxerr_Jy / diffflux_Jy))
+        # positive and for larger flux
+        diffmagerr_minus = np.where(bad, np.inf, 2.5 * np.log10(1 + difffluxerr_Jy / diffflux_Jy))
+
+    mjd_offset = mjd - MJD_OFFSET
+    dates = Time(mjd, format="mjd").strftime("%Y-%m-%d")
+
+    for i, obs in enumerate(data):
         obs["mark_size"] = mark_size
+        obs["flux_Jy"] = float(flux_Jy[i])
+        obs["fluxerr_Jy"] = float(fluxerr_Jy[i])
+        obs["diffflux_Jy"] = float(diffflux_Jy[i])
+        obs["difffluxerr_Jy"] = float(difffluxerr_Jy[i])
+        obs["ref_flux"] = float(ref_flux[i])
+        obs["diffmag"] = float(diffmag[i])
+        obs["diffmagerr_plus"] = float(diffmagerr_plus[i])
+        obs["diffmagerr_minus"] = float(diffmagerr_minus[i])
+        obs[f"mjd_{MJD_OFFSET}"] = float(mjd_offset[i])
+        obs["date"] = str(dates[i])
 
-        # Normally we have a single oid for the light curve, but it could not
-        # be a case, see get_antares_lc for an example
-        ref_flux = 10 ** (-0.4 * (ref_mag[obs["oid"]] - ABZPMAG_JY))
-        ref_fluxerr = LN10_04 * ref_flux * ref_magerr[obs["oid"]]
-
-        obs["flux_Jy"] = 10 ** (-0.4 * (obs["mag"] - ABZPMAG_JY))
-        obs["fluxerr_Jy"] = LN10_04 * obs["flux_Jy"] * obs["magerr"]
-
-        obs["diffflux_Jy"] = obs["flux_Jy"] - ref_flux
-        obs["difffluxerr_Jy"] = np.hypot(obs["fluxerr_Jy"], ref_fluxerr)
-        obs["ref_flux"] = ref_flux
-
-        # we do both for a weird case of negative error
-        if obs["diffflux_Jy"] <= 0 or obs["diffflux_Jy"] < obs["difffluxerr_Jy"]:
-            obs["diffmag"] = np.inf
-            obs["diffmagerr_plus"] = np.inf
-            obs["diffmagerr_minus"] = np.inf
-        else:
-            obs["diffmag"] = ABZPMAG_JY - 2.5 * m.log10(obs["diffflux_Jy"])
-            # for smaller flux
-            obs["diffmagerr_plus"] = -2.5 * m.log10(1 - obs["difffluxerr_Jy"] / obs["diffflux_Jy"])
-            # positive and for larger flux
-            obs["diffmagerr_minus"] = 2.5 * m.log10(1 + obs["difffluxerr_Jy"] / obs["diffflux_Jy"])
-
-        obs[f"mjd_{MJD_OFFSET}"] = obs["mjd"] - MJD_OFFSET
-        time = Time(obs["mjd"], format="mjd")
-        obs["date"] = time.strftime("%Y-%m-%d")
-
-        data.append(obs)
-
-    data = sorted(data, key=lambda obs: (FILTERS_ORDER[obs["filter"]], obs["mjd"]))
+    data.sort(key=lambda obs: (FILTERS_ORDER[obs["filter"]], obs["mjd"]))
 
     return data
 

--- a/ztf_viewer/pages/lc_csv.py
+++ b/ztf_viewer/pages/lc_csv.py
@@ -15,7 +15,9 @@ from ztf_viewer.app import app
 from ztf_viewer.catalogs import find_ztf_oid
 from ztf_viewer.catalogs.conesearch import ANTARES_QUERY, GAIA_DR3, PANSTARRS_DR2_QUERY
 from ztf_viewer.catalogs.ztf_ref import ztf_ref
+from ztf_viewer.csv_render import dfs_to_csv
 from ztf_viewer.exceptions import CatalogUnavailable, NotFound
+from ztf_viewer.procpool import run_in_process
 from ztf_viewer.web import csv_response, error_response, query_args
 
 
@@ -50,17 +52,7 @@ async def _get_oid_df(oid, dr, min_mjd, max_mjd):
 
 async def get_csv(dr, oids, min_mjd=None, max_mjd=None):
     dfs = await asyncio.gather(*(_get_oid_df(oid, dr, min_mjd, max_mjd) for oid in oids))
-    return await asyncio.to_thread(_dfs_to_csv, dfs)
-
-
-def _dfs_to_csv(dfs):
-    df = pd.concat(dfs, axis="index")
-    df.sort_values(by="mjd", inplace=True)
-    df = df[["oid", "filter", "mjd", "mag", "magerr", "clrcoeff", "ref", "ref_err"]]
-
-    string_io = StringIO()
-    df.to_csv(string_io, index=False)
-    return string_io.getvalue()
+    return await run_in_process(dfs_to_csv, dfs)
 
 
 def _lc_to_csv_response(lc, filename):


### PR DESCRIPTION
## What

Stacked on #689 (`profile-candidates`), which has the measurements this PR applies. Two of the four `aio-profile` candidates earned a change:

1. **`ztf_viewer/lc_data/plot_data.py`** — `plot_data`'s per-observation loop rewritten with numpy, ~10x faster at realistic sizes (50.9ms→4.8ms at 1,500 obs; 674.5ms→64.8ms at 20,000 obs — see #689 for the full numbers and the `cProfile` finding that the loop's biggest single cost was one `astropy.time.Time` object per observation). This wasn't offloaded at all before (no `to_thread`, no pool) — it ran fully inline, so this directly cuts how long the event loop is blocked per call, without needing a pool. Pinned by `tests/lc_data/test_plot_data_vectorized.py`, which asserts `plot_data`'s output contract directly against inline literals — the magnitude-to-flux conversion, reference subtraction, both `inf` branches, per-oid reference lookup, MJD-range bounds, sort order, in-place mutation, and the plain-`float` coercion the numpy rewrite has to do. An earlier revision kept a copy of the replaced loop as a test-only oracle; that was dropped in review. Two implementations written together agreeing with each other is not evidence — a mistake carried into both passes — and nobody maintains the copy. Verified by mutation instead: six deliberate breakages of `plot_data` (`hypot` → sum, dropped `float()`, date built from the offset MJD, sort by MJD only, exclusive range bounds, reference lookup ignoring `oid`) each fail exactly the test that names that behaviour.

2. **`ztf_viewer/pages/lc_csv.py`** — `get_csv` now runs its pandas assembly via `run_in_process` instead of `asyncio.to_thread`. Single-call cost is a wash, but under concurrent CSV-download load it cuts the worst event-loop stall by ~90-200x and wall time by ~45% (#689's numbers). The pure-pandas assembly function moved to a new module, **`ztf_viewer/csv_render.py`** — `lc_csv.py` imports the astroquery-backed catalog clients for its own routes, which costs seconds to import, and a process-pool worker re-imports whatever module holds the submitted function on every cold start. Same reasoning `ztf_viewer/figure_render.py` already established for the matplotlib renderers (`aio-figures`, #686). `tests/test_csv_render.py` covers the moved function directly and pins that importing `csv_render` alone never pulls in Dash, the app, or astroquery — mirroring `test_figure.py`'s existing `test_figure_render_import_has_no_app_side_effects`.

The other two candidates got **no change** — #689's measurements found the FITS parse too cheap to justify pooling, and `set_figure`'s plotly construction blocked outright by its `FigureWidget` return type not being picklable (plus a losing single-call cost even against the picklable `go.Figure` proxy).

## CI found a real regression, not a flake: fixed in `3f984ac`

First push, `tests/pages/test_lc_csv.py::test_get_csv_per_oid_fanout_is_concurrent` failed intermittently on CI — `assert 0.5179780260000086 < 0.5`. Not noise: `get_csv` now ends with a real `run_in_process(dfs_to_csv, dfs)` call, and that call pays a `ProcessPoolExecutor` cold start the first time the shared pool spawns a worker (measured below, ~560ms) — `tests/pages/test_figure.py` sorts before `test_lc_csv.py` and its `test_broken_pool_surfaces_as_500` deliberately kills a pool worker, so on a slow CI runner the *next* real pool use anywhere in the suite can land on a freshly-respawned, cold pool. 0.2s of I/O fan-out plus a cold worker spawn lands right on the test's 0.5s budget.

Fixed by stubbing the `run_in_process` hop in that one test (`3f984ac`), not by loosening the threshold — the test's own docstring says its job is asserting the per-OID I/O fan-out overlaps in wall time, not timing a CPU-pool round trip that follows it. The other `test_lc_csv.py` tests have no timing assertion and still exercise the real pool end to end, matching `test_figure.py`'s established precedent. Verified: 10/10 clean locally, standalone and run directly after `test_figure.py` (reproducing the pool-recycling order CI hit).

## Two costs the steady-state numbers in #689 don't show

#689 measured warm, steady-state round trips. Two real costs only show up around the edges of that, and both are worth naming explicitly:

**Cold start is real, ~560ms, once per worker.** Measured directly (fresh `_ProcessPool`, first call vs second): the first CSV render in a brand-new worker costs **560ms**, the second (same worker, warm) costs **13.6ms**. That 560ms is dominated by interpreter/process spawn itself, not by `csv_render`'s own import weight (it only needs pandas) — it lands in the same ballpark as `figure_render`'s own measured cold start, **~525ms** (#686's PR description). Same conclusion #686 already reached applies here: paid once per worker, amortized over that worker's lifetime, not per request — "several seconds" would justify a pool `initializer=` pre-warm, ~560ms doesn't. No pre-warm added here either, for the same reason.

**Pool contention with figure rendering is real and I think worth flagging as a risk, not just a footnote.** `PROCESS_POOL_SIZE` defaults to **2**, and #686 already routes every PNG and PDF render through that same pool. #689's site-2 numbers were measured with the pool serving CSV work alone — that's not the deployed reality after this PR. Measured directly: 2 concurrent PDF renders (400-obs synthetic light curve) plus 1 CSV render, submitted together against the default 2-worker pool —

| task | wall time |
| --- | --- |
| PDF #1 | 962ms |
| PDF #2 (queued for a worker) | 2198ms |
| CSV (queued for a worker) | 974ms |
| CSV alone, pool otherwise idle | 14ms |

The CSV render's own CPU work is still ~14ms once it gets a worker — the other ~960ms is pure queueing behind a slow PDF render, because both workers were busy. `gil_bench.py`'s own numbers show a real PDF/LaTeX render can take up to **~5s** serially for a larger light curve, not the 400-obs synthetic used here, so the realistic worst case is worse than this table's ~1s.

This does **not** contradict #689's responsiveness finding — event-loop stalling and per-request queueing delay are different things. The pool promotion still keeps the event loop free for *other* requests while a CSV job sits queued (that's what #689 measured and it still holds); what this adds is that the CSV *requester itself* can now wait behind unrelated PDF work in a way a dedicated 16-slot thread pool never made it wait before. Previously `THREAD_POOL_SIZE=16` gave CSV downloads their own generous headroom, isolated from figure rendering entirely.

**My honest read: this makes a case that `PROCESS_POOL_SIZE=2` is now too small, but I'm not confident enough in a number to change it here.** Before this PR, the pool served one workload (figure rendering) with reasonably well-understood latency. After it, a second, latency-sensitive workload (CSV downloads, previously fast and isolated) shares the same two slots with a workload that can legitimately take seconds. I don't have production traffic data — request-rate ratios of CSV downloads to figure renders, real concurrent-user counts — to say whether 2, 3, or `cpu_count`-sized is right, and bumping it isn't free (more child-process memory per worker, `aio-procpool`'s own sizing note: "~`cpu_count // workers`"). I'm leaving `PROCESS_POOL_SIZE` at its default and naming this as an open risk rather than picking a number without data to back it — the plan's `aio-gather` entry already flagged unowned pool sizing as an open question elsewhere in this stack, so this is the process-pool analogue of that same gap, not a new kind of problem.

I'm keeping the **promote** verdict for site 2 despite this: the responsiveness win (event loop stays free for unrelated work, ~90-200x smaller worst-case stall, #689) is real, reproducible, and the actual point of pooling per the plan. The queueing-behind-figure-renders risk is a genuine cost, but it's a latency risk for the CSV requester specifically under a busy pool, not a regression in what the pool promotion was meant to fix.

## Test plan

- [x] `pytest --basetemp=/tmp/pytest tests/lc_data/ tests/pages/ tests/test_procpool.py tests/test_csv_render.py` — 49 passed.
- [x] `tests/pages/test_lc_csv.py::test_get_csv_per_oid_fanout_is_concurrent`, 10x standalone and 10x run directly after `test_figure.py` (reproducing the CI failure's pool-recycling order) — clean every time after the `3f984ac` fix.
- [x] Full suite: `pytest --basetemp=/tmp/pytest` — all green (two pre-existing, unrelated JS9 skips).
- [x] `pre-commit run --all-files` — clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

