### PR TITLE
aio-cleanup: remove the dead sync timeout() helper

### DIFF
--- a/ztf_viewer/util.py
+++ b/ztf_viewer/util.py
@@ -8,7 +8,6 @@ import math
 import re
 from collections import defaultdict
 from collections.abc import Callable
-from concurrent.futures import ThreadPoolExecutor
 from functools import wraps
 from html import escape as html_escape
 from itertools import chain, count
@@ -290,29 +289,8 @@ def compose_plus_minus_expression(value, lower, upper, **to_str_kwargs):
     """)
 
 
-def timeout(seconds: float, exception=TimeoutError, exception_kwargs=None) -> Callable:
-    """A decorator to limit the execution time of a function"""
-
-    def decorator(func):
-        @wraps(func)
-        def wrapper(*args, **kwargs):
-            with ThreadPoolExecutor(max_workers=1) as executor:
-                future = executor.submit(func, *args, **kwargs)
-                try:
-                    return future.result(timeout=seconds)
-                except TimeoutError:
-                    if exception_kwargs is None:
-                        raise exception
-                    raise exception(**exception_kwargs)
-
-        return wrapper
-
-    return decorator
-
-
 def async_timeout(seconds: float, exception=TimeoutError, exception_kwargs=None) -> Callable:
-    """The async sibling of :func:`timeout`: wraps a coroutine function in ``asyncio.timeout``
-    instead of spawning a thread."""
+    """Wraps a coroutine function in ``asyncio.timeout``."""
 
     def decorator(func):
         @wraps(func)


### PR DESCRIPTION
## Scope

Implements the dead-code bullets of `aio-cleanup`. Per-target findings below — most were already dead by the time this PR was written, one was removed, and one plan assumption needed correcting.

## 1. Sync `timeout()` helper (`ztf_viewer/util.py`) — DEAD, removed

`ztf_viewer/catalogs/conesearch/_base.py` sets `self._timeout_decorator = async_timeout(...)` (it imports `async_timeout`, not `timeout`, at line 25) — the `_base.py:187` reference the task description flagged for scrutiny resolves to the async path, not the sync one. A repo-wide grep for any import of the bare `timeout` name from `ztf_viewer.util` (outside its own definition and `async_timeout`'s docstring) turned up nothing — no application code, no test. Removed the function and the `ThreadPoolExecutor` import it was the only user of. `Callable` (used by `async_timeout`) stays.

## 2. Sync `cache()` variant — nothing to remove

`ztf_viewer/cache/decorator.py` no longer exposes a separate sync-vs-async decorator for callers to choose between. `make_dispatching_cache` composes `make_cache` (internal sync-only factory) and `make_async_cache` (internal async-only factory) into the single public `cache()`, which dispatches on `inspect.iscoroutinefunction` at decoration time. The internal sync factory is still very much in use — every `@cache()` over a plain `def` routes through it — so there's no dead sync variant sitting alongside it. This matches what the plan itself now expects ("aio-cache-async makes cache() dispatch instead, so the choice a guard would police no longer exists").

## 3. `flask` remnants — nothing to remove

- `pyproject.toml` has no `flask` dependency entry at all (direct or extras); `flask` only appears there in an unrelated pytest-asyncio config comment, and separately in `uv.lock` as a transitive dependency.
- Repo-wide grep for `flask`/`Flask` outside README/AGENTS/CHANGELOG/the plan turns up only: comparison comments/docstrings describing pre-migration behaviour (`web.py`, `loop_registry.py`, `cache/memory.py`, `cache/redis.py`) and `tests/test_flask_import_guard.py`, which is the guard test itself (asserts `flask` is never imported under `ztf_viewer/`) — not a remnant to remove.
- No actual `import flask` / `from flask import ...` anywhere under `ztf_viewer/`.

Nothing here is "left over" in the sense the plan bullet means; it's already gone.

## Correction to the plan: `requests` cannot be dropped as written

The plan's `aio-cleanup` section says to "drop the `requests` direct dependency once the async-I/O stack is complete." This is no longer accurate — `requests` is still used **directly**, not just transitively:

- `ztf_viewer/catalogs/extinction/_base.py` — constructs `requests.Session()` (line 32) and catches `requests.RequestException` (line 39).
- `ztf_viewer/catalogs/snad/catalog.py` — does `requests.get(self.url, stream=True)` (line 44) and catches `requests.exceptions.ConnectionError` (line 51).

Separately, several modules import `RequestException` purely to catch what sync third-party clients raise (astroquery/alerce/antares are not being ported to async — see the plan's own baseline note):
- `ztf_viewer/catalogs/conesearch/_base.py:18` (`from requests import RequestException`, caught at line 190 alongside `httpx.HTTPError`)
- `ztf_viewer/catalogs/conesearch/antares.py:12`
- `ztf_viewer/catalogs/conesearch/gaia_dr3.py:9` (`from requests.exceptions import RequestException`)
- `ztf_viewer/catalogs/conesearch/alerce.py:13`
- `ztf_viewer/pages/viewer.py:21` (`from requests import ConnectionError`) — found in the same survey; out of scope to touch here per this PR's file boundaries, but the same category of legitimate use.

None of this is dead code — the sync direct usage (extinction dust-map session, SNAD catalog downloader) would need real async conversion work with its own risk, and the exception-catching imports are correct regardless since the sync clients genuinely raise those types. **`requests` was left in `pyproject.toml` unchanged.** This PR does not convert any of the above; a separate PR should fold this correction into `plans/001_async_dash.md` (not edited here).

## Verification

- `~/.virtualenvs/web/bin/python -m pytest --basetemp=/tmp/pytest` — full suite green (one `@pytest.mark.network` test, `test_figure_folded`, failed transiently on a real upstream 404 during one run; reproduced in isolation on both this branch and a clean `origin/master` worktree and passed both times — a flake, not a regression from this change).
- `pre-commit run --all-files` — green.
- App still imports/builds cleanly with `CACHE_TYPE=memory UNAVAILABLE_CATALOGS_CACHE_TYPE=memory`.

## Out of scope (left untouched per task boundaries)

`ztf_viewer/callbacks.py` and `ztf_viewer/pages/*.py` — another agent is concurrently retiring the callback shim there. `plans/001_async_dash.md`, `README.md`, `AGENTS.md`, `CHANGELOG.md` — separate PRs own those.
