### PR TITLE
Fix intermittent redis-connection test failures

### DIFF
--- a/.ci/Dockerfile_test
+++ b/.ci/Dockerfile_test
@@ -1,5 +1,8 @@
 FROM ztf-viewer
 
+ENV CACHE_TYPE=memory
+ENV UNAVAILABLE_CATALOGS_CACHE_TYPE=memory
+
 RUN apt update \
     && apt install -y redis-server
 


### PR DESCRIPTION
## Summary
This has been intermittently breaking CI on unrelated PRs (#722, and again on #725) with 3 tests failing on `redis:6379: Name or service not known`. Root cause, fully explained:

- `ztf_viewer/config.py` defaults `CACHE_TYPE` and `UNAVAILABLE_CATALOGS_CACHE_TYPE` to `"redis"`, and `ztf_viewer/cache/__init__.py` / `ztf_viewer/catalogs/unavailable_catalogs.py` each build a **module-level singleton eagerly at import time** using that default.
- `tests/conftest.py`'s `pytest_runtest_setup` monkeypatches `ztf_viewer.config.UNAVAILABLE_CATALOGS_CACHE_TYPE = "memory"` — but only right before each test *runs*. By then, pytest has already **imported every collected test module** during collection.
- Several existing test files (`tests/pages/test_viewer.py`, `tests/test_async_offload.py`, etc.) already patch `config.UNAVAILABLE_CATALOGS_CACHE_TYPE = "memory"` at their own module scope for this exact reason, and `tests/test_exceptions.py` spawns a subprocess with `env={"CACHE_TYPE": "memory", "UNAVAILABLE_CATALOGS_CACHE_TYPE": "memory"}` to sidestep it entirely.
- `tests/catalogs/**` sorts alphabetically before those top-level `test_*.py` files, so whichever module first imports the `unavailable_catalogs` chain wins the race — and that ordering was not reliably reproducible across container builds (confirmed empirically: identical commit, two CI runs, one pass one fail; reproduced locally too).

Fix: set `CACHE_TYPE=memory` and `UNAVAILABLE_CATALOGS_CACHE_TYPE=memory` as environment variables in `.ci/Dockerfile_test`, so `ztf_viewer.config` picks up "memory" the very first time it's imported — before any Python code runs, so collection order can no longer matter.

## Test plan
- [x] Reproduced the failure locally (without this fix) on an unrelated branch.
- [x] With `CACHE_TYPE=memory UNAVAILABLE_CATALOGS_CACHE_TYPE=memory` set, ran the full local suite 4 times in a row — all clean, no redis failures.

https://claude.ai/code/session_01HVqCbuk8EeaU3pP2brY5Fy