### PR TITLE
Stream get_summary progressively over the WS transport

### DIFF
--- a/tests/pages/test_viewer.py
+++ b/tests/pages/test_viewer.py
@@ -25,13 +25,18 @@ import contextlib
 import inspect
 import json
 import time
+import types
 from unittest.mock import AsyncMock, patch
 
 import pytest
 from astropy.table import Table
+from dash import html
+from dash._callback_context import context_value
 from dash.exceptions import PreventUpdate
+from fastapi.testclient import TestClient
 from plotly.utils import PlotlyJSONEncoder
 
+from tests.conftest import reset_shared_process_pool, reset_shared_thread_pool
 from ztf_viewer import config
 
 # `ztf_viewer.pages.viewer` pulls in `ztf_viewer.catalogs`, whose `unavailable_catalogs` connects
@@ -166,17 +171,51 @@ def summary_upstreams(monkeypatch):
     monkeypatch.setattr(viewer, "get_catalog_query", lambda name: _NotFoundGaiaEdr3())
 
 
-def _run_get_summary(catalogs, summary_upstreams):
+class _FakeWebsocket:
+    """Stands in for `ctx.websocket`. `is_shutdown` flips True after `shutdown_after` pushes."""
+
+    def __init__(self, shutdown_after=None):
+        self.pushes = 0
+        self._shutdown_after = shutdown_after
+
+    @property
+    def is_shutdown(self):
+        return self._shutdown_after is not None and self.pushes >= self._shutdown_after
+
+
+async def _run_get_summary(catalogs, summary_upstreams, ws=None):
+    """Run `get_summary` and capture every `set_props("summary", ...)` push it makes.
+
+    `get_summary` has no Output any more -- it streams via `set_props` -- so this drives it like
+    the real callback dispatcher does: a fake `dash_websocket` in the callback context (None
+    mimics an HTTP-dispatched, non-WS client; a `_FakeWebsocket` mimics a real WS connection).
+    Returns the pushed `children` divs in call order; the last one is the final, complete render,
+    so a test that only cares about the finished page should compare against `pushed[-1]`.
+    """
     del summary_upstreams  # only needed for its monkeypatching side effect
     ids, values = _radius_inputs(catalogs)
-    return get_summary(
-        oid="633207400004730",
-        dr="dr24",
-        different_filter=None,
-        different_field=None,
-        radius_ids=ids,
-        radius_values=values,
-    )
+    pushed = []
+
+    def fake_set_props(component_id, props):
+        assert component_id == "summary"
+        pushed.append(props["children"])
+        if ws is not None:
+            ws.pushes += 1
+
+    token = context_value.set(types.SimpleNamespace(dash_websocket=ws))
+    try:
+        with patch.object(viewer, "set_props", fake_set_props):
+            await get_summary(
+                oid="633207400004730",
+                dr="dr24",
+                different_filter=None,
+                different_field=None,
+                radius_ids=ids,
+                radius_values=values,
+            )
+    finally:
+        context_value.reset(token)
+    return pushed
 
 
 def _other_succeeding_catalog():
@@ -213,11 +252,11 @@ async def test_get_summary_failing_catalog_matches_catalog_absent(make_failing_c
     """A catalog that fails must render identically to a catalog that was never queried at all,
     and must not disturb the catalogs that do succeed."""
     with make_failing_catalogs() as catalogs, patch.object(viewer, "catalog_query_objects", lambda: catalogs):
-        failing = await _run_get_summary(list(catalogs), summary_upstreams)
+        failing = (await _run_get_summary(list(catalogs), summary_upstreams))[-1]
 
     absent_catalogs = {"other": _other_succeeding_catalog()}
     with patch.object(viewer, "catalog_query_objects", lambda: absent_catalogs):
-        absent = await _run_get_summary(list(absent_catalogs), summary_upstreams)
+        absent = (await _run_get_summary(list(absent_catalogs), summary_upstreams))[-1]
 
     assert _dump(failing) == _dump(absent)
 
@@ -236,11 +275,11 @@ async def test_get_summary_skips_catalog_with_no_radius_input(summary_upstreams)
     whole summary. Guards against the radius lookup escaping the swallow list."""
     catalogs = {"other": _other_succeeding_catalog(), "no-radius": _other_succeeding_catalog()}
     with patch.object(viewer, "catalog_query_objects", lambda: catalogs):
-        with_missing = await _run_get_summary(["other"], summary_upstreams)
+        with_missing = (await _run_get_summary(["other"], summary_upstreams))[-1]
 
     only_other = {"other": _other_succeeding_catalog()}
     with patch.object(viewer, "catalog_query_objects", lambda: only_other):
-        without = await _run_get_summary(["other"], summary_upstreams)
+        without = (await _run_get_summary(["other"], summary_upstreams))[-1]
 
     assert _dump(with_missing) == _dump(without)
 
@@ -256,7 +295,7 @@ async def test_get_summary_mixed_success_and_failures(summary_upstreams):
         ),
     }
     with patch.object(viewer, "catalog_query_objects", lambda: catalogs):
-        div = await _run_get_summary(list(catalogs), summary_upstreams)
+        div = (await _run_get_summary(list(catalogs), summary_upstreams))[-1]
 
     success_link = {"text": "Success Catalog", "href": "#success"}
     antares_href = (
@@ -323,6 +362,163 @@ async def test_get_summary_queries_each_catalog_once(summary_upstreams):
     with patch.object(viewer, "catalog_query_objects", lambda: {"stub": stub}):
         await _run_get_summary(["stub"], summary_upstreams)
     assert stub.call_count == 1
+
+
+# ---------------------------------------------------------------------------------------------
+# get_summary -- progressive rendering over the WS transport (`set_props`, no Output).
+#
+# `get_summary` is a single callback with a single logical output (the "summary" div), so
+# streaming it doesn't consolidate any failure domains the way the rejected per-catalog-table
+# streaming did (see the module docstring in the plan's aio-stream Progress entry). The tests
+# below cover the three accept criteria: a delayed catalog doesn't hold up the rest of the page,
+# a disconnect stops in-flight work, and -- the lesson from that rejected attempt -- every catalog
+# that succeeds still shows up in the final, complete push.
+# ---------------------------------------------------------------------------------------------
+
+
+async def test_get_summary_streams_fast_catalog_before_slow_one_finishes(summary_upstreams):
+    """Streaming actually streams: a slow catalog must not delay a fast one's row from appearing."""
+    push_times = []
+
+    def fake_set_props(component_id, props):
+        assert component_id == "summary"
+        push_times.append(time.perf_counter())
+
+    catalogs = {
+        "fast": _SleepingCatalogQuery("Fast", delay=0.0, table=_stub_table(objname="Fast Object")),
+        "slow": _SleepingCatalogQuery("Slow", delay=0.3, table=_stub_table(objname="Slow Object")),
+    }
+    ids, values = _radius_inputs(list(catalogs))
+    token = context_value.set(types.SimpleNamespace(dash_websocket=None))
+    try:
+        with (
+            patch.object(viewer, "catalog_query_objects", lambda: catalogs),
+            patch.object(viewer, "set_props", fake_set_props),
+        ):
+            start = time.perf_counter()
+            await get_summary(
+                oid="633207400004730",
+                dr="dr24",
+                different_filter=None,
+                different_field=None,
+                radius_ids=ids,
+                radius_values=values,
+            )
+    finally:
+        context_value.reset(token)
+
+    # First push (the fast catalog's row) lands well before the slow catalog's own delay elapses.
+    assert push_times[0] - start < 0.1
+    # And a later push (the final, complete render) does have to wait for it.
+    assert push_times[-1] - start > 0.1
+
+
+async def test_get_summary_final_push_is_complete(summary_upstreams):
+    """The lesson from the rejected per-catalog-table attempt: a partial-render check alone can't
+    tell 'still streaming' from 'streaming died'. Every catalog that succeeds must show up in the
+    final, complete push -- not just in whichever partial push happened to catch it."""
+    catalogs = {
+        f"stub-{i}": _SleepingCatalogQuery(f"Stub {i}", delay=0.01 * (4 - i), table=_stub_table()) for i in range(5)
+    }
+    with patch.object(viewer, "catalog_query_objects", lambda: catalogs):
+        pushed = await _run_get_summary(list(catalogs), summary_upstreams)
+
+    # One push per successful catalog as it streams in, plus one final complete push.
+    assert len(pushed) == len(catalogs) + 1
+    final_dump = _dump(pushed[-1])
+    for catalog in catalogs:
+        assert f'"href": "#{catalog}"' in final_dump
+
+
+async def test_get_summary_stops_work_on_disconnect(summary_upstreams):
+    """Closing the tab mid-load must stop querying catalogs that haven't completed yet."""
+    pushed = []
+    ws = _FakeWebsocket(shutdown_after=1)
+
+    def fake_set_props(component_id, props):
+        pushed.append(props["children"])
+        ws.pushes += 1
+
+    catalogs = {
+        "a": _SleepingCatalogQuery("A", delay=0.0, table=_stub_table()),
+        "b": _SleepingCatalogQuery("B", delay=0.05, table=_stub_table()),
+        # Still sleeping when the disconnect is noticed after "b" -- must get cancelled, not run
+        # its full delay out in the background.
+        "c": _SleepingCatalogQuery("C", delay=5.0, table=_stub_table()),
+    }
+    ids, values = _radius_inputs(list(catalogs))
+    token = context_value.set(types.SimpleNamespace(dash_websocket=ws))
+    try:
+        with (
+            patch.object(viewer, "catalog_query_objects", lambda: catalogs),
+            patch.object(viewer, "set_props", fake_set_props),
+        ):
+            start = time.perf_counter()
+            with pytest.raises(PreventUpdate):
+                await get_summary(
+                    oid="633207400004730",
+                    dr="dr24",
+                    different_filter=None,
+                    different_field=None,
+                    radius_ids=ids,
+                    radius_values=values,
+                )
+            elapsed = time.perf_counter() - start
+    finally:
+        context_value.reset(token)
+
+    # Only "a", already complete at the shutdown check, was ever pushed.
+    assert len(pushed) == 1
+    # Would be >= 5s if "c"'s still-pending task weren't cancelled on disconnect.
+    assert elapsed < 1.0
+
+
+async def test_get_summary_works_over_http_without_a_websocket(summary_upstreams):
+    """The WS opt-in is per-callback, not per-client: a browser without `SharedWorker` support
+    never opens the WS transport and dispatches over plain HTTP instead. `set_props` calls made
+    outside a WS context batch into the callback's response (`sideUpdate`) rather than streaming,
+    so this must still complete and deliver the full summary in one response."""
+    catalog = _StubCatalogQuery("Other Catalog", table=_stub_table(objname="Other Object", type_="SN II"))
+    entry = next(e for e in viewer.app.callback_map.values() if e.get("websocket") and e.get("no_output"))
+    callback_id = next(k for k, v in viewer.app.callback_map.items() if v is entry)
+
+    original_layout = viewer.app._layout, viewer.app._layout_is_function
+    original_error_mode = viewer.app.backend.error_handling_mode
+    viewer.app.layout = html.Div("x")
+    reset_shared_thread_pool()
+    reset_shared_process_pool()
+    try:
+        with (
+            patch.object(viewer, "catalog_query_objects", lambda: {"other": catalog}),
+            TestClient(viewer.app.server) as client,
+        ):
+            response = client.post(
+                "/_dash-update-component",
+                json={
+                    "output": callback_id,
+                    "outputs": [],
+                    "inputs": [
+                        {"id": "oid", "property": "children", "value": "633207400004730"},
+                        {"id": "dr", "property": "children", "value": "dr24"},
+                        {"id": "different_filter_neighbours", "property": "children", "value": None},
+                        {"id": "different_field_neighbours", "property": "children", "value": None},
+                        {
+                            "id": [{"index": "other", "type": "search-radius"}],
+                            "property": "id",
+                            "value": [{"index": "other", "type": "search-radius"}],
+                        },
+                        {"id": [{"index": "other", "type": "search-radius"}], "property": "value", "value": [3.0]},
+                    ],
+                    "state": [],
+                    "changedPropIds": ["oid.children"],
+                },
+            )
+    finally:
+        viewer.app._layout, viewer.app._layout_is_function = original_layout
+        viewer.app.backend.error_handling_mode = original_error_mode
+
+    assert response.status_code == 200
+    assert "Other Object" in json.dumps(response.json()["sideUpdate"])
 
 
 # ---------------------------------------------------------------------------------------------

--- a/tests/test_websocket_transport.py
+++ b/tests/test_websocket_transport.py
@@ -53,11 +53,13 @@ def test_heartbeat_interval_is_bounded_below_the_live_proxy_ceiling():
     assert WEBSOCKET_HEARTBEAT_INTERVAL_MS <= LIVE_PROXY_READ_TIMEOUT_MS / 2
 
 
-def test_no_callback_opts_into_websocket_transport_without_using_streaming():
+def test_only_get_summary_opts_into_websocket_transport():
     """A `websocket=True` opt-in must be justified by actually using streaming (set_props,
     progressive delivery); plain request/response callbacks gain nothing from it while losing
-    the HTTP fallback. If this fails, either justify the new opt-in with real streaming and
-    update this test, or drop `websocket=True` from the callback."""
+    the HTTP fallback. `get_summary` is the callback the plan sanctions -- it has no Output and
+    streams progressively via `set_props` (see `tests/pages/test_viewer.py`). If this fails,
+    either justify a new opt-in with real streaming and update this test, or drop
+    `websocket=True` from whatever callback grew it."""
     config.CACHE_TYPE = "memory"
     config.UNAVAILABLE_CATALOGS_CACHE_TYPE = "memory"
 
@@ -65,8 +67,18 @@ def test_no_callback_opts_into_websocket_transport_without_using_streaming():
     # CACHE_TYPE at import time, and this may be the first import of __main__ in the session.
     import ztf_viewer.__main__ as main_module
 
-    opted_in = [callback_id for callback_id, entry in main_module.app.callback_map.items() if entry.get("websocket")]
-    assert opted_in == []
+    opted_in = [entry for entry in main_module.app.callback_map.values() if entry.get("websocket")]
+    assert len(opted_in) == 1
+    entry = opted_in[0]
+    assert entry.get("no_output")
+    assert [str(inp) for inp in entry["raw_inputs"]] == [
+        "oid.children",
+        "dr.children",
+        "different_filter_neighbours.children",
+        "different_field_neighbours.children",
+        '{"index":["ALL"],"type":"search-radius"}.id',
+        '{"index":["ALL"],"type":"search-radius"}.value',
+    ]
 
 
 def test_http_fallback_still_works_for_a_non_websocket_callback():

--- a/ztf_viewer/pages/viewer.py
+++ b/ztf_viewer/pages/viewer.py
@@ -14,7 +14,7 @@ import plotly.graph_objects as go
 from astropy.coordinates import SkyCoord
 from astropy.table import QTable
 from astropy.units import Quantity
-from dash import ALL, MATCH, Input, Output, State, dcc, html
+from dash import ALL, MATCH, Input, Output, State, ctx, dcc, html, set_props
 from dash.dash_table import DataTable
 from dash.exceptions import PreventUpdate
 from immutabledict import immutabledict
@@ -1378,44 +1378,31 @@ async def set_ref_mag_magerr(dr, _n_clicks, link_id, all_mag_ids, all_mag_values
     )
 
 
-@app.callback(
-    Output("summary", "children"),
-    [
-        Input("oid", "children"),
-        Input("dr", "children"),
-        Input("different_filter_neighbours", "children"),
-        Input("different_field_neighbours", "children"),
-        Input({"type": "search-radius", "index": ALL}, "id"),
-        Input({"type": "search-radius", "index": ALL}, "value"),
-    ],
-)
-async def get_summary(oid, dr, different_filter, different_field, radius_ids, radius_values):
-    if None in radius_values:
-        raise PreventUpdate
-    radii = {id["index"]: float(value) for id, value in zip(radius_ids, radius_values)}
-    ra, dec = await find_ztf_oid.get_coord(oid, dr)
-    coord = await find_ztf_oid.get_sky_coord(oid, dr)
+async def _find_catalog_for_summary(catalog, query, ra, dec, radii):
+    """Isolate one catalog's query so an expected failure here can never reach its siblings.
 
-    async def find_in_catalog(catalog, query):
-        # radii is keyed by the radius inputs the layout renders, which don't cover every
-        # registered catalog -- the lookup has to fail inside the task so gather returns it.
-        return await query.find(ra, dec, radii[catalog])
+    radii is keyed by the radius inputs the layout renders, which don't cover every registered
+    catalog -- the lookup has to fail inside this per-task coroutine so it stays contained.
+    """
+    try:
+        table = await query.find(ra, dec, radii[catalog])
+    except NotFound, CatalogUnavailable, KeyError:
+        return catalog, None
+    return catalog, table
 
-    catalogs = catalog_query_objects()
-    catalog_results = await asyncio.gather(
-        *(find_in_catalog(catalog, query) for catalog, query in catalogs.items()),
-        return_exceptions=True,
-    )
-    catalog_tables = OrderedDict()
-    for (catalog, query), result in zip(catalogs.items(), catalog_results):
-        if isinstance(result, BaseException):
-            if isinstance(result, (NotFound, CatalogUnavailable, KeyError)):
-                continue
-            raise result
-        catalog_tables[catalog] = (query, result)
 
+def _summary_catalog_elements(catalogs, catalog_tables):
+    """Render the Name/Type/Distance/... rows for whichever catalogs have resolved so far.
+
+    Always walks `catalogs` in registration order, and only includes a catalog once its table is
+    in `catalog_tables` -- so a partial render during streaming and the final render use the same
+    row order, and rows never jump around as later catalogs arrive.
+    """
     elements = OrderedDict()
-    for catalog, (query, table) in catalog_tables.items():
+    for catalog, query in catalogs.items():
+        table = catalog_tables.get(catalog)
+        if table is None:
+            continue
         idx = np.argmin(table["separation"])
         row = table[idx]
         for table_field, display_name in SUMMARY_FIELDS.items():
@@ -1454,6 +1441,61 @@ async def get_summary(oid, dr, different_filter, different_field, radius_ids, ra
                     style={"display": "inline"},
                 )
             )
+    return elements
+
+
+def _summary_list_div(elements):
+    return html.Div(
+        html.Ul(
+            [html.Li([html.B(k), ": "] + list_join(", ", v)) for k, v in elements.items()],
+            style={"list-style-type": "none"},
+        ),
+    )
+
+
+@app.callback(
+    Input("oid", "children"),
+    Input("dr", "children"),
+    Input("different_filter_neighbours", "children"),
+    Input("different_field_neighbours", "children"),
+    Input({"type": "search-radius", "index": ALL}, "id"),
+    Input({"type": "search-radius", "index": ALL}, "value"),
+    # No Output: results are pushed with `set_props` as each catalog resolves, so the page is
+    # useful before the slowest catalog answers. A single Output already meant this callback had
+    # one failure domain before streaming; pushing progressively doesn't change that. Falls back
+    # to one batched HTTP response (the final push below) for clients without the WS transport.
+    websocket=True,
+)
+async def get_summary(oid, dr, different_filter, different_field, radius_ids, radius_values):
+    if None in radius_values:
+        raise PreventUpdate
+    ws = ctx.websocket
+    radii = {id["index"]: float(value) for id, value in zip(radius_ids, radius_values)}
+    ra, dec = await find_ztf_oid.get_coord(oid, dr)
+    coord = await find_ztf_oid.get_sky_coord(oid, dr)
+
+    catalogs = catalog_query_objects()
+    catalog_tables = {}
+    tasks = [
+        asyncio.ensure_future(_find_catalog_for_summary(catalog, query, ra, dec, radii))
+        for catalog, query in catalogs.items()
+    ]
+    try:
+        async for finished in asyncio.as_completed(tasks):
+            if ws is not None and ws.is_shutdown:
+                raise PreventUpdate
+            catalog, table = await finished
+            if table is not None:
+                catalog_tables[catalog] = table
+                set_props(
+                    "summary", {"children": _summary_list_div(_summary_catalog_elements(catalogs, catalog_tables))}
+                )
+    finally:
+        for task in tasks:
+            if not task.done():
+                task.cancel()
+
+    elements = _summary_catalog_elements(catalogs, catalog_tables)
     try:
         features = await light_curve_features(oid, dr, version="latest")
         period = features.get("period_0_magn", features.get("period_0"))
@@ -1478,8 +1520,9 @@ async def get_summary(oid, dr, different_filter, different_field, radius_ids, ra
         pass
 
     ml_classifications = []
-    for catalog, (query, table) in catalog_tables.items():
-        if len(table) == 0:
+    for catalog, query in catalogs.items():
+        table = catalog_tables.get(catalog)
+        if table is None or len(table) == 0:
             continue
         idx = np.argmin(table["separation"])
         row = table[idx]
@@ -1556,13 +1599,7 @@ async def get_summary(oid, dr, different_filter, different_field, radius_ids, ra
         f'Gal {await find_ztf_oid.get_coord_string(oid, dr, frame="galactic")}',
     ]
 
-    div = html.Div(
-        html.Ul(
-            [html.Li([html.B(k), ": "] + list_join(", ", v)) for k, v in elements.items()],
-            style={"list-style-type": "none"},
-        ),
-    )
-    return div
+    set_props("summary", {"children": _summary_list_div(elements)})
 
 
 @app.callback(


### PR DESCRIPTION
## Summary

The last planned slice of `aio-stream` (per `plans/001_async_dash.md`): progressive rendering of `get_summary` via `set_props`. This is the second attempt at `aio-stream` -- the first (#696, streaming the per-catalog tables) was closed without merging because it collapsed ~20 independent per-catalog callbacks into one, and a shared-loop failure took down every not-yet-completed table (only 3/19 rendered on the preview).

`get_summary` doesn't have that problem: it was already a single callback with a single logical output before this change, so streaming it doesn't consolidate any failure domain -- it's exactly the slice the plan says is still worth doing.

## What changed

- `get_summary` is now `websocket=True`, no `Output`. It fans out to every catalog via `asyncio.as_completed` (unchanged concurrency from the prior `asyncio.gather`), and pushes a `set_props("summary", {"children": ...})` update as each catalog resolves, then one final push once the period/ML-classification/extinction/coordinates extras are computed.
- Partial and final renders both walk catalogs in **registration order**, filtered to whichever have resolved so far -- so rows never reorder as later catalogs stream in, and the final render is byte-identical to what the old single-shot version produced (see the unchanged `test_get_summary_mixed_success_and_failures`).
- Per-catalog isolation stays inside the per-task coroutine (`_find_catalog_for_summary`): `NotFound`/`CatalogUnavailable`/`KeyError` (including a missing radius input) are swallowed there and never reach the streaming loop or its `finally`; anything else propagates and fails the whole callback, same as before.
- `ctx.websocket.is_shutdown` is checked at the top of each loop iteration; on shutdown the callback raises `PreventUpdate` and the `finally` block cancels whatever catalog tasks are still pending.
- Because `set_props` batches into the response (`sideUpdate`) instead of streaming when there's no WS context, this still works unmodified for clients without `SharedWorker` support -- verified with a real HTTP `TestClient` POST dispatch (`test_get_summary_works_over_http_without_a_websocket`).

## Tests

Rewrote `tests/pages/test_viewer.py`'s `get_summary` tests to drive the callback the way the real dispatcher does now (a fake `dash_websocket` in the callback context, `set_props` patched to capture pushes) instead of calling it for a return value. Existing failure-path/ordering assertions are unchanged in substance, just adapted to check the *final* push (`pushed[-1]`).

New, addressing the accept criteria and the lesson from #696:
- `test_get_summary_streams_fast_catalog_before_slow_one_finishes` -- a fast catalog's row appears well before a slow catalog's delay elapses.
- `test_get_summary_final_push_is_complete` -- **the completeness assertion #696 was missing.** Asserts every catalog that resolves actually shows up (by `href`) in the final push, not just in some partial push along the way, and that there's exactly one push per successful catalog plus one final push.
- `test_get_summary_stops_work_on_disconnect` -- a `_FakeWebsocket` set to "shut down" after one push causes a still-sleeping catalog task (5s delay) to be cancelled; asserted by wall-clock (`elapsed < 1.0`, would be `>= 5.0` if the task weren't actually cancelled), not just "the disconnect check ran."
- `test_get_summary_works_over_http_without_a_websocket` -- dispatches over a real HTTP `TestClient` POST (no WS) and asserts the final summary lands in `sideUpdate`.

`tests/test_websocket_transport.py`'s `test_no_callback_opts_into_websocket_transport_without_using_streaming` renamed to `test_only_get_summary_opts_into_websocket_transport` and updated to assert `get_summary` is the one (and only) opted-in, no-Output, streaming callback.

## Test plan

- [x] `~/.virtualenvs/web/bin/python -m pytest --basetemp=/tmp/pytest` -- full suite green (see below).
- [x] `pre-commit run --all-files` -- green.
- [ ] Live browser smoke test -- **not run.** This sandbox cannot reach CDS (VizieR/SIMBAD/MOCServer/Sesame) at all, so a local run can't exercise ~7 of 19 catalogs or give a meaningful "does the page actually stream in a browser" signal. Reporting the automated suite as "no regression detected in an environment that can't fully exercise this," not as a clean bill of health.

```
$ ~/.virtualenvs/web/bin/python -m pytest -q --basetemp=/tmp/pytest
........................................................................ [ 15%]
.................s...................................................... [ 31%]
........................................................................ [ 47%]
........................................................................ [ 63%]
..............................s......................................... [ 79%]
........................................................................ [ 95%]
....................                                                     [100%]
(2 skips: JS9 not installed locally -- unrelated, pre-existing)

$ pre-commit run --all-files
... (all hooks) Passed
```

## Accept criteria from the plan

- "With an artificially delayed catalog, the rest of the page renders without waiting" -- **verified** at the unit level (`test_get_summary_streams_fast_catalog_before_slow_one_finishes`). Not verified in a real browser (sandbox limitation above).
- "Closing the tab mid-load stops server-side work (assert via logs)" -- **partially verified**: `test_get_summary_stops_work_on_disconnect` proves task cancellation via wall-clock, not via server logs against a live disconnect (can't run against the deployment host per project constraints). Log-based verification against a live deployment is left to whoever can run that.
- "Completeness: every expected element populates" -- **verified** (`test_get_summary_final_push_is_complete`), the specific gap that let #696 ship broken while its own tests passed.

## Out of scope

The light-curve figure streaming slice mentioned alongside `get_summary` in the plan's `aio-stream` section is not part of this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CpFdWHuzGf4kzRgcxyGd3V