### PR TITLE
Fix master CI: defer GaiaDr3Query import in its test

### DIFF
--- a/tests/catalogs/conesearch/test_gaia_dr3.py
+++ b/tests/catalogs/conesearch/test_gaia_dr3.py
@@ -9,11 +9,13 @@ import pytest
 from astropy.table import Table
 from numpy import ma
 
-from ztf_viewer.catalogs.conesearch.gaia_dr3 import GaiaDr3Query
-
 
 @pytest.mark.asyncio
 async def test_add_prob_class_columns_skips_masked_probability():
+    # Deferred: a module-level import would run during collection, before conftest forces the
+    # memory-backed unavailable_catalogs singleton, and eagerly connect to Redis instead.
+    from ztf_viewer.catalogs.conesearch.gaia_dr3 import GaiaDr3Query
+
     table = Table(
         {
             "PQSO": ma.array([0.706, 0.0], mask=[False, True]),


### PR DESCRIPTION
## Summary
- #721 merged with `tests/catalogs/conesearch/test_gaia_dr3.py` importing `GaiaDr3Query` at module level, which broke master's CI.
- That import pulls in `ztf_viewer.catalogs.unavailable_catalogs` (via `_base.py`) at **collection time**, before `conftest.py`'s `pytest_runtest_setup` gets a chance to force the memory-backed singleton. The module-level singleton then gets built against the real `redis` default hostname, which doesn't resolve in the plain `docker run` test container — causing:
  - `tests/pages/test_viewer.py::test_get_summary_failing_catalog_matches_catalog_absent`
  - `tests/test_exceptions.py::test_marking_a_catalog_unavailable_is_opt_out`
  - `tests/test_unavailable_catalogs_async.py::test_memory_backend_shares_state_with_the_sync_accessor`
- Every other file in `tests/catalogs/conesearch/` already defers this kind of import inside the test/helper function for exactly this reason (see `test_unavailable_catalogs_async.py`'s own docstring warning about it). This just brings `test_gaia_dr3.py` in line.

## Test plan
- [x] Reproduced locally: reverting to the module-level import reproduces the identical 3 failures seen in CI.
- [x] `pytest tests/` passes fully locally with the deferred import.

https://claude.ai/code/session_01HVqCbuk8EeaU3pP2brY5Fy