### PR TITLE
Port ztf_viewer/catalogs/snad/catalog.py off requests to httpx

### DIFF
--- a/tests/test_async_offload.py
+++ b/tests/test_async_offload.py
@@ -13,7 +13,9 @@ to call inline (pure computation) versus which are blocking I/O, and that distin
 recoverable from the AST alone. So this only covers the specific call sites this change touches.
 """
 
+import asyncio
 import inspect
+import threading
 
 import pytest
 
@@ -22,6 +24,8 @@ from ztf_viewer import config
 config.CACHE_TYPE = "memory"
 config.UNAVAILABLE_CATALOGS_CACHE_TYPE = "memory"
 
+import ztf_viewer.__main__ as main_module
+from ztf_viewer.exceptions import NotFound
 from ztf_viewer.pages import viewer
 
 # function (or unbound method) -> a substring of the sync call it must route through a thread
@@ -46,3 +50,106 @@ def test_remaining_blocking_call_goes_through_to_thread(func, blocking_call):
     source = inspect.getsource(inspect.unwrap(func))
     assert blocking_call in source, f"expected {func.__qualname__} to still call {blocking_call}"
     assert "asyncio.to_thread" in source, f"{func.__qualname__} calls {blocking_call} without asyncio.to_thread"
+
+
+# --------------------------------------------------------------------------------------------
+# SNAD catalog: now a genuine async port (ztf_viewer/catalogs/snad/catalog.py), not a thread
+# hop. These pin the inverse of what this file pinned before: the lookup runs on the event
+# loop's own thread, not offloaded, and no `asyncio.to_thread` appears in the call sites.
+# --------------------------------------------------------------------------------------------
+
+
+def test_sky_coord_from_str_snad_lookup_runs_on_the_loop(monkeypatch):
+    loop_thread_id = threading.get_ident()
+    seen_thread_id = None
+
+    class StubSource:
+        @classmethod
+        async def create(cls, name):
+            nonlocal seen_thread_id
+            seen_thread_id = threading.get_ident()
+            self = cls()
+            self.coord = f"coord-for-{name}"
+            return self
+
+    monkeypatch.setattr(main_module, "SnadCatalogSource", StubSource)
+
+    result = asyncio.run(main_module.sky_coord_from_str("SNAD123"))
+
+    assert result == "coord-for-SNAD123"
+    assert seen_thread_id == loop_thread_id
+
+
+def test_sky_coord_from_str_reraises_key_error_as_value_error(monkeypatch):
+    class StubSource:
+        @classmethod
+        async def create(cls, name):
+            raise KeyError(name)
+
+    monkeypatch.setattr(main_module, "SnadCatalogSource", StubSource)
+
+    with pytest.raises(ValueError):
+        asyncio.run(main_module.sky_coord_from_str("SNAD123"))
+
+
+def test_oid_from_input_snad_lookup_runs_on_the_loop_without_to_thread(monkeypatch):
+    loop_thread_id = threading.get_ident()
+    seen_thread_id = None
+
+    class StubSource:
+        @classmethod
+        async def create(cls, name):
+            nonlocal seen_thread_id
+            seen_thread_id = threading.get_ident()
+            self = cls()
+            self.ztf_oid = 123
+            return self
+
+    monkeypatch.setattr(main_module, "SnadCatalogSource", StubSource)
+
+    result = asyncio.run(main_module.oid_from_input("SNAD123"))
+
+    assert result == "123"
+    assert seen_thread_id == loop_thread_id
+
+    source = inspect.getsource(inspect.unwrap(main_module.oid_from_input))
+    assert "asyncio.to_thread" not in source
+
+
+def test_set_title_snad_lookup_runs_on_the_loop(monkeypatch):
+    loop_thread_id = threading.get_ident()
+    seen_thread_id = None
+
+    async def stub_get_coord(oid, dr):
+        return 10.0, 20.0
+
+    async def stub_search_region(ra, dec, radius_arcsec):
+        nonlocal seen_thread_id
+        seen_thread_id = threading.get_ident()
+        return "SNAD1"
+
+    monkeypatch.setattr(viewer.find_ztf_oid, "get_coord", stub_get_coord)
+    monkeypatch.setattr(viewer.snad_catalog, "search_region", stub_search_region)
+
+    result = asyncio.run(viewer.set_title("oid", "dr"))
+
+    assert result == "SNAD1 — oid"
+    assert seen_thread_id == loop_thread_id
+
+    source = inspect.getsource(inspect.unwrap(viewer.set_title))
+    assert "asyncio.to_thread" not in source
+
+
+def test_set_title_propagates_not_found(monkeypatch):
+    async def stub_get_coord(oid, dr):
+        return 10.0, 20.0
+
+    async def stub_search_region(ra, dec, radius_arcsec):
+        raise NotFound
+
+    monkeypatch.setattr(viewer.find_ztf_oid, "get_coord", stub_get_coord)
+    monkeypatch.setattr(viewer.snad_catalog, "search_region", stub_search_region)
+
+    result = asyncio.run(viewer.set_title("oid", "dr"))
+
+    assert result == "oid"

--- a/tests/test_http.py
+++ b/tests/test_http.py
@@ -98,6 +98,7 @@ def test_per_api_timeouts_match_the_requests_audit() -> None:
     assert config.TIMEOUT_MODEL_FIT == httpx.Timeout(120.0)
     assert config.TIMEOUT_AKB == httpx.Timeout(10.0)
     assert config.TIMEOUT_ZTF_FITS_PROXY == httpx.Timeout(60.0)
+    assert config.TIMEOUT_SNAD == httpx.Timeout(10.0)
 
 
 async def test_async_timeout_lets_fast_calls_through() -> None:

--- a/tests/test_snad_catalog.py
+++ b/tests/test_snad_catalog.py
@@ -1,0 +1,132 @@
+"""Tests for the async SNAD catalog port (``ztf_viewer/catalogs/snad/catalog.py``).
+
+No network access: the refresh goes through a fake ``httpx.AsyncClient`` built on
+``httpx.MockTransport``, so these exercise the same client plumbing as production
+(``ztf_viewer.http.get_client``) without hitting ``snad.space``.
+"""
+
+import asyncio
+import email.utils
+from datetime import UTC, datetime
+
+import httpx
+
+from ztf_viewer import config
+from ztf_viewer.catalogs.snad.catalog import _SnadCatalog
+
+CSV_HEADER = "Name,R.A.,Dec.,OID,Discovery date (UT),mag,er_down,er_up,ref,er_ref,TNS,Type,Comments"
+CSV_ROW = "SNAD999,10.0,20.0,42,2018-04-08 09:45:49,21.11,0.27,0.36,20.84,0.06,AT 2018abc,PSN,test"
+CSV_BODY = f"{CSV_HEADER}\n{CSV_ROW}\n"
+
+
+def _stale_catalog():
+    """A catalog whose in-memory table is already due for a refresh."""
+    catalog = _SnadCatalog(interval_seconds=600)
+    catalog.updated_at = datetime(1900, 1, 1, tzinfo=UTC)
+    return catalog
+
+
+def _csv_response(when):
+    return httpx.Response(
+        200,
+        headers={"last-modified": email.utils.format_datetime(when, usegmt=True)},
+        content=CSV_BODY.encode(),
+    )
+
+
+async def test_update_goes_through_the_shared_client_with_the_snad_timeout(monkeypatch):
+    seen = {}
+
+    async def handler(request):
+        seen["url"] = str(request.url)
+        seen["timeout"] = request.extensions.get("timeout")
+        return _csv_response(datetime.now(tz=UTC))
+
+    client = httpx.AsyncClient(transport=httpx.MockTransport(handler))
+    monkeypatch.setattr("ztf_viewer.catalogs.snad.catalog.get_client", lambda: client)
+
+    catalog = _stale_catalog()
+    await catalog._update()
+
+    assert seen["url"] == _SnadCatalog.url
+    budget = config.TIMEOUT_SNAD
+    assert seen["timeout"] == {
+        "connect": budget.connect,
+        "read": budget.read,
+        "write": budget.write,
+        "pool": budget.pool,
+    }
+    assert "SNAD999" in catalog.table["Name"]
+    await client.aclose()
+
+
+async def test_hung_upstream_is_bounded_not_hanging_forever(monkeypatch):
+    """A timed-out request must be swallowed, not propagate and not hang the caller."""
+
+    async def handler(request):
+        raise httpx.ReadTimeout("simulated timeout", request=request)
+
+    client = httpx.AsyncClient(transport=httpx.MockTransport(handler))
+    monkeypatch.setattr("ztf_viewer.catalogs.snad.catalog.get_client", lambda: client)
+
+    catalog = _stale_catalog()
+    stale_updated_at = catalog.updated_at
+    stale_table = catalog.table
+
+    await asyncio.wait_for(catalog._update(), timeout=5.0)
+
+    # the timeout was swallowed: no refresh happened, the stale table is kept
+    assert catalog.updated_at == stale_updated_at
+    assert catalog.table is stale_table
+    await client.aclose()
+
+
+async def test_concurrent_stale_lookups_trigger_one_fetch(monkeypatch):
+    calls = 0
+
+    async def handler(request):
+        nonlocal calls
+        calls += 1
+        await asyncio.sleep(0.05)
+        return _csv_response(datetime.now(tz=UTC))
+
+    client = httpx.AsyncClient(transport=httpx.MockTransport(handler))
+    monkeypatch.setattr("ztf_viewer.catalogs.snad.catalog.get_client", lambda: client)
+
+    catalog = _stale_catalog()
+
+    await asyncio.gather(*(catalog._update() for _ in range(8)))
+
+    assert calls == 1, "N concurrent stale lookups must trigger one fetch, not N"
+    await client.aclose()
+
+
+async def test_fresh_table_within_check_interval_skips_fetch(monkeypatch):
+    calls = 0
+
+    async def handler(request):
+        nonlocal calls
+        calls += 1
+        return _csv_response(datetime.now(tz=UTC))
+
+    client = httpx.AsyncClient(transport=httpx.MockTransport(handler))
+    monkeypatch.setattr("ztf_viewer.catalogs.snad.catalog.get_client", lambda: client)
+
+    catalog = _SnadCatalog(interval_seconds=600)
+    catalog.updated_at = datetime.now(tz=UTC)
+
+    await catalog._update()
+
+    assert calls == 0
+    await client.aclose()
+
+
+async def test_search_region_awaits_update_and_returns_match():
+    catalog = _SnadCatalog(interval_seconds=600)
+    catalog.updated_at = datetime.now(tz=UTC)  # fresh: no network call needed
+    row = catalog.table[0]
+    ra, dec = float(row["R.A."]), float(row["Dec."])
+
+    name = await catalog.search_region(ra, dec, radius_arcsec=3)
+
+    assert name == row["Name"]

--- a/ztf_viewer/__main__.py
+++ b/ztf_viewer/__main__.py
@@ -260,8 +260,7 @@ async def oid_from_input(s: str):
         return s
     if s.isnumeric() or s.upper().startswith("SNAD"):
         try:
-            # `SnadCatalogSource` may refresh the SNAD catalog over `requests`; offload to a thread.
-            source = await asyncio.to_thread(SnadCatalogSource, s)
+            source = await SnadCatalogSource.create(s)
             return str(source.ztf_oid)
         except KeyError:
             pass
@@ -272,7 +271,8 @@ async def sky_coord_from_str(s):
     s = s.strip()
     if s.upper().startswith("SNAD"):
         try:
-            return SnadCatalogSource(s).coord
+            source = await SnadCatalogSource.create(s)
+            return source.coord
         except KeyError:
             raise ValueError(f"ID {s} isn't found in the SNAD catalog")
 

--- a/ztf_viewer/catalogs/snad/catalog.py
+++ b/ztf_viewer/catalogs/snad/catalog.py
@@ -3,12 +3,15 @@ import importlib.resources
 from datetime import UTC, datetime, timedelta
 from io import BytesIO
 
-import requests
+import httpx
 from astropy.coordinates import Angle, SkyCoord
 from astropy.io import ascii
 
+from ztf_viewer import config
+from ztf_viewer.cache.single_flight import AsyncSingleFlight
 from ztf_viewer.catalogs.snad import data
 from ztf_viewer.exceptions import NotFound
+from ztf_viewer.http import get_client
 
 
 class _SnadCatalog:
@@ -21,6 +24,9 @@ class _SnadCatalog:
             self.table = self._create_table(fh)
 
         self.updated_at = datetime(1900, 1, 1, 1, 1, tzinfo=UTC)
+        # Coalesces concurrent refreshes into one download; AsyncSingleFlight is already
+        # per-loop internally, so this instance is safe to share across loops.
+        self._single_flight = AsyncSingleFlight()
 
     @staticmethod
     def _create_table(src):
@@ -36,28 +42,31 @@ class _SnadCatalog:
         dt = datetime(*parsed[:7], tzinfo=UTC)
         return dt
 
-    def _update(self):
+    async def _update(self):
         now = datetime.now(tz=UTC)
         if now - self.updated_at < self.check_interval:
             return
-        try:
-            with requests.get(self.url, stream=True) as resp:
-                if resp.status_code != 200:
-                    return
-                if self.updated_at > self._last_modified(resp):
-                    return
-                self.updated_at = now
-                bio = BytesIO(resp.content)
-        except requests.exceptions.ConnectionError:
-            return
-        self.table = self._create_table(bio)
+        await self._single_flight.run("update", lambda: self._fetch(now))
 
-    def __call__(self):
-        self._update()
+    async def _fetch(self, now):
+        client = get_client()
+        try:
+            resp = await client.get(self.url, timeout=config.TIMEOUT_SNAD)
+        except httpx.HTTPError:
+            return
+        if resp.status_code != 200:
+            return
+        if self.updated_at > self._last_modified(resp):
+            return
+        self.updated_at = now
+        self.table = self._create_table(BytesIO(resp.content))
+
+    async def __call__(self):
+        await self._update()
         return self.table.copy()
 
-    def search_region(self, ra, dec, radius_arcsec):
-        self._update()
+    async def search_region(self, ra, dec, radius_arcsec):
+        await self._update()
         coord = SkyCoord(ra=ra, dec=dec, unit="deg")
         radius = Angle(radius_arcsec, unit="arcsec")
         idx, sep, _ = coord.match_to_catalog_sky(self.table["coord"])
@@ -70,12 +79,17 @@ snad_catalog = _SnadCatalog()
 
 
 class SnadCatalogSource:
-    def __init__(self, name):
+    def __init__(self, row):
+        self.row = row
+
+    @classmethod
+    async def create(cls, name):
         if isinstance(name, int) or not name.upper().startswith("SNAD"):
             name = f"SNAD{name}"
         name = name.upper()
-        catalog = snad_catalog()
-        self.row = catalog.loc[name]
+        catalog = await snad_catalog()
+        row = catalog.loc[name]
+        return cls(row)
 
     @property
     def coord(self):

--- a/ztf_viewer/config.py
+++ b/ztf_viewer/config.py
@@ -38,7 +38,7 @@ HTTP_DEFAULT_TIMEOUT = httpx.Timeout(30.0)
 
 # Per-API request budgets. Each of the first five mirrors what that call site's `requests` call
 # already uses today (`git grep timeout= ztf_viewer`), so the async conversions that follow start
-# from current behaviour rather than a guess. The last four have no timeout at all today --
+# from current behaviour rather than a guess. The last five have no timeout at all today --
 # `requests` then waits forever -- so each value below was chosen deliberately rather than
 # inherited from a shared default. Named for the API they serve, not the number, so the value can
 # move without a rename. Plain constants, not env vars: these encode a per-upstream behaviour
@@ -57,6 +57,7 @@ TIMEOUT_FEATURES = httpx.Timeout(60.0)  # lc_features.py: feature extraction ove
 TIMEOUT_MODEL_FIT = httpx.Timeout(120.0)  # model_fit.py: the heaviest per-request compute of the first-party APIs
 TIMEOUT_AKB = httpx.Timeout(10.0)  # akb.py: small CRUD-shaped JSON requests
 TIMEOUT_ZTF_FITS_PROXY = httpx.Timeout(60.0)  # catalogs/ztf_ref.py, date_with_frac.py: both hit ZTF_FITS_PROXY_URL
+TIMEOUT_SNAD = httpx.Timeout(10.0)  # catalogs/snad/catalog.py: a 16 KB CSV off snad.space
 
 # Must stay well under the deployed proxy's live 60s read-timeout default, in ms.
 WEBSOCKET_HEARTBEAT_INTERVAL_MS = int(os.environ.get("WEBSOCKET_HEARTBEAT_INTERVAL_MS", "20000"))

--- a/ztf_viewer/pages/viewer.py
+++ b/ztf_viewer/pages/viewer.py
@@ -827,7 +827,7 @@ async def get_layout(pathname, search):
 async def set_title(oid, dr):
     ra, dec = await find_ztf_oid.get_coord(oid, dr)
     try:
-        snad_name = snad_catalog.search_region(ra, dec, radius_arcsec=3)
+        snad_name = await snad_catalog.search_region(ra, dec, radius_arcsec=3)
         snad_name = f"{snad_name} — "
     except NotFound:
         snad_name = ""


### PR DESCRIPTION
## Summary

Ports `ztf_viewer/catalogs/snad/catalog.py` off `requests` onto the shared
per-loop `httpx.AsyncClient` (`ztf_viewer/http.py`), so the SNAD catalog
refresh runs on the event loop instead of blocking it in a thread.

This replaces #703, which was closed deliberately: `asyncio.to_thread` moved
*where* the call blocked, not *how long* — `requests.get(self.url,
stream=True)` at the old `catalog.py:44` had no timeout at all, so a hung
`snad.space` would pin a thread-pool slot indefinitely (a slow leak at
`THREAD_POOL_SIZE=64`, not a fix). Measurement in #703's closing comment
showed the CPU in this path (144 rows / 16 KB; steady-state `table.copy()`
0.41 ms, `_create_table` 1.36 ms, `match_to_catalog_sky` 0.42 ms) doesn't
justify a thread hop either — the ~116 ms first `match_to_catalog_sky` is
one-time astropy warmup, not per-call cost, and isn't specifically handled
here (no thread hop added for it).

## Changes

- `_SnadCatalog._update` is now `async def` and awaits `get_client().get(...)`
  with an explicit `timeout=config.TIMEOUT_SNAD`, instead of a bare,
  untimeouted `requests.get`. `search_region` and `__call__` are `async def`
  accordingly.
- Added `config.TIMEOUT_SNAD = httpx.Timeout(10.0)`. This call site had no
  timeout before (`requests` just hung), so the value is chosen, not
  inherited. 10s matches `TIMEOUT_CONESEARCH_API`, `TIMEOUT_EXTINCTION`, and
  `TIMEOUT_AKB` — the existing budget for small, first-party-hosted JSON/CSV
  requests, and this one is a 16 KB CSV off `snad.space`, the same host
  family. Pinned in `tests/test_http.py::test_per_api_timeouts_match_the_requests_audit`.
- `SnadCatalogSource.__init__` did the catalog fetch in a constructor, which
  cannot `await`. Replaced with an async factory,
  `await SnadCatalogSource.create(name)`; the instance itself now just wraps
  an already-resolved table row. Name normalisation (`SNAD` prefixing,
  uppercasing) and the `KeyError` `.loc[name]` raises for an unknown name are
  unchanged.
- Single-flight: `_update` mutates shared `self.table` / `self.updated_at`.
  Rather than adding a new `asyncio.Lock` (which would need its own
  `LoopRegistry`-style per-loop handling — a plain module-level
  `asyncio.Lock` binds to whichever loop first awaits it, which breaks under
  Flask's per-request-loop model), this reuses the existing
  `ztf_viewer.cache.single_flight.AsyncSingleFlight`, which is already
  per-loop internally (it holds its wait-table via `LoopRegistry`, same as
  `ztf_viewer/http.py`'s client). `_update` checks the staleness window, then
  routes the actual fetch through `self._single_flight.run("update", ...)`,
  so N concurrent stale lookups become one fetch, not N — covered by
  `tests/test_snad_catalog.py::test_concurrent_stale_lookups_trigger_one_fetch`.
- `requests.exceptions.ConnectionError` swallowing became a broader
  `httpx.HTTPError` catch, since a hung request can now also fail as an
  `httpx.TimeoutException` (a `TransportError`/`HTTPError` subclass) instead
  of hanging forever, and that case should be swallowed the same way the
  connection-error case always was (keep the stale table, try again next
  `check_interval`).
- Call sites (`ztf_viewer/__main__.py`'s `oid_from_input` and
  `sky_coord_from_str`, `ztf_viewer/pages/viewer.py`'s `set_title`) drop the
  `asyncio.to_thread` hop and `await` the async API directly. Exception
  translation is unchanged: `KeyError` → `ValueError` in
  `sky_coord_from_str`, `NotFound` swallowed to an empty title prefix in
  `set_title`.
- `tests/test_async_offload.py`: the SNAD tests are now the inverse of what
  #703 added — they assert the lookup runs *on* the event loop's own thread
  (no `asyncio.to_thread` in the call sites' source), not offloaded. The
  unrelated pins (`csfd.ebv`, `SKYBOT_QUERY.find`, `find_vizier.find`) are
  untouched.
- New `tests/test_snad_catalog.py` exercises `_SnadCatalog` directly against
  a fake `httpx.AsyncClient` built on `httpx.MockTransport` (no network):
  the refresh goes through the shared client with the SNAD timeout attached
  to the request, a simulated `httpx.ReadTimeout` is swallowed and bounded
  (`asyncio.wait_for(..., timeout=5.0)` around the call, so a hang would
  fail the test rather than hang it), concurrent stale lookups single-flight
  to one fetch, a fresh table within `check_interval` skips the network call
  entirely, and `search_region` returns a real match against the packaged
  CSV. No golden/serialized snapshots — every assertion is a claim about
  behaviour (call count, timeout value, table identity/content).

This does **not** remove `requests` from `pyproject.toml` — five other
modules still import it to catch what astroquery/alerce/antares raise.

## Verification

Ran (interpreter: `~/.virtualenvs/web/bin/python`, not `uv run`/repo `.venv`):

```
~/.virtualenvs/web/bin/python -m pytest --basetemp=/tmp/pytest -q \
  tests/test_async_offload.py tests/test_http.py tests/test_snad_catalog.py tests/test_sync_callbacks.py
```
→ `25 passed`. Ran again after rebasing onto current `origin/master` (which
now includes #705's plan-text fix) — still 25 passed, no conflicts.

`pre-commit run --all-files` → all hooks pass (ruff auto-fixed two unused
imports in the new test file on the first pass; committed after).

I narrowed the pytest invocation to the touched files plus the SNAD/http/
sync-callback suites rather than the full repo suite, because a prior full
run in this sandbox was still going after several minutes (likely the
redis-backed cache/single-flight tests' real `time.sleep` calls) with no
useful incremental signal; I did not get a clean full-suite pass in this
session. The narrowed run covers every file this change touches plus its
consumers.

**What I could not verify in this sandbox:** no live check against
`snad.space` (this sandbox may or may not reach it — not attempted, since
the mocked-transport tests already pin the timeout/client-plumbing behaviour
without depending on network reachability) and no CDS-backed
(VizieR/SIMBAD/Sesame/MOCServer) verification, per the task's constraints —
neither of those is part of this change's path. I have not run the
production/full test suite to completion in this sandbox; the narrowed
subset above is what I can vouch for directly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CpFdWHuzGf4kzRgcxyGd3V