### PR TITLE
Build the SIMBAD client on first query instead of at import

### DIFF
--- a/ztf_viewer/catalogs/conesearch/simbad.py
+++ b/ztf_viewer/catalogs/conesearch/simbad.py
@@ -25,9 +25,17 @@ class SimbadQuery(_BaseCatalogQuery):
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
-        self._query = Simbad()
-        self._query.add_votable_fields("mesdistance", "R", "V", "otype", "otypes")
-        self._query_region = self._query.query_region
+        self._query = None
+
+    def _query_region(self, coord, radius=None):
+        # add_votable_fields validates the field names against SIMBAD's TAP schema over the
+        # network, so build the client on first query instead of at import. find() reaches this
+        # through _ensure_coroutine, so the build runs in a worker thread, not on the loop.
+        if self._query is None:
+            query = Simbad()
+            query.add_votable_fields("mesdistance", "R", "V", "otype", "otypes")
+            self._query = query
+        return self._query.query_region(coord, radius=radius)
 
     def get_url(self, id, row=None):
         qid = urllib.parse.quote(id)


### PR DESCRIPTION
Stacked on #715. That PR stops the *exception class* from needing the network; this one stops the *catalog package* from needing it, which is what actually unblocks the test suite.

## The problem

`SimbadQuery.__init__` calls `add_votable_fields("mesdistance", "R", "V", "otype", "otypes")`. astroquery validates those field names against SIMBAD's TAP schema — over the network. `conesearch/__init__.py:36` constructs `SimbadQuery("Simbad")` at module scope, so **importing the catalog package requires CDS to be reachable**. The app does that at startup; most test modules do it transitively.

## The change

Build the client on first query, inside `_query_region`, rather than in `__init__`.

The subtlety worth reviewing: a naive lazy `@property` would be wrong here. `_base.py:187` reads `self._query_region` from inside `async def find()`, so a property doing blocking network I/O would block the event loop. Making `_query_region` a plain method instead means `find()` wraps it via `_ensure_coroutine`, which offloads with `asyncio.to_thread` — so the first-query build runs in a worker thread, same as the query itself.

Two concurrent first queries can both build a client. That is idempotent and costs one redundant schema fetch, so I did not add a lock; say the word if you would rather have one.

## Why this matters beyond the outage

This isn't only about the current CDS unreachability. Constructing every catalog client at import means app startup is gated on ~19 upstreams being healthy, and it puts a network round trip inside module import — which is also why a spawned process-pool worker re-importing the package would pay for it. This PR only fixes the SIMBAD one; I did not audit the other 18.

## Test evidence

With CDS unreachable from this machine (`simbad.cds.unistra.fr:443` TCP connect times out), on this branch:

```
474 passed, 2 skipped, 35 warnings in 54.20s
```

The 2 skips are the pre-existing "JS9 not installed locally" ones. On `master` the same command aborts during collection with 6 errors. This is the first full local run of the suite in this session — the extinction and load-test PRs (#711, #712) were opened without one for exactly this reason, and both should be re-checked once this lands.

**Not verified:** that SIMBAD queries still behave correctly against the live service, since I cannot reach it. The change preserves the field list and the `query_region(coord, radius=radius)` call shape, but somebody should exercise a real SIMBAD cone search on a preview before this merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CAVcYePtBQXZNrV1q3s1R3