### PR TITLE
Stop importing the conesearch package to construct CatalogUnavailable

### DIFF
--- a/tests/test_exceptions.py
+++ b/tests/test_exceptions.py
@@ -1,0 +1,62 @@
+"""Tests for ``ztf_viewer.exceptions``.
+
+The subprocess test is the point of this file: ``CatalogUnavailable`` used to import
+``ztf_viewer.catalogs.conesearch`` just to run an ``isinstance`` check, and that package
+constructs every query object at import, some of which reach the network. A CDS outage therefore
+broke the whole suite at *collection*, not at test time. Only a fresh interpreter can show that
+the import is gone, since by the time any other test runs the package is already in
+``sys.modules``.
+"""
+
+import subprocess
+import sys
+
+from ztf_viewer.exceptions import CatalogUnavailable
+
+_NO_CONESEARCH_IMPORT = """
+import sys
+from ztf_viewer.exceptions import CatalogUnavailable
+
+CatalogUnavailable("boom")
+
+leaked = [name for name in sys.modules if name.startswith("ztf_viewer.catalogs.conesearch")]
+assert not leaked, f"constructing CatalogUnavailable imported {leaked}"
+"""
+
+
+def test_constructing_the_exception_does_not_import_the_conesearch_package():
+    result = subprocess.run(
+        [sys.executable, "-c", _NO_CONESEARCH_IMPORT],
+        capture_output=True,
+        text=True,
+        check=False,
+        env={"PATH": "/usr/bin:/bin", "CACHE_TYPE": "memory", "UNAVAILABLE_CATALOGS_CACHE_TYPE": "memory"},
+    )
+    assert result.returncode == 0, result.stderr
+
+
+def test_bare_message_is_preserved_without_a_catalog():
+    assert str(CatalogUnavailable("boom")) == "boom"
+
+
+def test_catalog_is_named_by_its_query_name():
+    class FakeQuery:
+        query_name = "Fake"
+
+    assert "Fake" in str(CatalogUnavailable("detail", catalog=FakeQuery(), prolongate=False))
+
+
+def test_an_object_without_query_name_is_ignored():
+    # `alerce.py` passes `catalog="Alerce"`, a plain string; it has never been recognised as a
+    # catalog here, and this pins that the duck-typed check did not change that.
+    assert str(CatalogUnavailable("x", catalog="Alerce")) == "x"
+
+
+def test_marking_a_catalog_unavailable_is_opt_out():
+    from ztf_viewer.catalogs.unavailable_catalogs import unavailable_catalogs
+
+    class FakeQuery:
+        query_name = "NotMarked"
+
+    CatalogUnavailable("detail", catalog=FakeQuery(), prolongate=False)
+    assert "NotMarked" not in unavailable_catalogs

--- a/ztf_viewer/exceptions.py
+++ b/ztf_viewer/exceptions.py
@@ -7,18 +7,20 @@ class NotFound(Exception):
 
 class CatalogUnavailable(Exception):
     def __init__(self, *args, catalog: Any = None, prolongate: bool = True):
-        # We wouldn't like to have a circular import, so we import it here
-        from ztf_viewer.catalogs.conesearch import _BaseCatalogQuery
-        from ztf_viewer.catalogs.unavailable_catalogs import unavailable_catalogs
+        # Duck-typed rather than an isinstance check against _BaseCatalogQuery: importing the
+        # conesearch package constructs every query object, and some of those reach the network.
+        query_name = getattr(catalog, "query_name", None)
 
-        if not isinstance(catalog, _BaseCatalogQuery):
+        if query_name is None:
             super().__init__(*args)
             return
 
-        query_name = catalog.query_name
         super().__init__(f"Catalog {query_name} is unavailable: {args}")
 
         if prolongate:
+            # Imported here because ztf_viewer.catalogs pulls this module back in.
+            from ztf_viewer.catalogs.unavailable_catalogs import unavailable_catalogs
+
             unavailable_catalogs.add(query_name)
 
 


### PR DESCRIPTION
`CatalogUnavailable.__init__` imported `ztf_viewer.catalogs.conesearch` solely to run an `isinstance` check against `_BaseCatalogQuery`. That package instantiates all 19 query objects at import time, and one of them (`SimbadQuery`) reaches the network in its constructor. Net effect: **an exception class could not be constructed without network access to CDS.**

While CDS is unreachable, that turns into the whole test suite failing at *collection* rather than at test time — which is how I found it. Verified pre-existing on clean `master`:

```
$ python -c "from ztf_viewer.exceptions import CatalogUnavailable; CatalogUnavailable('x')"
pyvo.dal.exceptions.DALServiceError: Unable to access the capabilities endpoint at:
- https://simbad.cds.unistra.fr/simbad/sim-tap/capabilities: Connection failed
```

## The change

Duck-type on `query_name` instead of importing the package to `isinstance`-check. The conesearch import is gone entirely.

Behaviour is unchanged in every case, including the one that looks like it might change: `alerce.py:63,94` pass `catalog="Alerce"`, a plain **string**. A string fails `isinstance(_, _BaseCatalogQuery)` today and has no `query_name` attribute now, so it takes the bare-message path either way. (Worth noting separately: that means Alerce has never actually been marked unavailable by those two call sites, and its exception message drops the catalog name. That looks like a real bug, but fixing it changes circuit-breaker behaviour, so I left it alone — flagging it rather than folding it in.)

The `unavailable_catalogs` import stays function-local. I tried to hoist it and it is a genuine circular import: `ztf_viewer/catalogs/__init__.py` → `ztf_dr.py` → `ztf_viewer.exceptions`. The comment now says which import is circular and why, instead of the previous unqualified "we wouldn't like to have a circular import".

## Tests

New `tests/test_exceptions.py`. The load-bearing one runs a **subprocess**, because by the time any other test executes, `conesearch` is already in `sys.modules` and the assertion would pass vacuously — only a fresh interpreter can show the import is gone.

`474 passed, 2 skipped` locally with CDS unreachable — but note that full green depends on the SIMBAD fix stacked on top of this one; this PR alone fixes the exception class, not every import path into `conesearch`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CAVcYePtBQXZNrV1q3s1R3