### PR TITLE
Back off retries after a failed SNAD catalog refresh

### DIFF
--- a/tests/test_snad_catalog.py
+++ b/tests/test_snad_catalog.py
@@ -7,7 +7,7 @@ No network access: the refresh goes through a fake ``httpx.AsyncClient`` built o
 
 import asyncio
 import email.utils
-from datetime import UTC, datetime
+from datetime import UTC, datetime, timedelta
 
 import httpx
 
@@ -130,3 +130,71 @@ async def test_search_region_awaits_update_and_returns_match():
     name = await catalog.search_region(ra, dec, radius_arcsec=3)
 
     assert name == row["Name"]
+
+
+async def test_failed_refresh_backs_off_then_retries_after_the_interval(monkeypatch):
+    """A non-200/HTTPError attempt must not be retried on every call, only after backoff."""
+    calls = 0
+
+    async def handler(request):
+        nonlocal calls
+        calls += 1
+        return httpx.Response(500)
+
+    client = httpx.AsyncClient(transport=httpx.MockTransport(handler))
+    monkeypatch.setattr("ztf_viewer.catalogs.snad.catalog.get_client", lambda: client)
+
+    catalog = _SnadCatalog(interval_seconds=600, failure_retry_seconds=30)
+    catalog.updated_at = datetime(1900, 1, 1, tzinfo=UTC)
+    stale_table = catalog.table
+
+    await catalog._update()
+    assert calls == 1
+    assert catalog._failed_at is not None
+    # the fallback table must still be served after a failed refresh
+    assert catalog.table is stale_table
+
+    # a sequential call still within the retry backoff must not re-attempt the fetch
+    await catalog._update()
+    assert calls == 1
+    assert catalog.table is stale_table
+
+    # once the retry interval has elapsed, the next call must re-attempt
+    catalog._failed_at = datetime.now(tz=UTC) - catalog.failure_retry_interval - timedelta(seconds=1)
+    await catalog._update()
+    assert calls == 2
+    assert catalog.table is stale_table
+
+    await client.aclose()
+
+
+async def test_already_current_response_is_not_treated_as_a_failure(monkeypatch):
+    """Server confirming our copy is current is a success, not something to back off from."""
+    calls = 0
+
+    async def handler(request):
+        nonlocal calls
+        calls += 1
+        # last-modified far in the past: older than our (recent) updated_at below
+        return _csv_response(datetime.now(tz=UTC) - timedelta(days=1))
+
+    client = httpx.AsyncClient(transport=httpx.MockTransport(handler))
+    monkeypatch.setattr("ztf_viewer.catalogs.snad.catalog.get_client", lambda: client)
+
+    catalog = _SnadCatalog(interval_seconds=600, failure_retry_seconds=30)
+    # due for a check, but newer than the server's last-modified above
+    catalog.updated_at = datetime.now(tz=UTC) - catalog.check_interval - timedelta(seconds=1)
+    stale_table = catalog.table
+
+    await catalog._update()
+
+    assert calls == 1
+    assert catalog._failed_at is None, "an already-current response is not a failure"
+    assert catalog.table is stale_table, "nothing new to download, table is unchanged"
+
+    # updated_at was bumped to now, so an immediate follow-up call is within check_interval
+    # and skips the fetch entirely, not merely within the (shorter) failure backoff
+    await catalog._update()
+    assert calls == 1
+
+    await client.aclose()

--- a/ztf_viewer/catalogs/snad/catalog.py
+++ b/ztf_viewer/catalogs/snad/catalog.py
@@ -17,13 +17,15 @@ from ztf_viewer.http import get_client
 class _SnadCatalog:
     url = "https://snad.space/catalog/snad_catalog.csv"
 
-    def __init__(self, interval_seconds=600):
+    def __init__(self, interval_seconds=600, failure_retry_seconds=60):
         self.check_interval = timedelta(seconds=interval_seconds)
+        self.failure_retry_interval = timedelta(seconds=failure_retry_seconds)
 
         with importlib.resources.open_binary(data, "snad_catalog.csv") as fh:
             self.table = self._create_table(fh)
 
         self.updated_at = datetime(1900, 1, 1, 1, 1, tzinfo=UTC)
+        self._failed_at = None
         # Coalesces concurrent refreshes into one download; AsyncSingleFlight is already
         # per-loop internally, so this instance is safe to share across loops.
         self._single_flight = AsyncSingleFlight()
@@ -46,6 +48,8 @@ class _SnadCatalog:
         now = datetime.now(tz=UTC)
         if now - self.updated_at < self.check_interval:
             return
+        if self._failed_at is not None and now - self._failed_at < self.failure_retry_interval:
+            return
         await self._single_flight.run("update", lambda: self._fetch(now))
 
     async def _fetch(self, now):
@@ -53,10 +57,15 @@ class _SnadCatalog:
         try:
             resp = await client.get(self.url, timeout=config.TIMEOUT_SNAD)
         except httpx.HTTPError:
+            self._failed_at = now
             return
         if resp.status_code != 200:
+            self._failed_at = now
             return
+        self._failed_at = None
         if self.updated_at > self._last_modified(resp):
+            # Already current: not a failure, just nothing new to fetch.
+            self.updated_at = now
             return
         self.updated_at = now
         self.table = self._create_table(BytesIO(resp.content))


### PR DESCRIPTION
## Problem

`_SnadCatalog._update` only advances `self.updated_at` on a **successful** fetch. While `snad.space` is down or returning non-200, every sequential caller re-attempts the fetch and pays up to `config.TIMEOUT_SNAD` (10s). `AsyncSingleFlight` only coalesces *concurrent* callers onto one fetch — it does nothing for sequential ones, so every `set_title` / `SnadCatalogSource.create` call pays the full timeout while the upstream is unhealthy.

## Fix

Track failed attempts separately from successful ones:

- New `self._failed_at` timestamp, set whenever `_fetch` hits an `httpx.HTTPError` or a non-200 status, and cleared on any 200 response.
- New `failure_retry_interval` (constructor param `failure_retry_seconds`, default **60s**), distinct from the normal `check_interval` (default 600s). I gave failure backoff its own, shorter constant rather than overloading `check_interval`, since "how long to wait after a real outage before probing again" is a different tradeoff from "how often to poll a healthy upstream" — 60s recovers reasonably fast once snad.space comes back, without hammering it on every page load while it's down.
- `_update` now skips the fetch if **either** `check_interval` (measured from `updated_at`) or `failure_retry_interval` (measured from `_failed_at`) hasn't elapsed.

### The "already current" case

`_fetch` has a third early return: `if self.updated_at > self._last_modified(resp): return`. This fires when the server's `last-modified` is not newer than what we already have — i.e. the check succeeded and confirmed we're current. That's not a failure and must not trigger the failure backoff. It was, however, buggy before this change in a different way: it didn't bump `self.updated_at`, so once `check_interval` elapsed, every subsequent call would refetch again immediately (the server always reports the same old `last-modified`, so the comparison keeps failing to advance). This PR bumps `self.updated_at = now` in that branch too, so a confirmed-current check behaves like a successful refresh for scheduling purposes, and is not treated as a failure.

### Fallback table

The packaged CSV fallback keeps serving throughout: `self.table` is only ever reassigned on an actual successful download (200 + newer `last-modified`), so a failing or backed-off refresh never makes the catalog unavailable — this was already true and still holds.

Base: this stacks on #707 (async httpx port) — branched from its head, not from `master`.

## Tests

Extended `tests/test_snad_catalog.py` (added by #707, `httpx.MockTransport` idiom):

- `test_failed_refresh_backs_off_then_retries_after_the_interval`: a 500 response is not retried on the very next sequential call (transport hit count stays 1), but is retried once `_failed_at` is past the backoff window. Also asserts the fallback table keeps serving throughout.
- `test_already_current_response_is_not_treated_as_a_failure`: a 200 response with an older `last-modified` does not set `_failed_at`, and the table is left unchanged.

Time is controlled by setting `updated_at`/`_failed_at`/`check_interval` directly rather than sleeping.

Full suite (`~/.virtualenvs/web/bin/python -m pytest --basetemp=/tmp/pytest -q`): 460 collected, 0 failures, 0 errors, 2 skipped (JS9, expected locally). `pre-commit run --all-files`: all hooks passed.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>