### PR TITLE
Stream per-catalog tables over the WS transport

### DIFF
--- a/tests/pages/test_viewer.py
+++ b/tests/pages/test_viewer.py
@@ -25,10 +25,13 @@ import contextlib
 import inspect
 import json
 import time
+import types
+from typing import ClassVar
 from unittest.mock import AsyncMock, patch
 
 import pytest
 from astropy.table import Table
+from dash._callback_context import context_value
 from dash.exceptions import PreventUpdate
 from plotly.utils import PlotlyJSONEncoder
 
@@ -52,6 +55,8 @@ get_metadata = inspect.unwrap(viewer.get_metadata)
 get_layout = inspect.unwrap(viewer.get_layout)
 set_features_list = inspect.unwrap(viewer.set_features_list)
 set_lc_table = inspect.unwrap(viewer.set_lc_table)
+stream_tables = inspect.unwrap(viewer.stream_tables)
+set_table = viewer.set_table  # a plain async helper, never wrapped by the callback shim
 set_figure_link = viewer.set_figure_link  # a plain function, never wrapped
 
 
@@ -85,6 +90,10 @@ def _project(node):
 
 class _StubCatalogQuery:
     """A `_BaseCatalogQuery`-shaped stand-in whose `find()` does exactly what a test wants."""
+
+    # Only read by `set_table`'s HTML rendering path (`get_summary` reads table rows directly).
+    columns: ClassVar[dict] = {"separation": "Separation, arcsec", "__objname": "Name", "__type": "Type"}
+    html_columns: ClassVar[frozenset] = frozenset()
 
     def __init__(self, name, *, table=None, exc=None):
         self.query_name = name
@@ -476,3 +485,173 @@ def test_set_figure_link_prevents_update_when_range_is_backwards():
 def test_set_figure_link_raises_for_unknown_type():
     with pytest.raises(ValueError, match="lc_type"):
         set_figure_link("633207400004730", "dr24", "Title", None, None, None, None, "bogus", None, None, "png")
+
+
+# ---------------------------------------------------------------------------------------------
+# stream_tables -- progressive per-catalog table streaming over the WS transport.
+#
+# The central design hazard: consolidating the ~20 per-catalog `set_table` callbacks into one
+# streaming callback keyed on every search-radius input would re-query all catalogs on a single
+# radius edit. `stream_tables` is instead triggered only by oid/dr (once per object page load);
+# a radius change still runs only that one catalog's own `set_table` callback, registered with
+# `prevent_initial_call=True` above so it does not duplicate the initial fan-out.
+# ---------------------------------------------------------------------------------------------
+
+
+class _FakeWebsocket:
+    """Stands in for `ctx.websocket`. `is_shutdown` flips True after `shutdown_after` pushes."""
+
+    def __init__(self, shutdown_after=None):
+        self.pushes = 0
+        self._shutdown_after = shutdown_after
+
+    @property
+    def is_shutdown(self):
+        return self._shutdown_after is not None and self.pushes >= self._shutdown_after
+
+
+async def _run_stream_tables(catalogs, ws=None, oid="633207400004730", dr="dr24"):
+    ids, values = _radius_inputs(list(catalogs))
+    token = context_value.set(types.SimpleNamespace(dash_websocket=ws))
+    try:
+        with (
+            patch.object(viewer, "catalog_query_objects", lambda: catalogs),
+            patch.object(viewer, "get_catalog_query", lambda name: catalogs[name]),
+        ):
+            return await stream_tables(oid=oid, dr=dr, radius_ids=ids, radius_values=values)
+    finally:
+        context_value.reset(token)
+
+
+def test_stream_tables_triggered_only_by_oid_and_dr():
+    """Pins the trigger-granularity decision at the registration level: if this callback ever
+    grows an Input on the search-radius pattern, this fails before the amplification ships."""
+    streaming_entries = [e for e in viewer.app.callback_map.values() if e.get("websocket") and e.get("no_output")]
+    assert len(streaming_entries) == 1
+    assert [str(inp) for inp in streaming_entries[0]["raw_inputs"]] == ["oid.children", "dr.children"]
+
+
+async def test_single_radius_change_queries_only_that_catalog(monkeypatch):
+    """End-to-end guard for the same hazard: dispatching a real radius change for one catalog's
+    `set_table` callback over HTTP must not touch any other catalog's `find`."""
+    from dash import html
+    from fastapi.testclient import TestClient
+
+    from tests.conftest import reset_shared_process_pool, reset_shared_thread_pool
+
+    calls = {}
+
+    class _CountingCatalogQuery:
+        query_name = "Stub"
+        columns: ClassVar[dict] = {"separation": "Separation"}
+        html_columns: ClassVar[frozenset] = frozenset()
+
+        def __init__(self, name):
+            self._name = name
+
+        async def find(self, ra, dec, radius):
+            calls[self._name] = calls.get(self._name, 0) + 1
+            table = Table()
+            table["separation"] = [1.0]
+            return table
+
+    async def fake_get_coord(oid, dr):
+        return 10.0, 20.0
+
+    monkeypatch.setattr(viewer.find_ztf_oid, "get_coord", fake_get_coord)
+    monkeypatch.setattr(viewer, "get_catalog_query", _CountingCatalogQuery)
+
+    original_layout = viewer.app._layout, viewer.app._layout_is_function
+    original_error_mode = viewer.app.backend.error_handling_mode
+    viewer.app.layout = html.Div("x")
+    reset_shared_thread_pool()
+    reset_shared_process_pool()
+    try:
+        with TestClient(viewer.app.server) as client:
+            response = client.post(
+                "/_dash-update-component",
+                json={
+                    "output": "gcvs-table.children",
+                    "outputs": {"id": "gcvs-table", "property": "children"},
+                    "inputs": [{"id": {"type": "search-radius", "index": "gcvs"}, "property": "value", "value": 5}],
+                    "state": [
+                        {"id": "oid", "property": "children", "value": "633207400004730"},
+                        {"id": "dr", "property": "children", "value": "dr24"},
+                    ],
+                    "changedPropIds": ['{"index":"gcvs","type":"search-radius"}.value'],
+                },
+            )
+    finally:
+        viewer.app._layout, viewer.app._layout_is_function = original_layout
+        viewer.app.backend.error_handling_mode = original_error_mode
+
+    assert response.status_code == 200
+    assert calls == {"gcvs": 1}
+
+
+async def test_stream_tables_pushes_fast_catalog_before_slow_one_finishes():
+    """Streaming actually streams: a slow catalog must not delay a fast one's table."""
+    pushed = []
+
+    def fake_set_props(component_id, props):
+        pushed.append((component_id, time.perf_counter()))
+
+    catalogs = {
+        "fast": _SleepingCatalogQuery("Fast", delay=0.0, table=_stub_table()),
+        "slow": _SleepingCatalogQuery("Slow", delay=0.3, table=_stub_table()),
+    }
+    with patch.object(viewer, "set_props", fake_set_props):
+        await _run_stream_tables(catalogs)
+
+    assert [component_id for component_id, _ in pushed] == ["fast-table", "slow-table"]
+    # The fast push must land well before the slow catalog's own delay has elapsed.
+    assert pushed[1][1] - pushed[0][1] > 0.1
+
+
+async def test_stream_tables_failing_catalog_contributes_nothing():
+    """A catalog whose query raises must not be pushed at all -- indistinguishable from a
+    catalog that was never queried -- and must not stop its sibling from streaming."""
+    pushed = {}
+
+    def fake_set_props(component_id, props):
+        pushed[component_id] = props
+
+    catalogs = {
+        "broken": _StubCatalogQuery("Broken", exc=RuntimeError("boom")),
+        "ok": _other_succeeding_catalog(),
+    }
+    with patch.object(viewer, "set_props", fake_set_props):
+        await _run_stream_tables(catalogs)
+
+    assert "broken-table" not in pushed
+    assert "ok-table" in pushed
+
+
+async def test_stream_tables_stops_on_disconnect():
+    """Closing the tab mid-load must stop querying catalogs that have not started yet."""
+    pushed = []
+    ws = _FakeWebsocket(shutdown_after=1)
+
+    def fake_set_props(component_id, props):
+        pushed.append(component_id)
+        ws.pushes += 1
+
+    catalogs = {
+        "first": _SleepingCatalogQuery("First", delay=0.0, table=_stub_table()),
+        "second": _SleepingCatalogQuery("Second", delay=0.2, table=_stub_table()),
+    }
+    with patch.object(viewer, "set_props", fake_set_props), pytest.raises(PreventUpdate):
+        await _run_stream_tables(catalogs, ws=ws)
+
+    # Only the catalog that had already completed before the shutdown check got pushed.
+    assert pushed == ["first-table"]
+
+
+async def test_set_table_still_works_over_the_unconverted_http_path():
+    """The per-catalog `set_table` callback itself (the HTTP fallback path) is unchanged."""
+    with (
+        patch.object(viewer.find_ztf_oid, "get_coord", AsyncMock(return_value=(10.0, 20.0))),
+        patch.object(viewer, "get_catalog_query", lambda name: _other_succeeding_catalog()),
+    ):
+        div = await set_table(radius=3.0, oid="633207400004730", dr="dr24", catalog="other")
+    assert "Other Object" in _dump(div)

--- a/tests/test_websocket_transport.py
+++ b/tests/test_websocket_transport.py
@@ -5,8 +5,8 @@ proxy's live 60s read-timeout default. HTTP-transport callbacks still work.
 
 import pytest
 from dash import Input, Output, html
+from fastapi import WebSocketDisconnect
 from fastapi.testclient import TestClient
-from starlette.websockets import WebSocketDisconnect
 
 from tests.conftest import reset_shared_process_pool, reset_shared_thread_pool
 from ztf_viewer import config
@@ -62,7 +62,9 @@ def test_at_least_one_callback_opted_into_websocket_transport():
     import ztf_viewer.__main__ as main_module
 
     opted_in = [callback_id for callback_id, entry in main_module.app.callback_map.items() if entry.get("websocket")]
-    assert opted_in == ["skybot.children"]
+    # skybot.children (single Output) plus stream_tables (no Output, hashed id below).
+    assert "skybot.children" in opted_in
+    assert len(opted_in) == 2
 
 
 def test_http_fallback_still_works_for_a_non_websocket_callback():

--- a/ztf_viewer/pages/viewer.py
+++ b/ztf_viewer/pages/viewer.py
@@ -14,7 +14,7 @@ import plotly.graph_objects as go
 from astropy.coordinates import SkyCoord
 from astropy.table import QTable
 from astropy.units import Quantity
-from dash import ALL, MATCH, Input, Output, State, dcc, html
+from dash import ALL, MATCH, Input, Output, State, ctx, dcc, html, set_props
 from dash.dash_table import DataTable
 from dash.exceptions import PreventUpdate
 from immutabledict import immutabledict
@@ -2097,10 +2097,59 @@ def set_tables():
                 State("oid", "children"),
                 State("dr", "children"),
             ],
+            # The initial fan-out over every catalog is handled by `stream_tables` below;
+            # this callback only has to react to this one catalog's radius changing later.
+            prevent_initial_call=True,
         )(partial(set_table, catalog=catalog))
 
 
 set_tables()
+
+
+async def _find_table_for_stream(catalog, radius, oid, dr):
+    """Isolate one catalog's query so a failure can never stop its siblings from streaming."""
+    try:
+        result = await set_table(radius, oid, dr, catalog)
+    except Exception:  # noqa: BLE001 - isolates one catalog's failure from its siblings
+        # Contributes nothing -- indistinguishable from a catalog that was never queried.
+        result = None
+    return catalog, result
+
+
+@callback(
+    Input("oid", "children"),
+    Input("dr", "children"),
+    State({"type": "search-radius", "index": ALL}, "id"),
+    State({"type": "search-radius", "index": ALL}, "value"),
+    # No Output: results are pushed with `set_props` as each catalog's query completes, so fast
+    # catalogs paint without waiting on slow ones.
+    websocket=True,
+)
+async def stream_tables(oid, dr, radius_ids, radius_values):
+    """Fan out to every catalog once per object page load, streaming each table as it completes.
+
+    Triggered only by `oid`/`dr`, not by the per-catalog radius inputs -- a single radius change
+    still re-runs only that one catalog's `set_table` callback above. Consolidating this into one
+    callback keyed on every radius input would re-query all ~20 catalogs on every radius edit;
+    keeping the per-catalog callbacks for that path avoids the amplification entirely.
+    """
+    ws = ctx.websocket
+    radii = {id_["index"]: value for id_, value in zip(radius_ids, radius_values)}
+    catalogs = catalog_query_objects()
+    tasks = [
+        asyncio.ensure_future(_find_table_for_stream(catalog, radii.get(catalog), oid, dr)) for catalog in catalogs
+    ]
+    try:
+        async for finished in asyncio.as_completed(tasks):
+            if ws is not None and ws.is_shutdown:
+                raise PreventUpdate
+            catalog, result = await finished
+            if result is not None:
+                set_props(f"{catalog}-table", {"children": result})
+    finally:
+        for task in tasks:
+            if not task.done():
+                task.cancel()
 
 
 @callback(


### PR DESCRIPTION
## Summary

First slice of `aio-stream` (see `plans/001_async_dash.md`): the per-catalog
tables only. `get_summary`'s incremental rows and the light-curve figure are
separate, later PRs -- this one establishes the pattern they should follow.

## Trigger-granularity decision (the central hazard)

Today's `set_tables()` registers ~20 independent `Output(f"{catalog}-table",
"children")` callbacks, each with `Input({"type": "search-radius", "index":
catalog}, "value")`. A naive consolidation into one streaming callback keyed
on `Input({"type": "search-radius", "index": ALL}, "value")` would re-query
**every** catalog whenever **any single** radius changes -- a 20x amplification
on every radius tweak, and a behavioural regression from today's
per-catalog independence.

**Decision: keep the per-catalog callbacks for the radius-edit path, and add a
separate streaming callback for the initial fan-out.**

- The 19 `set_table` callbacks are unchanged except for `prevent_initial_call=True`
  (`ztf_viewer/pages/viewer.py`'s `set_tables()`). A radius edit still triggers
  exactly one catalog's own callback, over HTTP, exactly as before.
- A new `stream_tables` callback (`websocket=True`, no `Output`) is triggered
  only by `Input("oid", "children")` / `Input("dr", "children")` -- i.e. once
  per object page load, never by a radius change. It reads the layout's
  current radius values via `State({"type": "search-radius", "index": ALL},
  ...)`, fans out to every catalog via `asyncio.as_completed`, and pushes each
  table with `set_props` as its query finishes.
- Pinned by `test_stream_tables_triggered_only_by_oid_and_dr` (asserts the
  registered `raw_inputs` are exactly `oid.children`/`dr.children` -- fails if
  this callback ever grows a radius Input) and
  `test_single_radius_change_queries_only_that_catalog` (an end-to-end HTTP
  dispatch of one catalog's radius change, asserting no other catalog's
  `find` was ever called).

## What streams vs. what doesn't

- Streams: the initial per-catalog table fan-out on page load, via
  `stream_tables`.
- Does not stream (HTTP, unchanged): a later radius edit for one catalog
  (`set_table`'s own callback), `get_summary`, the light-curve figure, and
  everything else.

## Disconnect handling

`stream_tables`'s loop checks `ctx.websocket.is_shutdown` before processing
each completed catalog and raises `PreventUpdate`; the `finally` block cancels
any tasks still in flight. Covered by
`test_stream_tables_stops_on_disconnect`, which simulates a mid-stream
disconnect and asserts the not-yet-completed catalog's task never gets pushed.
I could not find a way to also exercise this over a real WebSocket connection
in-process (unlike the plain callback dispatch test), so the real-transport
disconnect path is exercised only by the origin/heartbeat tests already in
`tests/test_websocket_transport.py`, not by a new test here.

## Failure isolation

`_find_table_for_stream` catches any exception per catalog and pushes
nothing for it (`test_stream_tables_failing_catalog_contributes_nothing`) --
indistinguishable from a catalog that was never queried, matching the
invariant `get_summary`'s tests already pin, without touching `get_summary`
itself.

## Also folded in

`tests/test_websocket_transport.py` imported `WebSocketDisconnect` from
`starlette.websockets`; `starlette` isn't a declared dependency (only
transitive via `fastapi`). Switched to `from fastapi import
WebSocketDisconnect`, which re-exports the identical object.

## Verified live

Ran the app locally (`CACHE_TYPE=memory UNAVAILABLE_CATALOGS_CACHE_TYPE=memory`,
`python -m ztf_viewer`) and loaded a real object page in a real browser
(Firefox via devtools MCP) against live upstreams. Confirmed:
- Right after navigation the catalog sections render with empty tables
  ("Loading...", then headers with no rows).
- A follow-up snapshot mid-load shows a genuinely partial state: Astro-COLIBRI
  already has rows while GCVS/VSX/SPICY/SDSS/ATLAS/ZTF-periodic/Pan-STARRS/TNS/
  Astrocats/Otter/OGLE/Simbad/Gaia/ALeRCE/Fink are still empty -- i.e. tables
  really do paint independently as their own upstream responds, not all at once.
- A later snapshot shows all tables filled in, including an
  `Astrocats -> "Catalog data is temporarily unavailable"` case rendering
  correctly (the `CatalogUnavailable` path through `set_table` still works
  unchanged).

**Not verified live:** I did not click-test an actual radius-value edit in the
browser to watch only one catalog's table refresh (time-boxed) -- that
behaviour is covered by the automated end-to-end test instead
(`test_single_radius_change_queries_only_that_catalog`), which dispatches a
real HTTP `_dash-update-component` request and asserts call counts.

## Outstanding from the plan's `aio-stream` acceptance criteria

- "With an artificially delayed catalog, the rest of the page renders without
  waiting" -- covered by
  `test_stream_tables_pushes_fast_catalog_before_slow_one_finishes`
  (wall-clock overlap) plus the live partial-state observation above.
- "Closing the tab mid-load stops server-side work (assert via logs)" --
  covered at the unit level (`test_stream_tables_stops_on_disconnect`), not
  via server logs against a live browser disconnect; left for a follow-up if
  that's wanted.
- `get_summary`'s incremental rows and the light-curve figure streaming are
  explicitly out of scope for this PR, per the task split.

## Test plan

- [x] `~/.virtualenvs/web/bin/python -m pytest --basetemp=/tmp/pytest` -- full
      suite green.
- [x] `pre-commit run --all-files` -- green.
- [x] Live smoke test in a real browser against real upstreams (see above).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01K9Q6vcLGkKQpsSd4qmYocF