### PR TITLE
Fix x-axis offset text colliding with MJD label in downloadable plots

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,10 @@ Version schema is `year.month.num_release`
 
 - Switched the web server backend from Flask to FastAPI/Starlette, served by uvicorn, with Dash callbacks running as native coroutines
 
+### Fixed
+
+- X-axis offset text no longer collides with the "MJD" label on downloadable plots with a small time range https://github.com/snad-space/ztf-viewer/issues/173
+
 ## [2026.8.0] 2026 August 14
 
 ### Added

--- a/ztf_viewer/figure_render.py
+++ b/ztf_viewer/figure_render.py
@@ -171,9 +171,6 @@ def plot_data(oid, data, fmt="png", caption=True, title=None):
     ax.set_title(title, usetex=usetex)
     ax.set_xlabel("MJD", usetex=usetex)
     ax.set_ylabel("magnitude", usetex=usetex)
-    # Without this, matplotlib's default offset notation (e.g. "+5.867e4") collides with the
-    # "MJD" label when the plotted time range is small. See
-    # https://github.com/snad-space/ztf-viewer/issues/173
     ax.ticklabel_format(axis="x", style="plain", useOffset=False)
     ax.xaxis.set_minor_locator(AutoMinorLocator(2))
     ax.yaxis.set_minor_locator(AutoMinorLocator(2))

--- a/ztf_viewer/figure_render.py
+++ b/ztf_viewer/figure_render.py
@@ -171,6 +171,10 @@ def plot_data(oid, data, fmt="png", caption=True, title=None):
     ax.set_title(title, usetex=usetex)
     ax.set_xlabel("MJD", usetex=usetex)
     ax.set_ylabel("magnitude", usetex=usetex)
+    # Without this, matplotlib's default offset notation (e.g. "+5.867e4") collides with the
+    # "MJD" label when the plotted time range is small. See
+    # https://github.com/snad-space/ztf-viewer/issues/173
+    ax.ticklabel_format(axis="x", style="plain", useOffset=False)
     ax.xaxis.set_minor_locator(AutoMinorLocator(2))
     ax.yaxis.set_minor_locator(AutoMinorLocator(2))
     ax.tick_params(which="major", direction="in", length=6, width=1.5)


### PR DESCRIPTION
## Summary
- Matplotlib's default offset notation (e.g. `+5.867e4`) overlaps the "MJD" x-axis label on downloadable light-curve plots when the plotted time range is small, as shown in #173.
- Disabled the offset via `ax.ticklabel_format(axis="x", style="plain", useOffset=False)` so full-precision MJD values are shown on the ticks instead.

Fixes #173

## Test plan
- [x] `ruff check` / `ruff format --check` on the changed file
- [x] `pytest tests/pages/test_figure.py` passes
- [x] Manually rendered plots at both a narrow (~0.09 day) and wide (~778 day) MJD range with matplotlib to confirm no regression at either extreme

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01T6zPEeWasbWMPMwvqNREwZ