### PR TITLE
Fix Dash 4 input borders, number spinners, and tag spacing

### DIFF
--- a/ztf_viewer/assets/style.css
+++ b/ztf_viewer/assets/style.css
@@ -127,6 +127,28 @@ select:focus {
   display: none;
 }
 
+/* The wrapper keeps its own rounded corners and `overflow: hidden` even with
+   its box stripped above, which clips the corners off the input's own border,
+   and its `vertical-align: middle` no longer lines the field up with the
+   button next to it (the "Go" buttons in the header). */
+.dash-input-container.dash-input {
+  overflow: visible;
+  border-radius: 0;
+  vertical-align: baseline;
+  margin-right: 0.35em;
+}
+
+/* Dash 4 squares off number inputs and hides the native spinner in favour of
+   its own stepper buttons, hidden just above. Restore the rounded corners the
+   text fields have and the browser's own arrows. */
+.dash-input-element[type="number"] {
+  border-radius: 4px;
+  -moz-appearance: number-input;
+}
+.dash-input-element[type="number"]::-webkit-inner-spin-button {
+  appearance: auto;
+}
+
 /* Dash 4's redesigned form controls (radio dots, checkboxes, the slider
    handle, dropdown focus rings) all key off this custom property for their
    "selected/interactive" color. Left at Dash's own default it's a plain

--- a/ztf_viewer/assets/style.css
+++ b/ztf_viewer/assets/style.css
@@ -149,6 +149,14 @@ select:focus {
   appearance: auto;
 }
 
+/* Dash 4 puts 8px between a checkbox/radio and its own label - the same gap it
+   puts between adjacent options, so a row of them reads as evenly spaced and
+   no label looks attached to its own control. Tighten the inner gap so the
+   grouping is unambiguous and the rows stay compact. */
+.dash-options-list-option-checkbox {
+  margin-right: 0.25em;
+}
+
 /* Dash 4's redesigned form controls (radio dots, checkboxes, the slider
    handle, dropdown focus rings) all key off this custom property for their
    "selected/interactive" color. Left at Dash's own default it's a plain

--- a/ztf_viewer/pages/viewer.py
+++ b/ztf_viewer/pages/viewer.py
@@ -1011,7 +1011,7 @@ async def set_akb_info(_, oid):
                     title=tag["description"],
                     # Without the margin the next tag's checkbox sits flush against this
                     # tag's name and reads as belonging to it.
-                    style={"display": "inline-block", "margin-right": "0.5em"},
+                    style={"display": "inline-block", "margin-right": "0.75em"},
                 )
                 for column, tag in enumerate(tags)
             ],

--- a/ztf_viewer/pages/viewer.py
+++ b/ztf_viewer/pages/viewer.py
@@ -1011,7 +1011,7 @@ async def set_akb_info(_, oid):
                     title=tag["description"],
                     # Without the margin the next tag's checkbox sits flush against this
                     # tag's name and reads as belonging to it.
-                    style={"display": "inline-block", "margin-right": "1em"},
+                    style={"display": "inline-block", "margin-right": "0.5em"},
                 )
                 for column, tag in enumerate(tags)
             ],
@@ -1327,7 +1327,7 @@ async def show_ref_mag_or_magerr(oid, dr, different_filter, different_field):
                             type="number",
                             maxLength=6,
                             step=0.01,
-                            style={"width": "6em", "display": "inline-block"},
+                            style={"width": "6em"},
                         ),
                         html.Div(
                             "  err ",
@@ -1341,7 +1341,7 @@ async def show_ref_mag_or_magerr(oid, dr, different_filter, different_field):
                             maxLength=5,
                             min=0,
                             step=0.01,
-                            style={"width": "5em", "display": "inline-block"},
+                            style={"width": "5em"},
                         ),
                     ],
                 )

--- a/ztf_viewer/pages/viewer.py
+++ b/ztf_viewer/pages/viewer.py
@@ -1007,10 +1007,11 @@ async def set_akb_info(_, oid):
                         id={"type": "akb-tags", "index": f"{row}-{column}"},
                         options=[{"label": tag["name"], "value": tag["name"]}],
                         value=[tag["name"]] if tag["name"] in tags_enabled else [],
-                        labelStyle={"display": "inline-block"},
                     ),
                     title=tag["description"],
-                    style={"display": "inline-block"},
+                    # Without the margin the next tag's checkbox sits flush against this
+                    # tag's name and reads as belonging to it.
+                    style={"display": "inline-block", "margin-right": "1em"},
                 )
                 for column, tag in enumerate(tags)
             ],


### PR DESCRIPTION
Closes #670, closes #671, closes #672.

All three are leftovers from the Dash 4 upgrade. Dash 4 wraps every `dcc.Input` in a container `div` that carries the visible box; `style.css` already strips that box so the inner `<input>` keeps its Skeleton look, but three details survived.

### #672 / #670 — clipped borders

The wrapper keeps `overflow: hidden` and its own `border-radius: 4px`. It is laid out at exactly the same size as the input, so it clips the corners off the input's own border — the "uncomplete" borders in #672 and the notches circled in #670.

```css
.dash-input-container.dash-input {
  overflow: visible;
  border-radius: 0;
}
```

### #672 / #670 — missing arrows, mixed border styles

Dash's `.dash-input-element[type='number']` sets `border-radius: 0` and replaces the native spinners with its own stepper buttons, which `style.css` hides. Result: square-cornered number fields next to rounded text fields, and no arrows anywhere. Restored both, using Dash's own mobile fallback (it re-enables the native spinner when its steppers are hidden).

### #672 — field sizing (follow-up)

Removing `overflow: hidden` exposed a second bug it had been masking. Dash 4 copies a `dcc.Input`'s Python `style` onto the wrapper div, so the `display: inline-block` left over from Dash 3 replaced the wrapper's own `inline-flex`. That makes Dash's `.dash-input-element { flex: 1 1 0 }` inert, and the input fell back to its intrinsic ~200px instead of filling its 6em/5em wrapper — the clipping was all that kept it looking 6em wide. Dropped the two now-harmful `display: inline-block` entries so the input sizes to the wrapper again.

### #670 — borders too close

The wrapper's `vertical-align: middle` and zero margin left the header fields both misaligned with and flush against the "Go" buttons. `vertical-align: baseline` + a `0.35em` right margin.

### #671 — tag checkbox positions

Dash 4 puts 8px between a checkbox/radio and its own label — **the same gap it puts between adjacent options**. So every row of controls reads as evenly spaced with no label visibly belonging to any one control, and no amount of tuning the inter-option margin fixes it; widening it just makes the row sparse. Tightened the inner gap to `0.25em` in `style.css`, which fixes the light-curve type, brightness unit, and closest-object rows too, and lets far more fit per line.

On top of that, the akb tag editor lays each tag out as its own single-option `Checklist` inside an inline-block `div`, with no gap between them — so the next tag's checkbox sits immediately after the previous tag's name and reads as belonging to it. Added a `0.75em` right margin on the wrapper, and dropped the `labelStyle` left over from Dash 3 (inert since the Dash 4 DOM restructure, same as the ones removed in cdbc3bd).

## Testing

- `pytest`: 480 passed, 2 skipped (both JS9-not-installed-locally).
- `pre-commit run --files ...`: passed.
- Verified in WebKit (matching the reporter's Safari screenshots) and Firefox, both against the running app (`/`, `/dr24/view/633207400004730` — header fields, MJD range, every per-catalog search-radius field) and against a standalone Dash app reproducing the tag-editor and reference-mag layouts, which need a login to reach in the real app. Before/after renders match the "Before" image in #672: complete rounded borders and native arrows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SWVHmGLt7mHu7HPb4AHtFm
