### PR TITLE
Distinguish Skybot service errors from "no object found"

### DIFF
--- a/tests/catalogs/test_skybot.py
+++ b/tests/catalogs/test_skybot.py
@@ -14,8 +14,9 @@ import pytest
 from astropy.coordinates import Angle
 from astropy.table import MaskedColumn, QTable
 from astropy.time import Time
+from requests import ConnectionError as RequestsConnectionError
 
-from ztf_viewer.exceptions import NotFound
+from ztf_viewer.exceptions import CatalogUnavailable, NotFound
 
 
 def _make_empty_skybot_table():
@@ -109,6 +110,28 @@ def test_result_outside_radius_raises_not_found():
 
     with pytest.raises(NotFound):
         query.find(ra=331.0, dec=-11.4, observatory_mjd=_OBS_MJD, radius_arcsec=60.0)
+
+
+def test_network_error_raises_catalog_unavailable():
+    """A network/HTTP failure from astroquery should raise CatalogUnavailable, not crash.
+
+    Regression test for https://github.com/snad-space/ztf-viewer/issues/379:
+    ``cone_search`` (built on ``requests``) can raise ``requests.RequestException``
+    subclasses on connection or HTTP errors, e.g. when the SkyBot service is down.
+    Previously only ``(RuntimeError, ValueError)`` were caught, so a real service
+    error propagated uncaught instead of being reported as "catalog unavailable" —
+    indistinguishable from, and worse than, the "no object found" case.
+    """
+    from ztf_viewer.catalogs.skybot import SkybotQuery
+
+    query = SkybotQuery.__new__(SkybotQuery)
+    query._query = MagicMock()
+    query._query.cone_search.side_effect = RequestsConnectionError("connection refused")
+
+    # Distinct args from the other tests: `find` is memoized by (ra, dec, mjd, radius),
+    # and a cache hit from another test would make this test pass regardless of the fix.
+    with pytest.raises(CatalogUnavailable):
+        query.find(ra=12.3, dec=45.6, observatory_mjd=_OBS_MJD, radius_arcsec=60.0)
 
 
 def test_radius_too_large_raises_value_error():

--- a/ztf_viewer/catalogs/skybot.py
+++ b/ztf_viewer/catalogs/skybot.py
@@ -4,9 +4,10 @@ logger = logging.getLogger(__name__)
 from astropy.coordinates import Angle, SkyCoord
 from astropy.time import Time
 from astroquery.imcce import Skybot
+from requests import RequestException
 
 from ztf_viewer.cache import cache
-from ztf_viewer.exceptions import NotFound
+from ztf_viewer.exceptions import CatalogUnavailable, NotFound
 from ztf_viewer.util import PALOMAR_OBS_CODE
 
 
@@ -46,6 +47,10 @@ class SkybotQuery:
                 find_asteroids=True,
                 find_comets=True,
             )
+        except RequestException as e:
+            # Network/HTTP failure: the service is down, not that there's no object here.
+            logger.warning(e)
+            raise CatalogUnavailable(f"Skybot request failed: {e}")
         except RuntimeError, ValueError:
             # RuntimeError: general Skybot failure
             # ValueError("No table found"): Skybot returned an error VOTable (e.g. invalid epoch)

--- a/ztf_viewer/pages/viewer.py
+++ b/ztf_viewer/pages/viewer.py
@@ -2081,6 +2081,8 @@ async def update_skybot_for_graph_clicked(data, dr):
         )
     except NotFound:
         return html.Div("No minor planets found in 15″")
+    except CatalogUnavailable:
+        return html.Div("Skybot is unavailable now")
 
     return [html.B("Minor planets: ")] + list_join(
         ", ", (f"{row['__name']} ({row['__separation']}, mV={row['__v_mag']:.1f})" for row in table)


### PR DESCRIPTION
SkybotQuery.find() only caught (RuntimeError, ValueError) around the astroquery cone_search call. astroquery.imcce.Skybot uses requests internally, so a real network/HTTP failure (service down, timeout, non-2xx response) raises a requests.RequestException subclass that wasn't caught at all -- it propagated out of the Dash callback and crashed the "minor planets near this point" feature instead of being reported as unavailable, exactly the kind of "service error" vs. "not found" ambiguity raised in the issue.

Catch RequestException separately and raise CatalogUnavailable, and have the graph-click callback show a distinct message for it instead of silently erroring out.

Fixes #379