### PR TITLE
Distinguish Skybot service errors from "no object found"

### DIFF
--- a/tests/catalogs/test_skybot.py
+++ b/tests/catalogs/test_skybot.py
@@ -14,8 +14,9 @@ import pytest
 from astropy.coordinates import Angle
 from astropy.table import MaskedColumn, QTable
 from astropy.time import Time
+from requests import ConnectionError as RequestsConnectionError
 
-from ztf_viewer.exceptions import NotFound
+from ztf_viewer.exceptions import CatalogUnavailable, NotFound
 
 
 def _make_empty_skybot_table():
@@ -109,6 +110,28 @@ def test_result_outside_radius_raises_not_found():
 
     with pytest.raises(NotFound):
         query.find(ra=331.0, dec=-11.4, observatory_mjd=_OBS_MJD, radius_arcsec=60.0)
+
+
+def test_network_error_raises_catalog_unavailable():
+    """A network/HTTP failure from astroquery should raise CatalogUnavailable, not crash.
+
+    Regression test for https://github.com/snad-space/ztf-viewer/issues/379:
+    ``cone_search`` (built on ``requests``) can raise ``requests.RequestException``
+    subclasses on connection or HTTP errors, e.g. when the SkyBot service is down.
+    Previously only ``(RuntimeError, ValueError)`` were caught, so a real service
+    error propagated uncaught instead of being reported as "catalog unavailable" —
+    indistinguishable from, and worse than, the "no object found" case.
+    """
+    from ztf_viewer.catalogs.skybot import SkybotQuery
+
+    query = SkybotQuery.__new__(SkybotQuery)
+    query._query = MagicMock()
+    query._query.cone_search.side_effect = RequestsConnectionError("connection refused")
+
+    # Distinct args from the other tests: `find` is memoized by (ra, dec, mjd, radius),
+    # and a cache hit from another test would make this test pass regardless of the fix.
+    with pytest.raises(CatalogUnavailable):
+        query.find(ra=12.3, dec=45.6, observatory_mjd=_OBS_MJD, radius_arcsec=60.0)
 
 
 def test_radius_too_large_raises_value_error():

--- a/ztf_viewer/catalogs/skybot.py
+++ b/ztf_viewer/catalogs/skybot.py
@@ -4,9 +4,10 @@ logger = logging.getLogger(__name__)
 from astropy.coordinates import Angle, SkyCoord
 from astropy.time import Time
 from astroquery.imcce import Skybot
+from requests import RequestException
 
 from ztf_viewer.cache import cache
-from ztf_viewer.exceptions import NotFound
+from ztf_viewer.exceptions import CatalogUnavailable, NotFound
 from ztf_viewer.util import PALOMAR_OBS_CODE
 
 
@@ -46,6 +47,10 @@ class SkybotQuery:
                 find_asteroids=True,
                 find_comets=True,
             )
+        except RequestException as e:
+            # Network/HTTP failure: the service is down, not that there's no object here.
+            logger.warning(e)
+            raise CatalogUnavailable(f"Skybot request failed: {e}")
         except RuntimeError, ValueError:
             # RuntimeError: general Skybot failure
             # ValueError("No table found"): Skybot returned an error VOTable (e.g. invalid epoch)

--- a/ztf_viewer/pages/viewer.py
+++ b/ztf_viewer/pages/viewer.py
@@ -2081,6 +2081,8 @@ async def update_skybot_for_graph_clicked(data, dr):
         )
     except NotFound:
         return html.Div("No minor planets found in 15″")
+    except CatalogUnavailable:
+        return html.Div("Skybot is unavailable now")
 
     return [html.B("Minor planets: ")] + list_join(
         ", ", (f"{row['__name']} ({row['__separation']}, mV={row['__v_mag']:.1f})" for row in table)


### PR DESCRIPTION
## Summary
- `SkybotQuery.find()` only caught `(RuntimeError, ValueError)` around the astroquery `cone_search` call. `astroquery.imcce.Skybot` makes its HTTP request with `requests` internally, so a real network/HTTP failure (service down, timeout, non-2xx response) raises a `requests.RequestException` subclass that wasn't caught at all — it propagated uncaught out of the "minor planets near this point" Dash callback and crashed it, instead of being reported as unavailable.
- This is the concrete manifestation of the ambiguity raised in #379 between "no object found" and "service error": previously a service error wasn't even lumped in with "not found" — it just crashed.
- Catch `RequestException` separately and raise `CatalogUnavailable` (the pattern already used by every other catalog query in `ztf_viewer/catalogs/conesearch/`), and have the graph-click callback in `ztf_viewer/pages/viewer.py` show a distinct "Skybot is unavailable now" message for it instead of erroring out.

## Test plan
- Added `tests/catalogs/test_skybot.py::test_network_error_raises_catalog_unavailable`, a unit test that mocks `cone_search` to raise `requests.exceptions.ConnectionError` and asserts `CatalogUnavailable` is raised. Verified it fails without the fix (using `--no-net-skip` so a real transport error isn't auto-skipped) and passes with it.
- `python -m pytest tests/ -q --basetemp=/tmp/pytest` — same 3 pre-existing failures as on a clean checkout with these changes stashed out (test-order state leakage in `unavailable_catalogs`, unrelated to this change); no new failures. Network-dependent catalog tests skip locally as expected (no Redis, no live network), JS9 tests skip as expected.

Fixes #379

https://claude.ai/code/session_01HVqCbuk8EeaU3pP2brY5Fy