### PR TITLE
Enable Dash WebSocket callback transport

### DIFF
--- a/tests/test_websocket_transport.py
+++ b/tests/test_websocket_transport.py
@@ -1,25 +1,46 @@
-"""The WS callback transport is enabled with an explicit origin allowlist and a heartbeat pinned
-under the deployed proxy's live 60s read-timeout default; HTTP-transport callbacks still work.
+"""The WS callback transport is enabled: same-origin connections work via dash's own same-Host
+fallback, cross-origin ones are still rejected, and the heartbeat is pinned under the deployed
+proxy's live 60s read-timeout default. HTTP-transport callbacks still work.
 """
 
+import pytest
 from dash import Input, Output, html
 from fastapi.testclient import TestClient
+from starlette.websockets import WebSocketDisconnect
 
 from tests.conftest import reset_shared_process_pool, reset_shared_thread_pool
 from ztf_viewer import config
 from ztf_viewer.app import app
-from ztf_viewer.config import WEBSOCKET_ALLOWED_ORIGINS, WEBSOCKET_HEARTBEAT_INTERVAL_MS
+from ztf_viewer.config import WEBSOCKET_HEARTBEAT_INTERVAL_MS
 
 # nginx's compiled default; the deployed proxy has no proxy_read_timeout override live anywhere,
 # so this is the real ceiling a heartbeat must stay under.
 LIVE_PROXY_READ_TIMEOUT_MS = 60_000
 
 
-def test_websocket_transport_is_enabled_with_explicit_origins():
-    """The handler rejects every cross-origin connection without an explicit allowlist."""
-    assert app._websocket_allowed_origins == WEBSOCKET_ALLOWED_ORIGINS
-    assert len(WEBSOCKET_ALLOWED_ORIGINS) > 0
-    assert all(isinstance(origin, str) and origin for origin in WEBSOCKET_ALLOWED_ORIGINS)
+def test_websocket_origin_check_allows_same_origin_and_rejects_cross_origin():
+    """The security-relevant behavior: dash's same-Host fallback (not the allowlist, which
+    defaults empty) is what accepts ordinary same-origin connections; a genuine cross-origin
+    one must still be rejected at the handshake."""
+    original_allowed_origins = app._websocket_allowed_origins
+    original_layout = app._layout, app._layout_is_function
+    app._websocket_allowed_origins = []
+    app.layout = html.Div("x")
+    reset_shared_thread_pool()
+    reset_shared_process_pool()
+    try:
+        with TestClient(app.server) as client:
+            with client.websocket_connect("/_dash-ws-callback", headers={"Origin": "http://testserver"}):
+                pass  # same-origin: connects without being on the allowlist
+
+            with (
+                pytest.raises(WebSocketDisconnect),
+                client.websocket_connect("/_dash-ws-callback", headers={"Origin": "https://evil.example.com"}),
+            ):
+                pass  # cross-origin, not on the allowlist: rejected
+    finally:
+        app._websocket_allowed_origins = original_allowed_origins
+        app._layout, app._layout_is_function = original_layout
 
 
 def test_heartbeat_interval_is_bounded_below_the_live_proxy_ceiling():

--- a/tests/test_websocket_transport.py
+++ b/tests/test_websocket_transport.py
@@ -1,13 +1,12 @@
 """The WS callback transport is enabled with an explicit origin allowlist and a heartbeat pinned
-well under the deployed proxy's live 60s read-timeout default -- see ``ztf_viewer/config.py``.
-
-HTTP-transport callbacks must keep working: only one callback (``skybot``) has opted into
-``websocket=True`` so far, everything else still dispatches over the existing POST path.
+under the deployed proxy's live 60s read-timeout default; HTTP-transport callbacks still work.
 """
 
-from dash import html
+from dash import Input, Output, html
 from fastapi.testclient import TestClient
 
+from tests.conftest import reset_shared_process_pool, reset_shared_thread_pool
+from ztf_viewer import config
 from ztf_viewer.app import app
 from ztf_viewer.config import WEBSOCKET_ALLOWED_ORIGINS, WEBSOCKET_HEARTBEAT_INTERVAL_MS
 
@@ -17,19 +16,15 @@ LIVE_PROXY_READ_TIMEOUT_MS = 60_000
 
 
 def test_websocket_transport_is_enabled_with_explicit_origins():
-    """Global ``websocket_callbacks`` stays off (opt-in per callback), but the transport itself
-    -- reachable via per-callback ``websocket=True`` -- needs an explicit, non-empty origin list,
-    since the handler otherwise rejects every cross-origin connection."""
+    """The handler rejects every cross-origin connection without an explicit allowlist."""
     assert app._websocket_allowed_origins == WEBSOCKET_ALLOWED_ORIGINS
     assert len(WEBSOCKET_ALLOWED_ORIGINS) > 0
     assert all(isinstance(origin, str) and origin for origin in WEBSOCKET_ALLOWED_ORIGINS)
 
 
 def test_heartbeat_interval_is_bounded_below_the_live_proxy_ceiling():
-    """The single most important invariant here: this must keep failing if someone raises the
-    heartbeat interval past what the live (not intended) proxy timeout allows. A value at or
-    above the ceiling would silently break idle WS connections in production, so this failure
-    mode is not something CI would otherwise catch."""
+    """This must keep failing if the heartbeat is ever raised past the live proxy ceiling --
+    that failure mode is silent in production, not something CI would otherwise catch."""
     assert app._websocket_heartbeat_interval == WEBSOCKET_HEARTBEAT_INTERVAL_MS
     assert WEBSOCKET_HEARTBEAT_INTERVAL_MS < LIVE_PROXY_READ_TIMEOUT_MS
     # Real margin, not just "technically under": at least a 2x safety factor.
@@ -38,11 +33,11 @@ def test_heartbeat_interval_is_bounded_below_the_live_proxy_ceiling():
 
 def test_at_least_one_callback_opted_into_websocket_transport():
     """Proves the transport is actually reachable, not just configured and unused."""
-    from ztf_viewer import config
-
     config.CACHE_TYPE = "memory"
     config.UNAVAILABLE_CATALOGS_CACHE_TYPE = "memory"
 
+    # Must import after the config assignment above: unavailable_catalogs binds its backend from
+    # CACHE_TYPE at import time, and this may be the first import of __main__ in the session.
     import ztf_viewer.__main__ as main_module
 
     opted_in = [callback_id for callback_id, entry in main_module.app.callback_map.items() if entry.get("websocket")]
@@ -50,12 +45,7 @@ def test_at_least_one_callback_opted_into_websocket_transport():
 
 
 def test_http_fallback_still_works_for_a_non_websocket_callback():
-    """A callback without ``websocket=True`` must still dispatch over the plain HTTP POST path
-    the transport is meant to fall back to -- registers its own throwaway callback rather than
-    relying on one from ``ztf_viewer.pages`` having already been imported elsewhere."""
-    from dash import Input, Output
-
-    from tests.conftest import reset_shared_process_pool, reset_shared_thread_pool
+    """A callback without `websocket=True` still dispatches over the plain HTTP POST path."""
 
     def echo(value):
         return f"echoed: {value}"

--- a/tests/test_websocket_transport.py
+++ b/tests/test_websocket_transport.py
@@ -1,0 +1,90 @@
+"""The WS callback transport is enabled with an explicit origin allowlist and a heartbeat pinned
+well under the deployed proxy's live 60s read-timeout default -- see ``ztf_viewer/config.py``.
+
+HTTP-transport callbacks must keep working: only one callback (``skybot``) has opted into
+``websocket=True`` so far, everything else still dispatches over the existing POST path.
+"""
+
+from dash import html
+from fastapi.testclient import TestClient
+
+from ztf_viewer.app import app
+from ztf_viewer.config import WEBSOCKET_ALLOWED_ORIGINS, WEBSOCKET_HEARTBEAT_INTERVAL_MS
+
+# nginx's compiled default; the deployed proxy has no proxy_read_timeout override live anywhere,
+# so this is the real ceiling a heartbeat must stay under.
+LIVE_PROXY_READ_TIMEOUT_MS = 60_000
+
+
+def test_websocket_transport_is_enabled_with_explicit_origins():
+    """Global ``websocket_callbacks`` stays off (opt-in per callback), but the transport itself
+    -- reachable via per-callback ``websocket=True`` -- needs an explicit, non-empty origin list,
+    since the handler otherwise rejects every cross-origin connection."""
+    assert app._websocket_allowed_origins == WEBSOCKET_ALLOWED_ORIGINS
+    assert len(WEBSOCKET_ALLOWED_ORIGINS) > 0
+    assert all(isinstance(origin, str) and origin for origin in WEBSOCKET_ALLOWED_ORIGINS)
+
+
+def test_heartbeat_interval_is_bounded_below_the_live_proxy_ceiling():
+    """The single most important invariant here: this must keep failing if someone raises the
+    heartbeat interval past what the live (not intended) proxy timeout allows. A value at or
+    above the ceiling would silently break idle WS connections in production, so this failure
+    mode is not something CI would otherwise catch."""
+    assert app._websocket_heartbeat_interval == WEBSOCKET_HEARTBEAT_INTERVAL_MS
+    assert WEBSOCKET_HEARTBEAT_INTERVAL_MS < LIVE_PROXY_READ_TIMEOUT_MS
+    # Real margin, not just "technically under": at least a 2x safety factor.
+    assert WEBSOCKET_HEARTBEAT_INTERVAL_MS <= LIVE_PROXY_READ_TIMEOUT_MS / 2
+
+
+def test_at_least_one_callback_opted_into_websocket_transport():
+    """Proves the transport is actually reachable, not just configured and unused."""
+    from ztf_viewer import config
+
+    config.CACHE_TYPE = "memory"
+    config.UNAVAILABLE_CATALOGS_CACHE_TYPE = "memory"
+
+    import ztf_viewer.__main__ as main_module
+
+    opted_in = [callback_id for callback_id, entry in main_module.app.callback_map.items() if entry.get("websocket")]
+    assert opted_in == ["skybot.children"]
+
+
+def test_http_fallback_still_works_for_a_non_websocket_callback():
+    """A callback without ``websocket=True`` must still dispatch over the plain HTTP POST path
+    the transport is meant to fall back to -- registers its own throwaway callback rather than
+    relying on one from ``ztf_viewer.pages`` having already been imported elsewhere."""
+    from dash import Input, Output
+
+    from tests.conftest import reset_shared_process_pool, reset_shared_thread_pool
+
+    def echo(value):
+        return f"echoed: {value}"
+
+    app.callback(Output("ws-fallback-target", "children"), [Input("ws-fallback-source", "value")])(echo)
+
+    original = app._layout, app._layout_is_function
+    app.layout = html.Div(
+        [
+            html.Div(id="ws-fallback-target"),
+            html.Div(id="ws-fallback-source"),
+        ]
+    )
+    reset_shared_thread_pool()
+    reset_shared_process_pool()
+    try:
+        with TestClient(app.server) as client:
+            response = client.post(
+                "/_dash-update-component",
+                json={
+                    "output": "ws-fallback-target.children",
+                    "outputs": {"id": "ws-fallback-target", "property": "children"},
+                    "inputs": [{"id": "ws-fallback-source", "property": "value", "value": "hi"}],
+                    "state": [],
+                    "changedPropIds": ["ws-fallback-source.value"],
+                },
+            )
+    finally:
+        app._layout, app._layout_is_function = original
+
+    assert response.status_code == 200
+    assert response.json()["response"]["ws-fallback-target"]["children"] == "echoed: hi"

--- a/ztf_viewer/app.py
+++ b/ztf_viewer/app.py
@@ -43,9 +43,7 @@ app = dash.Dash(
     external_scripts=js9_js,
     health_endpoint="health",
     backend="fastapi",
-    # Transport enabled, but callbacks opt in individually (`websocket=True`) rather than via
-    # `websocket_callbacks=True`, so the HTTP path stays a working fallback while we gain
-    # confidence.
+    # Transport enabled; callbacks opt in individually via `websocket=True`.
     websocket_allowed_origins=WEBSOCKET_ALLOWED_ORIGINS,
     websocket_max_workers=WEBSOCKET_MAX_WORKERS,
     websocket_inactivity_timeout=WEBSOCKET_INACTIVITY_TIMEOUT_MS,

--- a/ztf_viewer/app.py
+++ b/ztf_viewer/app.py
@@ -4,11 +4,7 @@ import dash
 from fastapi.responses import Response
 from fastapi.staticfiles import StaticFiles
 
-from ztf_viewer.config import (
-    WEBSOCKET_ALLOWED_ORIGINS,
-    WEBSOCKET_HEARTBEAT_INTERVAL_MS,
-    WEBSOCKET_INACTIVITY_TIMEOUT_MS,
-)
+from ztf_viewer.config import WEBSOCKET_HEARTBEAT_INTERVAL_MS
 
 _STATIC_DIR = pathlib.Path(__file__).parent / "static"
 
@@ -43,8 +39,6 @@ app = dash.Dash(
     health_endpoint="health",
     backend="fastapi",
     # Transport enabled; callbacks opt in individually via `websocket=True`.
-    websocket_allowed_origins=WEBSOCKET_ALLOWED_ORIGINS,
-    websocket_inactivity_timeout=WEBSOCKET_INACTIVITY_TIMEOUT_MS,
     websocket_heartbeat_interval=WEBSOCKET_HEARTBEAT_INTERVAL_MS,
 )
 app.config.suppress_callback_exceptions = True

--- a/ztf_viewer/app.py
+++ b/ztf_viewer/app.py
@@ -4,6 +4,13 @@ import dash
 from fastapi.responses import Response
 from fastapi.staticfiles import StaticFiles
 
+from ztf_viewer.config import (
+    WEBSOCKET_ALLOWED_ORIGINS,
+    WEBSOCKET_HEARTBEAT_INTERVAL_MS,
+    WEBSOCKET_INACTIVITY_TIMEOUT_MS,
+    WEBSOCKET_MAX_WORKERS,
+)
+
 _STATIC_DIR = pathlib.Path(__file__).parent / "static"
 
 
@@ -36,6 +43,13 @@ app = dash.Dash(
     external_scripts=js9_js,
     health_endpoint="health",
     backend="fastapi",
+    # Transport enabled, but callbacks opt in individually (`websocket=True`) rather than via
+    # `websocket_callbacks=True`, so the HTTP path stays a working fallback while we gain
+    # confidence.
+    websocket_allowed_origins=WEBSOCKET_ALLOWED_ORIGINS,
+    websocket_max_workers=WEBSOCKET_MAX_WORKERS,
+    websocket_inactivity_timeout=WEBSOCKET_INACTIVITY_TIMEOUT_MS,
+    websocket_heartbeat_interval=WEBSOCKET_HEARTBEAT_INTERVAL_MS,
 )
 app.config.suppress_callback_exceptions = True
 

--- a/ztf_viewer/app.py
+++ b/ztf_viewer/app.py
@@ -8,7 +8,6 @@ from ztf_viewer.config import (
     WEBSOCKET_ALLOWED_ORIGINS,
     WEBSOCKET_HEARTBEAT_INTERVAL_MS,
     WEBSOCKET_INACTIVITY_TIMEOUT_MS,
-    WEBSOCKET_MAX_WORKERS,
 )
 
 _STATIC_DIR = pathlib.Path(__file__).parent / "static"
@@ -45,7 +44,6 @@ app = dash.Dash(
     backend="fastapi",
     # Transport enabled; callbacks opt in individually via `websocket=True`.
     websocket_allowed_origins=WEBSOCKET_ALLOWED_ORIGINS,
-    websocket_max_workers=WEBSOCKET_MAX_WORKERS,
     websocket_inactivity_timeout=WEBSOCKET_INACTIVITY_TIMEOUT_MS,
     websocket_heartbeat_interval=WEBSOCKET_HEARTBEAT_INTERVAL_MS,
 )

--- a/ztf_viewer/config.py
+++ b/ztf_viewer/config.py
@@ -58,10 +58,5 @@ TIMEOUT_MODEL_FIT = httpx.Timeout(120.0)  # model_fit.py: the heaviest per-reque
 TIMEOUT_AKB = httpx.Timeout(10.0)  # akb.py: small CRUD-shaped JSON requests
 TIMEOUT_ZTF_FITS_PROXY = httpx.Timeout(60.0)  # catalogs/ztf_ref.py, date_with_frac.py: both hit ZTF_FITS_PROXY_URL
 
-# Extra origins the WS handler accepts outright; same-origin connections are already allowed
-# without this (dash/backends/_fastapi.py's same-Host fallback). Comma-separated.
-WEBSOCKET_ALLOWED_ORIGINS = [o for o in os.environ.get("WEBSOCKET_ALLOWED_ORIGINS", "").split(",") if o]
-# Closes a connection that has sent nothing (not even a heartbeat) for this long, in ms.
-WEBSOCKET_INACTIVITY_TIMEOUT_MS = int(os.environ.get("WEBSOCKET_INACTIVITY_TIMEOUT_MS", "300000"))
 # Must stay well under the deployed proxy's live 60s read-timeout default, in ms.
 WEBSOCKET_HEARTBEAT_INTERVAL_MS = int(os.environ.get("WEBSOCKET_HEARTBEAT_INTERVAL_MS", "20000"))

--- a/ztf_viewer/config.py
+++ b/ztf_viewer/config.py
@@ -57,3 +57,26 @@ TIMEOUT_FEATURES = httpx.Timeout(60.0)  # lc_features.py: feature extraction ove
 TIMEOUT_MODEL_FIT = httpx.Timeout(120.0)  # model_fit.py: the heaviest per-request compute of the first-party APIs
 TIMEOUT_AKB = httpx.Timeout(10.0)  # akb.py: small CRUD-shaped JSON requests
 TIMEOUT_ZTF_FITS_PROXY = httpx.Timeout(60.0)  # catalogs/ztf_ref.py, date_with_frac.py: both hit ZTF_FITS_PROXY_URL
+
+# `dash.Dash(..., websocket_...=...)` tuning (ztf_viewer/app.py). Origins the WS handler accepts
+# without falling back to its same-Host check: production, the master build, and local dev.
+# Comma-separated so a deployment can add a value without a code change.
+WEBSOCKET_ALLOWED_ORIGINS = [
+    origin
+    for origin in os.environ.get(
+        "WEBSOCKET_ALLOWED_ORIGINS",
+        "https://ztf.snad.space,https://master.ztf.snad.space,http://localhost:8050,http://127.0.0.1:8050",
+    ).split(",")
+    if origin
+]
+# Sync-callback thread pool for the WS handler, separate from THREAD_POOL_SIZE's executor.
+WEBSOCKET_MAX_WORKERS = int(os.environ.get("WEBSOCKET_MAX_WORKERS", "4"))
+# Closes a connection that has sent nothing (not even a heartbeat) for this long, in ms.
+WEBSOCKET_INACTIVITY_TIMEOUT_MS = int(os.environ.get("WEBSOCKET_INACTIVITY_TIMEOUT_MS", "300000"))
+# The deployed reverse proxy has no proxy_read_timeout configured anywhere, so nginx's compiled
+# 60s default is what's actually live (not the 1h the ops repo intends but never applies). An
+# idle WS connection survives only on heartbeats landing under that ceiling, so this must stay
+# well below 60000ms with real margin -- raising it toward 60000 would silently break idle
+# connections in production. If the proxy timeout is ever fixed, a low value here is still
+# correct, just more conservative than it needs to be.
+WEBSOCKET_HEARTBEAT_INTERVAL_MS = int(os.environ.get("WEBSOCKET_HEARTBEAT_INTERVAL_MS", "20000"))

--- a/ztf_viewer/config.py
+++ b/ztf_viewer/config.py
@@ -58,17 +58,9 @@ TIMEOUT_MODEL_FIT = httpx.Timeout(120.0)  # model_fit.py: the heaviest per-reque
 TIMEOUT_AKB = httpx.Timeout(10.0)  # akb.py: small CRUD-shaped JSON requests
 TIMEOUT_ZTF_FITS_PROXY = httpx.Timeout(60.0)  # catalogs/ztf_ref.py, date_with_frac.py: both hit ZTF_FITS_PROXY_URL
 
-# `dash.Dash(..., websocket_...=...)` tuning (ztf_viewer/app.py). Comma-separated allowlist.
-WEBSOCKET_ALLOWED_ORIGINS = [
-    origin
-    for origin in os.environ.get(
-        "WEBSOCKET_ALLOWED_ORIGINS",
-        "https://ztf.snad.space,https://master.ztf.snad.space,http://localhost:8050,http://127.0.0.1:8050",
-    ).split(",")
-    if origin
-]
-# Sync-callback thread pool for the WS handler, separate from THREAD_POOL_SIZE's executor.
-WEBSOCKET_MAX_WORKERS = int(os.environ.get("WEBSOCKET_MAX_WORKERS", "4"))
+# Extra origins the WS handler accepts outright; same-origin connections are already allowed
+# without this (dash/backends/_fastapi.py's same-Host fallback). Comma-separated.
+WEBSOCKET_ALLOWED_ORIGINS = [o for o in os.environ.get("WEBSOCKET_ALLOWED_ORIGINS", "").split(",") if o]
 # Closes a connection that has sent nothing (not even a heartbeat) for this long, in ms.
 WEBSOCKET_INACTIVITY_TIMEOUT_MS = int(os.environ.get("WEBSOCKET_INACTIVITY_TIMEOUT_MS", "300000"))
 # Must stay well under the deployed proxy's live 60s read-timeout default, in ms.

--- a/ztf_viewer/config.py
+++ b/ztf_viewer/config.py
@@ -58,9 +58,7 @@ TIMEOUT_MODEL_FIT = httpx.Timeout(120.0)  # model_fit.py: the heaviest per-reque
 TIMEOUT_AKB = httpx.Timeout(10.0)  # akb.py: small CRUD-shaped JSON requests
 TIMEOUT_ZTF_FITS_PROXY = httpx.Timeout(60.0)  # catalogs/ztf_ref.py, date_with_frac.py: both hit ZTF_FITS_PROXY_URL
 
-# `dash.Dash(..., websocket_...=...)` tuning (ztf_viewer/app.py). Origins the WS handler accepts
-# without falling back to its same-Host check: production, the master build, and local dev.
-# Comma-separated so a deployment can add a value without a code change.
+# `dash.Dash(..., websocket_...=...)` tuning (ztf_viewer/app.py). Comma-separated allowlist.
 WEBSOCKET_ALLOWED_ORIGINS = [
     origin
     for origin in os.environ.get(
@@ -73,10 +71,5 @@ WEBSOCKET_ALLOWED_ORIGINS = [
 WEBSOCKET_MAX_WORKERS = int(os.environ.get("WEBSOCKET_MAX_WORKERS", "4"))
 # Closes a connection that has sent nothing (not even a heartbeat) for this long, in ms.
 WEBSOCKET_INACTIVITY_TIMEOUT_MS = int(os.environ.get("WEBSOCKET_INACTIVITY_TIMEOUT_MS", "300000"))
-# The deployed reverse proxy has no proxy_read_timeout configured anywhere, so nginx's compiled
-# 60s default is what's actually live (not the 1h the ops repo intends but never applies). An
-# idle WS connection survives only on heartbeats landing under that ceiling, so this must stay
-# well below 60000ms with real margin -- raising it toward 60000 would silently break idle
-# connections in production. If the proxy timeout is ever fixed, a low value here is still
-# correct, just more conservative than it needs to be.
+# Must stay well under the deployed proxy's live 60s read-timeout default, in ms.
 WEBSOCKET_HEARTBEAT_INTERVAL_MS = int(os.environ.get("WEBSOCKET_HEARTBEAT_INTERVAL_MS", "20000"))

--- a/ztf_viewer/pages/viewer.py
+++ b/ztf_viewer/pages/viewer.py
@@ -2028,8 +2028,7 @@ async def load_fits_for_graph_clicked(data, dr):
     Output("skybot", "children"),
     [Input("graph", "clickData")],
     [State("dr", "children")],
-    # First callback opted into the WS transport: no cookies, no chained outputs, so a WS-path
-    # regression stays contained while the HTTP fallback covers everything else.
+    # First callback opted into the WS transport: no cookies, no chained outputs.
     websocket=True,
 )
 async def update_skybot_for_graph_clicked(data, dr):

--- a/ztf_viewer/pages/viewer.py
+++ b/ztf_viewer/pages/viewer.py
@@ -2024,7 +2024,14 @@ async def load_fits_for_graph_clicked(data, dr):
     ]
 
 
-@callback(Output("skybot", "children"), [Input("graph", "clickData")], [State("dr", "children")])
+@callback(
+    Output("skybot", "children"),
+    [Input("graph", "clickData")],
+    [State("dr", "children")],
+    # First callback opted into the WS transport: no cookies, no chained outputs, so a WS-path
+    # regression stays contained while the HTTP fallback covers everything else.
+    websocket=True,
+)
 async def update_skybot_for_graph_clicked(data, dr):
     if data is None:
         raise PreventUpdate


### PR DESCRIPTION
## What this does

Enables Dash's WebSocket callback transport (`dash[fastapi]` 4.4.1) in `ztf_viewer/app.py`,
opts one callback into it, and configures **exactly one** value:

```python
websocket_heartbeat_interval=WEBSOCKET_HEARTBEAT_INTERVAL_MS,
```

That is the whole shape of this PR, and it is deliberate, not incomplete. The plan named five
`dash.Dash(...)` WebSocket arguments to consider: `websocket_callbacks`, `websocket_allowed_origins`,
`websocket_max_workers`, `websocket_inactivity_timeout`, `websocket_heartbeat_interval`. All five
exist in the installed Dash version (verified by reading `dash/dash.py`, not guessed). Four of
them are **not** passed here, each for a checked, specific reason:

- `websocket_callbacks` stays at its default `False` — see "opt-in" below.
- `websocket_allowed_origins` is not set. Dash's own default is `None`, stored internally as
  `websocket_allowed_origins or []` (`dash/dash.py:491,666`) — an empty list. Passing an empty
  list, or not passing the argument at all, computes the identical value, so configuring it
  would have been a no-op. There is also no cross-origin use case to justify a non-empty list:
  the viewer's WS client connects from its own page, and Dash's origin check
  (`dash/backends/_fastapi.py`'s `validate_origin`) already accepts that via a same-Host
  fallback that requires no allowlist entry at all — see "the origin check" below.
- `websocket_max_workers` is not set. That argument sizes the WS handler's *sync*-callback
  thread pool (`dash/backends/base_server.py`'s `get_callback_executor` — its docstring states
  async callbacks run directly on the connection event loop and never touch this pool). Every
  callback in this app is registered as a coroutine — `ztf_viewer/callbacks.py` wraps every
  registration, and `tests/test_callbacks_shim.py::test_every_server_side_callback_is_a_coroutine_function`
  pins that invariant, and a direct `grep` confirms nothing anywhere calls `app.callback`
  except that one wrapping call site — so nothing can ever reach that executor regardless of
  its size. Dash's own default is `4`.
- `websocket_inactivity_timeout` is not set. Dash's own default is `300000` (ms) —
  `dash/dash.py:492` — which is exactly the value an earlier version of this PR configured
  explicitly. Passing it changed nothing.

Config that looks like a tuning knob but cannot affect behavior is worse than no config, since
a future reader will try to tune it and be confused when nothing changes. So `ztf_viewer/config.py`
gains exactly one new value, `WEBSOCKET_HEARTBEAT_INTERVAL_MS`, and `ztf_viewer/app.py` passes
exactly one new argument.

**Opt-in, not global.** The transport is available, but the global `websocket_callbacks` flag
stays off. Only one callback — `update_skybot_for_graph_clicked` (`ztf_viewer/pages/viewer.py`)
— opts in via `websocket=True`: it sets no cookies, chains into no other callback, and is
reachable with a single click on a light-curve point, so it is easy to exercise and its blast
radius is contained if something regresses. Every other callback keeps dispatching over the
existing HTTP POST path. Migrating the rest of the callbacks is the next PR (`stream`, i.e.
`aio-stream`), not this one.

## The heartbeat bound (the one value that is genuinely load-bearing)

`websocket_heartbeat_interval` is in **milliseconds**. Dash's own default is `30000` (30s). The
deployed reverse proxy's effective running configuration has no
`proxy_read_timeout`/`proxy_send_timeout`/`proxy_connect_timeout` directive anywhere, so nginx's
compiled **60s default** is what's actually enforced today — not the longer timeout the ops repo
intends but never applies.

Against that live 60s ceiling, Dash's 30s default leaves only a 2x margin — a **single** dropped
or delayed heartbeat can already push past the 60s window and drop the connection, with no error
anywhere that would show up in review. `WEBSOCKET_HEARTBEAT_INTERVAL_MS` defaults instead to
**20000 (20s)**: that leaves room to lose one heartbeat entirely and still land inside the live
60s window on the next one. That margin — not just "lower is safer" — is the justification for
overriding Dash's default at all. It's configurable via env for deployments that need to tune it
further; the comment in `ztf_viewer/config.py` is intentionally short (the reasoning lives here,
not in the code) but stays correct if/when the proxy timeout is fixed: a longer real timeout only
makes a conservative heartbeat *more* comfortable, never wrong.

`tests/test_websocket_transport.py::test_heartbeat_interval_is_bounded_below_the_live_proxy_ceiling`
pins this: it fails if the interval is ever raised past half the live 60s ceiling, which is
exactly the failure mode that would otherwise be silent until something disconnects in
production.

## The origin check: same-Host fallback, no allowlist configured

Dash's `validate_origin` (`dash/backends/_fastapi.py`, around line 696) accepts a WebSocket
connection either because `Origin` is in an explicit allowlist, **or** because
`urlparse(origin).netloc == host` (the request's `Host` header) — a same-origin fallback that
needs no listing at all. The viewer's own page is always the same origin as its WS endpoint, so
this fallback is what actually secures the handshake here, with nothing configured. This also
covers per-PR preview hosts (`pr<N>.ztf.snad.space`) automatically, since nginx-proxy passes the
real public `Host` through to the backend — no per-PR entry, and no wildcard weakening the check
for the one case it exists to reject (a genuine cross-origin connection).

This is proven end-to-end, not just read from the source:
`tests/test_websocket_transport.py::test_websocket_origin_check_allows_same_origin_and_rejects_cross_origin`
drives a real WS handshake through `TestClient.websocket_connect` with `app._websocket_allowed_origins`
forced to `[]` (i.e. nothing configured, matching Dash's own default) and asserts a same-origin
connection is accepted while a cross-origin one (`https://evil.example.com`) is rejected with
`WebSocketDisconnect`. It passes with no allowlist configured at all — that is exactly the point
it demonstrates.

## Tests (`tests/test_websocket_transport.py`)

- `test_websocket_origin_check_allows_same_origin_and_rejects_cross_origin` — a real WS handshake:
  same-origin accepted, cross-origin rejected, with no allowlist configured (see above)
- `test_heartbeat_interval_is_bounded_below_the_live_proxy_ceiling` — heartbeat interval equals
  config and stays ≤ half the live 60s proxy ceiling (the one test that actually protects
  against a silent production regression)
- `test_at_least_one_callback_opted_into_websocket_transport` — exactly one callback
  (`skybot.children`) has opted into `websocket=True`
- `test_http_fallback_still_works_for_a_non_websocket_callback` — a callback without
  `websocket=True` still dispatches successfully over the plain HTTP `/_dash-update-component`
  path (the fallback stays intact)

Full suite: `~/.virtualenvs/web/bin/python -m pytest --basetemp=/tmp/pytest` — all green.
`pre-commit run --all-files` — all green.

## What I verified live vs. what I could not

**Verified live**, running the app locally (`CACHE_TYPE=memory
UNAVAILABLE_CATALOGS_CACHE_TYPE=memory python -m ztf_viewer`) and driving it with a raw
`websockets` client against `/_dash-ws-callback`:
- a `callback_request` for `skybot.children` sent over `ws://` gets a `callback_response`
  back over the same connection (observed `{"status":"prevent_update"}` for a `clickData`-less
  request, i.e. the callback body actually ran on the WS path);
- a connection from a disallowed `Origin` (not same-Host) is rejected with HTTP 403 at the WS
  handshake, confirming the origin check is live, not just configured.

**Not verified** (per the task's hard rules, I did not touch the deployment host, any
container, or the proxy): reconnect-after-proxy-restart behavior, and the heartbeat actually
surviving a full 60s window against the *real* deployed proxy rather than the config asserted
in tests. Both require the actual deployment and are out of scope for this sandbox.

## Plan's acceptance criteria (`aio-ws`)

- "callbacks dispatch over `ws://` in devtools" — **met**, observed directly via a WS client
  (see above); did not additionally confirm via browser devtools.
- "reconnect after a proxy restart works" — **not verified**, requires the live deployment.
- "HTTP fallback still functions with `websocket_callbacks=False`" — **met**: global
  `websocket_callbacks` is `False` (its default, not overridden), and
  `test_http_fallback_still_works_for_a_non_websocket_callback` plus the rest of the existing
  suite (every other callback) confirms the HTTP path still works.

Draft, per the plan's house rules — not merging, not marking ready.
