### PR TITLE
Add ?fits=first/last/peak query param to load a FITS image on page load

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ Version schema is `year.month.num_release`
 
 ## [Unreleased]
 
+### Added
+
+- `?fits=first|last|peak` query parameter to load a FITS image on page load https://github.com/snad-space/ztf-viewer/issues/400
+
 ### Changed
 
 - Switched the web server backend from Flask to FastAPI/Starlette, served by uvicorn, with Dash callbacks running as native coroutines

--- a/tests/pages/test_viewer.py
+++ b/tests/pages/test_viewer.py
@@ -672,3 +672,59 @@ def test_set_figure_link_prevents_update_when_range_is_backwards():
 def test_set_figure_link_raises_for_unknown_type():
     with pytest.raises(ValueError, match="lc_type"):
         set_figure_link("633207400004730", "dr24", "Title", None, None, None, None, "bogus", None, None, "png")
+
+
+# ---------------------------------------------------------------------------------------------
+# parse_search / pick_fits_observation / fits_children_for_observation -- the `?fits=` query
+# param that loads a FITS image on page load instead of requiring a click on the light curve.
+# ---------------------------------------------------------------------------------------------
+
+parse_search = viewer.parse_search  # a plain function, never wrapped
+pick_fits_observation = viewer.pick_fits_observation  # a plain function, never wrapped
+fits_children_for_observation = inspect.unwrap(viewer.fits_children_for_observation)
+
+
+def test_parse_search_fits_param():
+    assert parse_search("?fits=peak")["fits"] == "peak"
+
+
+def test_parse_search_fits_param_absent():
+    assert parse_search("")["fits"] is None
+
+
+def test_pick_fits_observation_empty_lc():
+    assert pick_fits_observation([], "peak") is None
+
+
+def test_pick_fits_observation_unknown_param():
+    lc = [{"mjd": 58000.0, "mag": 18.0}]
+    assert pick_fits_observation(lc, "bogus") is None
+
+
+def test_pick_fits_observation_first():
+    lc = [{"mjd": 58002.0, "mag": 18.0}, {"mjd": 58000.0, "mag": 19.0}, {"mjd": 58001.0, "mag": 17.0}]
+    assert pick_fits_observation(lc, "first")["mjd"] == 58000.0
+
+
+def test_pick_fits_observation_last():
+    lc = [{"mjd": 58002.0, "mag": 18.0}, {"mjd": 58000.0, "mag": 19.0}, {"mjd": 58001.0, "mag": 17.0}]
+    assert pick_fits_observation(lc, "last")["mjd"] == 58002.0
+
+
+def test_pick_fits_observation_peak_is_brightest():
+    lc = [{"mjd": 58002.0, "mag": 18.0}, {"mjd": 58000.0, "mag": 19.0}, {"mjd": 58001.0, "mag": 17.0}]
+    assert pick_fits_observation(lc, "peak")["mjd"] == 58001.0
+
+
+async def test_fits_children_for_observation(summary_upstreams):
+    with patch.object(viewer, "correct_date", AsyncMock()):
+        children = await fits_children_for_observation(58000.0, "633207400004730", 796, 12, "zg", "dr24")
+    ra_text, dec_text, cutout_text, js9_link, _, download_link, _, prod_link = _project(children)
+    assert ra_text == "10.0"
+    assert dec_text == "20.0"
+    assert "size=449pix" in cutout_text
+    assert js9_link == {"text": "Open in JS9", "href": js9_link["href"]}
+    assert "ra=10.0" in js9_link["href"] and "dec=20.0" in js9_link["href"]
+    assert download_link["text"] == "Download FITS"
+    assert "_000796_zg_c" in download_link["href"]
+    assert prod_link["text"] == "Product directory"

--- a/ztf_viewer/pages/viewer.py
+++ b/ztf_viewer/pages/viewer.py
@@ -123,7 +123,43 @@ def parse_search(search_query: str) -> dict[str, Any]:
     result = {}
     result["min_mjd"] = float(parsed.get("min_mjd", [-INF])[-1])
     result["max_mjd"] = float(parsed.get("max_mjd", [INF])[-1])
+    result["fits"] = parsed.get("fits", [None])[-1]
     return result
+
+
+def pick_fits_observation(own_lc: list[dict], fits_param: str) -> dict | None:
+    """Pick an observation to show as a FITS image for the `fits` query parameter"""
+    if not own_lc:
+        return None
+    if fits_param == "first":
+        return min(own_lc, key=lambda obs: obs["mjd"])
+    if fits_param == "last":
+        return max(own_lc, key=lambda obs: obs["mjd"])
+    if fits_param == "peak":
+        return min(own_lc, key=lambda obs: obs["mag"])
+    return None
+
+
+async def fits_children_for_observation(mjd, oid, fieldid, rcid, fltr, dr):
+    ra, dec = await find_ztf_oid.get_coord(oid, dr)
+    coord = await find_ztf_oid.get_sky_coord(oid, dr)
+    date = DateWithFrac.from_hmjd(mjd, coord=coord)
+    await correct_date(date)
+    fits_url = urljoin(ZTF_FITS_PROXY_URL, date.sciimg_path(fieldid=fieldid, rcid=rcid, filter=fltr))
+    cutout_query = urlencode({"size": "449pix", "gzip": "false", "center": f"{ra},{dec}"})
+    fits_cutout_url = f"{fits_url}?{cutout_query}"
+    js9_url = f'{JS9_URL}?{urlencode({"url": fits_url,"zoom": 10,"ra": ra,"dec": dec,"scale": "histeq","flip": "y"})}'
+    prod_dir_url = urljoin(ZTF_FITS_PROXY_URL, date.products_path)
+    return [
+        html.Div(ra, id="fits-to-show-ra", style={"display": "none"}),
+        html.Div(dec, id="fits-to-show-dec", style={"display": "none"}),
+        html.Div(fits_cutout_url, id="fits-to-show-cutout-url", style={"display": "none"}),
+        html.A("Open in JS9", href=js9_url, id="fits-to-show-js9-url"),
+        " ",
+        html.A("Download FITS", href=fits_url, id="fits-to-download-url"),
+        " ",
+        html.A("Product directory", href=prod_dir_url, id="fits-to-show-dir-url"),
+    ]
 
 
 async def set_div_for_aladin(oid, version):
@@ -163,6 +199,15 @@ async def get_layout(pathname, search):
     search_query_parsed = parse_search(search)
     min_mjd = search_query_parsed.get("min_mjd", min_mjd)
     max_mjd = search_query_parsed.get("max_mjd", max_mjd)
+    fits_param = search_query_parsed.get("fits")
+
+    fits_to_show_children = []
+    if fits_param is not None:
+        own_lc = (await get_plot_data(oid, dr, min_mjd=min_mjd, max_mjd=max_mjd)).get(oid, [])
+        if obs := pick_fits_observation(own_lc, fits_param):
+            fits_to_show_children = await fits_children_for_observation(
+                obs["mjd"], obs["oid"], obs["fieldid"], obs["rcid"], obs["filter"], dr
+            )
 
     try:
         features = await light_curve_features(oid, dr, version="latest", min_mjd=min_mjd, max_mjd=max_mjd)
@@ -381,7 +426,7 @@ async def get_layout(pathname, search):
                         [
                             html.Div(className="JS9", id="JS9"),
                             dji.Import(src="/static/js/js9_helper.js"),
-                            html.Div(id="fits-to-show"),
+                            html.Div(fits_to_show_children, id="fits-to-show"),
                             html.Div(id="skybot"),
                         ],
                         style={"min-width": "450px", "width": "20%", "vertical-align": "top", "flex-shrink": 0},
@@ -2040,25 +2085,7 @@ async def load_fits_for_graph_clicked(data, dr):
         raise PreventUpdate
     point = points[0]
     mjd, oid, fieldid, rcid, fltr, *_ = point["customdata"]
-    ra, dec = await find_ztf_oid.get_coord(oid, dr)
-    coord = await find_ztf_oid.get_sky_coord(oid, dr)
-    date = DateWithFrac.from_hmjd(mjd, coord=coord)
-    await correct_date(date)
-    fits_url = urljoin(ZTF_FITS_PROXY_URL, date.sciimg_path(fieldid=fieldid, rcid=rcid, filter=fltr))
-    cutout_query = urlencode({"size": "449pix", "gzip": "false", "center": f"{ra},{dec}"})
-    fits_cutout_url = f"{fits_url}?{cutout_query}"
-    js9_url = f'{JS9_URL}?{urlencode({"url": fits_url,"zoom": 10,"ra": ra,"dec": dec,"scale": "histeq","flip": "y"})}'
-    prod_dir_url = urljoin(ZTF_FITS_PROXY_URL, date.products_path)
-    return [
-        html.Div(ra, id="fits-to-show-ra", style={"display": "none"}),
-        html.Div(dec, id="fits-to-show-dec", style={"display": "none"}),
-        html.Div(fits_cutout_url, id="fits-to-show-cutout-url", style={"display": "none"}),
-        html.A("Open in JS9", href=js9_url, id="fits-to-show-js9-url"),
-        " ",
-        html.A("Download FITS", href=fits_url, id="fits-to-download-url"),
-        " ",
-        html.A("Product directory", href=prod_dir_url, id="fits-to-show-dir-url"),
-    ]
+    return await fits_children_for_observation(mjd, oid, fieldid, rcid, fltr, dr)
 
 
 @app.callback(


### PR DESCRIPTION
## Summary
- Adds a `fits` query parameter (`first`, `last`, or `peak`) to the object viewer URL, e.g. `?fits=peak`, that loads the corresponding FITS cutout image automatically on page load instead of requiring a click on a light-curve point.
- Extracts the FITS-image-building logic already used by the click-on-graph callback (`load_fits_for_graph_clicked`) into a shared `fits_children_for_observation` helper, reused by `get_layout` to pre-populate the `fits-to-show` div. The existing clientside `JS9.Load` callback then fires on initial page load since Dash callbacks run once against the layout's initial values.
- `peak` picks the observation with the brightest (lowest) magnitude; `first`/`last` pick by minimum/maximum MJD, all within any `min_mjd`/`max_mjd` window already in effect.

## Test plan
- [x] `pytest tests/pages/test_viewer.py tests/lc_data -q` — full suite passes, including new unit tests for `parse_search`, `pick_fits_observation`, and `fits_children_for_observation`.
- [x] `pytest -q` (full repo suite) passes.
- [ ] Manual check in a running instance: load `/dr24/view/<oid>?fits=peak` and confirm the FITS panel populates without clicking a light-curve point.

Closes #400.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GZUCXbDRiV1mdf7HsYDtXW