### PR TITLE
Import WebSocketDisconnect from fastapi, not starlette

### DIFF
--- a/tests/test_websocket_transport.py
+++ b/tests/test_websocket_transport.py
@@ -5,8 +5,8 @@ proxy's live 60s read-timeout default. HTTP-transport callbacks still work.
 
 import pytest
 from dash import Input, Output, html
+from fastapi import WebSocketDisconnect
 from fastapi.testclient import TestClient
-from starlette.websockets import WebSocketDisconnect
 
 from tests.conftest import reset_shared_process_pool, reset_shared_thread_pool
 from ztf_viewer import config


### PR DESCRIPTION
`tests/test_websocket_transport.py` imported `WebSocketDisconnect` from `starlette.websockets`. `starlette` is not declared in `pyproject.toml` — it arrives transitively via `fastapi`, which re-exports the identical object (verified: `fastapi.WebSocketDisconnect is starlette.websockets.WebSocketDisconnect`).

This is the convention the route port established: import from `fastapi`, which `pyproject.toml` actually names.

Salvaged from #696, which was closed without merging. One line, no behaviour change; the four WS transport tests pass.