### PR TITLE
Stop reporting a missing last-modified header as an unknown SNAD ID

### DIFF
--- a/tests/test_async_offload.py
+++ b/tests/test_async_offload.py
@@ -16,7 +16,9 @@ recoverable from the AST alone. So this only covers the specific call sites this
 import asyncio
 import inspect
 import threading
+from datetime import UTC, datetime
 
+import httpx
 import pytest
 
 from ztf_viewer import config
@@ -25,6 +27,7 @@ config.CACHE_TYPE = "memory"
 config.UNAVAILABLE_CATALOGS_CACHE_TYPE = "memory"
 
 import ztf_viewer.__main__ as main_module
+from ztf_viewer.catalogs.snad.catalog import snad_catalog as real_snad_catalog
 from ztf_viewer.exceptions import NotFound
 from ztf_viewer.pages import viewer
 
@@ -80,16 +83,44 @@ def test_sky_coord_from_str_snad_lookup_runs_on_the_loop(monkeypatch):
     assert seen_thread_id == loop_thread_id
 
 
-def test_sky_coord_from_str_reraises_key_error_as_value_error(monkeypatch):
+def test_sky_coord_from_str_reraises_not_found_as_value_error(monkeypatch):
     class StubSource:
         @classmethod
         async def create(cls, name):
-            raise KeyError(name)
+            raise NotFound(name)
 
     monkeypatch.setattr(main_module, "SnadCatalogSource", StubSource)
 
     with pytest.raises(ValueError):
         asyncio.run(main_module.sky_coord_from_str("SNAD123"))
+
+
+def test_sky_coord_from_str_does_not_mask_an_unrelated_key_error(monkeypatch):
+    """A KeyError unrelated to the name lookup (e.g. surfacing from deep in the refresh
+    path) must not be reported as an unknown SNAD ID.
+    """
+
+    class StubSource:
+        @classmethod
+        async def create(cls, name):
+            raise KeyError("last-modified")
+
+    monkeypatch.setattr(main_module, "SnadCatalogSource", StubSource)
+
+    with pytest.raises(KeyError):
+        asyncio.run(main_module.sky_coord_from_str("SNAD123"))
+
+
+def test_oid_from_input_does_not_mask_an_unrelated_key_error(monkeypatch):
+    class StubSource:
+        @classmethod
+        async def create(cls, name):
+            raise KeyError("last-modified")
+
+    monkeypatch.setattr(main_module, "SnadCatalogSource", StubSource)
+
+    with pytest.raises(KeyError):
+        asyncio.run(main_module.oid_from_input("SNAD123"))
 
 
 def test_oid_from_input_snad_lookup_runs_on_the_loop_without_to_thread(monkeypatch):
@@ -138,6 +169,61 @@ def test_set_title_snad_lookup_runs_on_the_loop(monkeypatch):
 
     source = inspect.getsource(inspect.unwrap(viewer.set_title))
     assert "asyncio.to_thread" not in source
+
+
+def test_oid_from_input_swallows_not_found(monkeypatch):
+    class StubSource:
+        @classmethod
+        async def create(cls, name):
+            raise NotFound(name)
+
+    monkeypatch.setattr(main_module, "SnadCatalogSource", StubSource)
+
+    result = asyncio.run(main_module.oid_from_input("SNAD123"))
+
+    assert result == "SNAD123"
+
+
+# --------------------------------------------------------------------------------------------
+# End-to-end: a real refresh through the real SnadCatalogSource, not a stub. A response with no
+# ``last-modified`` header must not surface as "ID ... isn't found in the SNAD catalog"; a
+# genuinely unknown SNAD name still must.
+# --------------------------------------------------------------------------------------------
+
+_SNAD_CSV_HEADER = "Name,R.A.,Dec.,OID,Discovery date (UT),mag,er_down,er_up,ref,er_ref,TNS,Type,Comments"
+_SNAD_CSV_ROW = "SNAD999,10.0,20.0,42,2018-04-08 09:45:49,21.11,0.27,0.36,20.84,0.06,AT 2018abc,PSN,test"
+_SNAD_CSV_BODY = f"{_SNAD_CSV_HEADER}\n{_SNAD_CSV_ROW}\n"
+
+
+def test_sky_coord_from_str_survives_a_response_with_no_last_modified_header(monkeypatch):
+    async def handler(request):
+        # No "last-modified" header at all, unlike a normal snad.space response.
+        return httpx.Response(200, content=_SNAD_CSV_BODY.encode())
+
+    client = httpx.AsyncClient(transport=httpx.MockTransport(handler))
+    monkeypatch.setattr("ztf_viewer.catalogs.snad.catalog.get_client", lambda: client)
+    monkeypatch.setattr(real_snad_catalog, "updated_at", datetime(1900, 1, 1, tzinfo=UTC))
+    monkeypatch.setattr(real_snad_catalog, "_failed_at", None)
+
+    result = asyncio.run(main_module.sky_coord_from_str("SNAD999"))
+
+    assert result is not None
+    asyncio.run(client.aclose())
+
+
+def test_sky_coord_from_str_still_reports_a_genuinely_unknown_name(monkeypatch):
+    async def handler(request):
+        return httpx.Response(200, content=_SNAD_CSV_BODY.encode())
+
+    client = httpx.AsyncClient(transport=httpx.MockTransport(handler))
+    monkeypatch.setattr("ztf_viewer.catalogs.snad.catalog.get_client", lambda: client)
+    monkeypatch.setattr(real_snad_catalog, "updated_at", datetime(1900, 1, 1, tzinfo=UTC))
+    monkeypatch.setattr(real_snad_catalog, "_failed_at", None)
+
+    with pytest.raises(ValueError, match="isn't found in the SNAD catalog"):
+        asyncio.run(main_module.sky_coord_from_str("SNADNOTAREALNAME"))
+
+    asyncio.run(client.aclose())
 
 
 def test_set_title_propagates_not_found(monkeypatch):

--- a/tests/test_snad_catalog.py
+++ b/tests/test_snad_catalog.py
@@ -198,3 +198,34 @@ async def test_already_current_response_is_not_treated_as_a_failure(monkeypatch)
     assert calls == 1
 
     await client.aclose()
+
+
+def test_last_modified_returns_none_for_a_missing_header():
+    resp = httpx.Response(200, content=CSV_BODY.encode())
+
+    assert _SnadCatalog._last_modified(resp) is None
+
+
+async def test_fetch_with_no_last_modified_header_does_not_raise_and_downloads(monkeypatch):
+    """A response missing the header can't be compared, so it is treated as newer: the table
+    is (re)downloaded rather than the fetch raising or silently doing nothing.
+    """
+    calls = 0
+
+    async def handler(request):
+        nonlocal calls
+        calls += 1
+        return httpx.Response(200, content=CSV_BODY.encode())
+
+    client = httpx.AsyncClient(transport=httpx.MockTransport(handler))
+    monkeypatch.setattr("ztf_viewer.catalogs.snad.catalog.get_client", lambda: client)
+
+    catalog = _stale_catalog()
+
+    await catalog._update()
+
+    assert calls == 1
+    assert catalog._failed_at is None
+    assert "SNAD999" in catalog.table["Name"]
+
+    await client.aclose()

--- a/ztf_viewer/__main__.py
+++ b/ztf_viewer/__main__.py
@@ -262,7 +262,7 @@ async def oid_from_input(s: str):
         try:
             source = await SnadCatalogSource.create(s)
             return str(source.ztf_oid)
-        except KeyError:
+        except NotFound:
             pass
     return s
 
@@ -273,7 +273,7 @@ async def sky_coord_from_str(s):
         try:
             source = await SnadCatalogSource.create(s)
             return source.coord
-        except KeyError:
+        except NotFound:
             raise ValueError(f"ID {s} isn't found in the SNAD catalog")
 
     try:

--- a/ztf_viewer/catalogs/snad/catalog.py
+++ b/ztf_viewer/catalogs/snad/catalog.py
@@ -39,7 +39,9 @@ class _SnadCatalog:
 
     @staticmethod
     def _last_modified(resp):
-        s = resp.headers["last-modified"]
+        s = resp.headers.get("last-modified")
+        if s is None:
+            return None
         parsed = email.utils.parsedate(s)
         dt = datetime(*parsed[:7], tzinfo=UTC)
         return dt
@@ -63,7 +65,10 @@ class _SnadCatalog:
             self._failed_at = now
             return
         self._failed_at = None
-        if self.updated_at > self._last_modified(resp):
+        last_modified = self._last_modified(resp)
+        # A missing header means we can't tell whether the server has something
+        # newer, so treat it as newer rather than skip the download.
+        if last_modified is not None and self.updated_at > last_modified:
             # Already current: not a failure, just nothing new to fetch.
             self.updated_at = now
             return
@@ -97,7 +102,10 @@ class SnadCatalogSource:
             name = f"SNAD{name}"
         name = name.upper()
         catalog = await snad_catalog()
-        row = catalog.loc[name]
+        try:
+            row = catalog.loc[name]
+        except KeyError:
+            raise NotFound(f"{name} isn't found in the SNAD catalog") from None
         return cls(row)
 
     @property


### PR DESCRIPTION
## Problem

`_SnadCatalog._last_modified` does `resp.headers["last-modified"]`, which raises `KeyError` if the response has no such header. That propagates out of `_fetch` -> `_update` -> `snad_catalog()` -> `SnadCatalogSource.create`, straight into:

```python
try:
    source = await SnadCatalogSource.create(s)
    return source.coord
except KeyError:
    raise ValueError(f"ID {s} isn't found in the SNAD catalog")
```

in `sky_coord_from_str` (`ztf_viewer/__main__.py`) — so a missing HTTP header gets reported to the user as "ID SNAD123 isn't found in the SNAD catalog". `oid_from_input` has the same `except KeyError` shape and silently swallows it. That `except KeyError` exists to catch the genuine `KeyError` from `catalog.loc[name]` (an unknown SNAD name) — an unrelated `KeyError` from deep in the refresh path was indistinguishable from it.

This is **pre-existing behaviour**, not something #707 (the async httpx port) introduced — `_last_modified` did the same unguarded header access before that port too.

## Fix (defence at both ends, as suggested)

1. **At the source**: `_last_modified` now returns `None` for a missing header instead of raising. `_fetch` treats `None` as "can't tell, assume newer" and proceeds to download rather than raising or silently skipping — a missing header plausibly just means the server didn't give us reliable freshness info, so we go get a fresh copy.
2. **At the call sites**: `SnadCatalogSource.create` now catches the specific `catalog.loc[name]` `KeyError` and translates it into the existing `ztf_viewer.exceptions.NotFound`. Both call sites in `__main__.py` (`oid_from_input`, `sky_coord_from_str`) now catch `NotFound` instead of the broad `KeyError`, so any other `KeyError` (a header problem, or anything else) can no longer masquerade as an unknown ID — it now propagates as what it actually is.

I did both rather than picking one: (1) alone leaves the call sites still catching an overly broad exception type that could mask a different, unrelated `KeyError` in the future; (2) alone still leaves `_last_modified` needlessly raising on a legitimate "we don't know" case instead of degrading gracefully.

Only `ztf_viewer/__main__.py` and `ztf_viewer/catalogs/snad/catalog.py` were touched; `ztf_viewer/pages/viewer.py` was not — its `set_title` already goes through `snad_catalog.search_region`, which doesn't touch `_last_modified` on this path in a way that needed changing here.

Base: stacks on #708 (`snad-refresh-backoff`), which stacks on #707.

## Tests

- `tests/test_snad_catalog.py`: `_last_modified` returns `None` for a header-less response (unit); `_fetch` with no header downloads the table without raising and does not mark it as a failure.
- `tests/test_async_offload.py` (already covers `sky_coord_from_str`/`oid_from_input`'s SNAD branches):
  - updated the existing stub-based test to raise `NotFound` (matching the new contract) instead of a bare `KeyError`;
  - added stub-based tests that an unrelated `KeyError` is no longer masked by either call site;
  - added `NotFound`-swallowing test for `oid_from_input`;
  - added two **end-to-end** tests using the real `SnadCatalogSource`/`_SnadCatalog` singleton with `httpx.MockTransport`: a response with no `last-modified` header does not surface as `ValueError("ID ... isn't found ...")` from `sky_coord_from_str`, while a genuinely unknown SNAD name still does.

Full suite (`~/.virtualenvs/web/bin/python -m pytest --basetemp=/tmp/pytest -q`): 467 collected, 0 failures, 0 errors, 2 skipped (JS9, expected locally). `pre-commit run --all-files`: all hooks passed.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>