### PR TITLE
Fix missing Gaia DR3 ML classification when probability is masked

### DIFF
--- a/tests/catalogs/conesearch/test_gaia_dr3.py
+++ b/tests/catalogs/conesearch/test_gaia_dr3.py
@@ -1,0 +1,28 @@
+"""Tests for GaiaDr3Query.add_prob_class_columns — covers the fix for issue #310.
+
+Vizier returns masked (missing) probability values as numpy.ma.masked, not
+None. The bug compared against `None`, so a masked probability slipped
+through into the classifications dict and was later rendered as "--%".
+"""
+
+import pytest
+from astropy.table import Table
+from numpy import ma
+
+from ztf_viewer.catalogs.conesearch.gaia_dr3 import GaiaDr3Query
+
+
+@pytest.mark.asyncio
+async def test_add_prob_class_columns_skips_masked_probability():
+    table = Table(
+        {
+            "PQSO": ma.array([0.706, 0.0], mask=[False, True]),
+            "PGal": ma.array([0.0, 0.0], mask=[True, True]),
+            "PSS": ma.array([0.0, 0.5], mask=[True, False]),
+        }
+    )
+
+    await GaiaDr3Query.add_prob_class_columns(None, table)
+
+    assert table["classifications"][0] == {"Quasar": pytest.approx(0.706)}
+    assert table["classifications"][1] == {"single star": pytest.approx(0.5)}

--- a/ztf_viewer/catalogs/conesearch/gaia_dr3.py
+++ b/ztf_viewer/catalogs/conesearch/gaia_dr3.py
@@ -163,6 +163,6 @@ class GaiaDr3Query(_BaseVizierQuery, _BaseLightCurveQuery):
         table["classifications"] = [{} for _ in range(len(table))]
         for row in table:
             for pretty_name, column_name in [("Quasar", "PQSO"), ("galaxy", "PGal"), ("single star", "PSS")]:
-                if (prob := row[column_name]) is None:
+                if (prob := row[column_name]) is None or prob is np.ma.masked:
                     continue
                 row["classifications"][pretty_name] = prob


### PR DESCRIPTION
## Summary
- Vizier returns a missing PQSO/PGal/PSS value as `numpy.ma.masked`, not `None`, so `add_prob_class_columns` compared against the wrong sentinel and let masked probabilities leak into the `classifications` dict, where they rendered as `--%` in the object summary instead of being skipped.
- Now skips both `None` and `numpy.ma.masked`.

## Test plan
- [x] Added `tests/catalogs/conesearch/test_gaia_dr3.py`, which fails on the pre-fix code (reproducing the `--%` bug) and passes with the fix.
- [x] `pytest tests/catalogs/conesearch/` (network-dependent tests skip locally, as expected).

Fixes #310

https://claude.ai/code/session_01HVqCbuk8EeaU3pP2brY5Fy