### PR TITLE
Remove skybot's WebSocket opt-in

### DIFF
--- a/tests/test_websocket_transport.py
+++ b/tests/test_websocket_transport.py
@@ -1,6 +1,7 @@
 """The WS callback transport is enabled: same-origin connections work via dash's own same-Host
 fallback, cross-origin ones are still rejected, and the heartbeat is pinned under the deployed
-proxy's live 60s read-timeout default. HTTP-transport callbacks still work.
+proxy's live 60s read-timeout default. No callback currently opts in, and HTTP-transport
+callbacks still work.
 """
 
 import pytest
@@ -52,8 +53,11 @@ def test_heartbeat_interval_is_bounded_below_the_live_proxy_ceiling():
     assert WEBSOCKET_HEARTBEAT_INTERVAL_MS <= LIVE_PROXY_READ_TIMEOUT_MS / 2
 
 
-def test_at_least_one_callback_opted_into_websocket_transport():
-    """Proves the transport is actually reachable, not just configured and unused."""
+def test_no_callback_opts_into_websocket_transport_without_using_streaming():
+    """A `websocket=True` opt-in must be justified by actually using streaming (set_props,
+    progressive delivery); plain request/response callbacks gain nothing from it while losing
+    the HTTP fallback. If this fails, either justify the new opt-in with real streaming and
+    update this test, or drop `websocket=True` from the callback."""
     config.CACHE_TYPE = "memory"
     config.UNAVAILABLE_CATALOGS_CACHE_TYPE = "memory"
 
@@ -62,7 +66,7 @@ def test_at_least_one_callback_opted_into_websocket_transport():
     import ztf_viewer.__main__ as main_module
 
     opted_in = [callback_id for callback_id, entry in main_module.app.callback_map.items() if entry.get("websocket")]
-    assert opted_in == ["skybot.children"]
+    assert opted_in == []
 
 
 def test_http_fallback_still_works_for_a_non_websocket_callback():

--- a/ztf_viewer/pages/viewer.py
+++ b/ztf_viewer/pages/viewer.py
@@ -2028,8 +2028,6 @@ async def load_fits_for_graph_clicked(data, dr):
     Output("skybot", "children"),
     [Input("graph", "clickData")],
     [State("dr", "children")],
-    # First callback opted into the WS transport: no cookies, no chained outputs.
-    websocket=True,
 )
 async def update_skybot_for_graph_clicked(data, dr):
     if data is None:


### PR DESCRIPTION
## Why

The WS callback transport was verified to work end-to-end in a real browser: a click dispatches `skybot.children` as a `callback_request` through the SharedWorker's WebSocket, with zero HTTP request for that callback, while a sibling callback sharing the same Input (`fits-to-show.children`) goes over HTTP. So this is not being removed because it's broken — it works.

It's being removed because skybot is a plain request/response callback: no `set_props`, no progressive delivery, nothing that the WS transport improves. It was opted in as a canary to prove the transport worked, which it has now done conclusively. With nothing to gain, it shouldn't carry the transport's one real gap.

### The gap, precisely

There are two distinct fallback paths, and only one of them exists.

**Capability fallback — exists.** In the renderer bundle, dispatch computes `useWebSocket = !background && (isWebSocketEnabled(config) || cb.callback.websocket && isWebSocketAvailable(config))`, and `isWebSocketAvailable` requires `typeof SharedWorker !== 'undefined'`. A browser without `SharedWorker` never attempts WS at all — it takes the HTTP path cleanly at dispatch time, no failed connection, no delay. Older/limited browsers are unaffected by this change either way.

**Runtime-failure fallback — does not exist.** A browser that has `SharedWorker` passes the capability check and commits to the WS path. Reading `dash/dash-renderer/build/dash-ws-worker.js`: when the socket isn't open, `send()` pushes the request onto an internal `messageQueue` and retries the *connection* (`maxRetries: 10`, 1s initial delay, 30s cap, jitter — roughly a couple of minutes total). It never re-dispatches the queued request over HTTP. On exhausting retries it emits an `ERROR` to the renderer (`"Max reconnection attempts reached"`).

So the actual exposure is narrow: modern browsers (with `SharedWorker`) on networks that block the WS `Upgrade` (restrictive proxy, VPN, captive portal). For that population, an opted-in callback doesn't degrade to HTTP — it hangs for a couple of minutes and then errors. That's a real but small risk, and skybot buys nothing in exchange for taking it.

### The rule

**A WebSocket opt-in must be justified by actually using streaming.** Callbacks that gain nothing from WS shouldn't bear the no-runtime-fallback risk. This doesn't argue against WS opt-in generally — where streaming provides a real benefit (the planned `get_summary` slice), accepting this narrow risk is a defensible trade.

## What changed

- `ztf_viewer/pages/viewer.py`: dropped `websocket=True` (and its explanatory comment) from `update_skybot_for_graph_clicked`. The transport stays enabled at the app level (`websocket_heartbeat_interval` in `ztf_viewer/app.py` untouched) — it now simply has no users until a future PR introduces genuine streaming.
- `tests/test_websocket_transport.py`: replaced `test_at_least_one_callback_opted_into_websocket_transport` (asserted `opted_in == ["skybot.children"]`) with `test_no_callback_opts_into_websocket_transport_without_using_streaming` (asserts `opted_in == []`), which fails loudly if a future `websocket=True` opt-in is added, pointing at the rule in its docstring/assertion context. Updated the module docstring to reflect that no callback currently opts in.

## Test plan
- [x] `~/.virtualenvs/web/bin/python -m pytest --basetemp=/tmp/pytest` — full suite green (one pre-existing, network-dependent failure in `test_golden_http.py::test_figure_pdf`, unrelated to this change — reproduces on `origin/master` too, hits a live external ZTF DR API returning 404 for `dr24`).
- [x] `pre-commit run --all-files` — green.