### PR TITLE
Add GitHub Actions cache to test.yml's Docker builds

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -19,17 +19,9 @@ jobs:
         push: false
         cache-from: type=gha,scope=base
         cache-to: type=gha,mode=max,scope=base
-    - name: Copy test Dockerfile
-      run: cp .ci/Dockerfile_test Dockerfile_test
     - name: Build test docker image
-      uses: docker/build-push-action@v6
-      with:
-        context: .
-        file: Dockerfile_test
-        tags: ztf-viewer-test
-        load: true
-        push: false
-        cache-from: type=gha,scope=test
-        cache-to: type=gha,mode=max,scope=test
+      run: |
+        cp .ci/Dockerfile_test Dockerfile_test
+        docker build --tag ztf-viewer-test --file Dockerfile_test .
     - name: Run tests
       run: docker run -t ztf-viewer-test

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,21 +1,35 @@
 name: "Test"
-
 on:
   push:
   pull_request:
-
 jobs:
   test:
     runs-on: ubuntu-latest
-
     steps:
     - name: Checkout repository
       uses: actions/checkout@v7
+    - name: Set up Docker Buildx
+      uses: docker/setup-buildx-action@v3
     - name: Build base docker image
-      run: docker build --tag ztf-viewer .
+      uses: docker/build-push-action@v6
+      with:
+        context: .
+        tags: ztf-viewer
+        load: true
+        push: false
+        cache-from: type=gha,scope=base
+        cache-to: type=gha,mode=max,scope=base
+    - name: Copy test Dockerfile
+      run: cp .ci/Dockerfile_test Dockerfile_test
     - name: Build test docker image
-      run: |
-        cp .ci/Dockerfile_test Dockerfile_test
-        docker build --tag ztf-viewer-test --file Dockerfile_test .
+      uses: docker/build-push-action@v6
+      with:
+        context: .
+        file: Dockerfile_test
+        tags: ztf-viewer-test
+        load: true
+        push: false
+        cache-from: type=gha,scope=test
+        cache-to: type=gha,mode=max,scope=test
     - name: Run tests
       run: docker run -t ztf-viewer-test


### PR DESCRIPTION
## Summary
- \`test.yml\` built both the base and test Docker images from scratch on every run — no buildx, no cache-from/cache-to — so \`apt install\`, LaTeX/fmtutil setup, and \`uv sync\` were repeated in full each time, adding a couple minutes to every CI run.
- Switches both builds to \`docker/setup-buildx-action\` + \`docker/build-push-action\` with \`cache-from/cache-to: type=gha\`, using separate scopes (\`base\`/\`test\`) so the two images' caches don't collide, and \`load: true\` so the images land in the local daemon for the subsequent \`docker run\`.

## Test plan
- [x] YAML validated.
- [ ] First run on this PR will populate the GHA cache cold (no speedup yet); the speedup shows on the next run that hits the same layers.

https://claude.ai/code/session_01HVqCbuk8EeaU3pP2brY5Fy