### PR TITLE
Raise THREAD_POOL_SIZE default from 16 to 64

### DIFF
--- a/ztf_viewer/config.py
+++ b/ztf_viewer/config.py
@@ -18,7 +18,7 @@ DUSTMAPS_API_URL = os.environ.get("DUSTMAPS_API_URL", "https://dustmaps.snad.spa
 
 # Size of both thread pools the entrypoint installs: asyncio's default executor and anyio's
 # sync-route limiter. Caps how many blocking calls the single event loop can have in flight.
-THREAD_POOL_SIZE = int(os.environ.get("THREAD_POOL_SIZE", "16"))
+THREAD_POOL_SIZE = int(os.environ.get("THREAD_POOL_SIZE", "64"))
 
 # Size of the CPU-bound process pool (ztf_viewer/procpool.py).
 PROCESS_POOL_SIZE = int(os.environ.get("PROCESS_POOL_SIZE", "2"))


### PR DESCRIPTION
## Summary

Owner-directed change: `THREAD_POOL_SIZE`'s default (`ztf_viewer/config.py`) goes from 16 to 64. This is a deliberate sizing decision by the project owner, not something this PR argues for on its own merits. `PROCESS_POOL_SIZE` is untouched, still defaults to 2. Both remain env-overridable in the existing `int(os.environ.get("NAME", "default"))` style; no other behavior changes.

## Consequence check: how many blocking threads does this actually allow?

Read `ztf_viewer/__main__.py`'s `_size_thread_pools` and the anyio source directly to confirm rather than assume:

- `_thread_pool = ThreadPoolExecutor(max_workers=THREAD_POOL_SIZE, ...)` is installed as asyncio's default executor via `set_default_executor`.
- `anyio.to_thread.current_default_thread_limiter().total_tokens = THREAD_POOL_SIZE` is set separately.
- `anyio.to_thread.run_sync` (used by anyio's sync-route limiter for Dash's sync callbacks) calls into `get_async_backend().run_sync_in_worker_thread(...)`, which manages **its own** worker threads — it does not run on asyncio's default executor. Confirmed by reading `anyio.to_thread.run_sync`'s source in the installed package.

So these are two independent thread pools, each capped at `THREAD_POOL_SIZE`, not one pool counted twice. With the default at 64, that's up to **64 (asyncio executor) + 64 (anyio limiter) = 128 blocking threads per process**, not 64.

## What else was checked

Searched the repo (code, tests, Dockerfile, docker-compose*.yml, `.ci/`, README.md, AGENTS.md) for anything depending on the old default of 16:

- No hardcoded `16` anywhere outside `config.py`'s old value.
- `tests/conftest.py`'s `reset_shared_thread_pool` reads `main_module.THREAD_POOL_SIZE` dynamically (not a literal), so it already tracks the new default; no test changes were needed.
- No Dockerfile/compose/CI file sets or documents `THREAD_POOL_SIZE`.
- README.md/AGENTS.md don't mention the value.
- `plans/001_async_dash.md` references the old default of 16 in several places but is left untouched — bookkeeping there is a separate PR by convention.

Full `pytest --basetemp=/tmp/pytest` suite is green, `pre-commit run --all-files` is green, and the app starts cleanly locally with `CACHE_TYPE=memory UNAVAILABLE_CATALOGS_CACHE_TYPE=memory` at the new default — no startup slowdown or resource issue observed.

## What to watch after deployment

~128 concurrent thread-offloaded calls per process means substantially more simultaneous outbound requests to the same upstreams from one IP than before (master plus each `pr<N>` preview are separate containers sharing that IP). Watch for a rise in upstream failures or rate-limiting that would present as catalogs looking flaky — CDS services (SIMBAD/VizieR/MOCServer/Sesame) are the most exposure-prone given their published per-IP rate limits.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01K9Q6vcLGkKQpsSd4qmYocF