### PR TITLE
Fix ?fits= query parameter not loading a FITS image on page load

### DIFF
--- a/tests/pages/test_viewer.py
+++ b/tests/pages/test_viewer.py
@@ -736,11 +736,33 @@ async def test_fits_children_for_observation(summary_upstreams):
 # implementation of `?fits=` produced. So the `?fits=` load is instead wired as a second trigger
 # of the very callback the click uses, keyed off `oid` mounting -- a plain prop update on an
 # already-present component, just like the click case.
+#
+# On that very first firing, nothing has "changed" from Dash's point of view (there is no prior
+# value to diff against), so `ctx.triggered_id` is None rather than "oid" -- not "graph" either,
+# so the fits-param branch must be the default, not something keyed on seeing "oid" specifically.
 load_fits_for_graph_clicked = inspect.unwrap(viewer.load_fits_for_graph_clicked)
 
 
-def _set_triggered(prop_id):
-    return context_value.set(types.SimpleNamespace(triggered_inputs=[{"prop_id": prop_id}]))
+def _set_triggered(*prop_ids):
+    return context_value.set(types.SimpleNamespace(triggered_inputs=[{"prop_id": p} for p in prop_ids]))
+
+
+async def test_load_fits_for_graph_clicked_initial_mount_honours_fits_param(monkeypatch, summary_upstreams):
+    """Reproduces the real page-load call: nothing "changed" yet, so `ctx.triggered_id` is None."""
+
+    async def fake_get_plot_data(oid, dr, min_mjd=None, max_mjd=None):
+        return {oid: [{"mjd": 58000.0, "mag": 18.0, "oid": oid, "fieldid": 796, "rcid": 12, "filter": "zg"}]}
+
+    monkeypatch.setattr(viewer, "get_plot_data", fake_get_plot_data)
+
+    token = _set_triggered()
+    try:
+        with patch.object(viewer, "correct_date", AsyncMock()):
+            children = await load_fits_for_graph_clicked(None, "633207400004730", "dr24", "?fits=last")
+    finally:
+        context_value.reset(token)
+    *_, download_link, _, _ = _project(children)
+    assert download_link["text"] == "Download FITS"
 
 
 async def test_load_fits_for_graph_clicked_oid_trigger_honours_fits_param(monkeypatch, summary_upstreams):

--- a/tests/pages/test_viewer.py
+++ b/tests/pages/test_viewer.py
@@ -728,3 +728,53 @@ async def test_fits_children_for_observation(summary_upstreams):
     assert download_link["text"] == "Download FITS"
     assert "_000796_zg_c" in download_link["href"]
     assert prod_link["text"] == "Product directory"
+
+
+# The Dash clientside callback that hands the FITS cutout to JS9 only reacts to a `children`
+# update on an *already-mounted* "fits-to-show" div (as a graph click produces) -- not to that
+# div appearing for the first time with pre-populated content, which is what a naive `get_layout`
+# implementation of `?fits=` produced. So the `?fits=` load is instead wired as a second trigger
+# of the very callback the click uses, keyed off `oid` mounting -- a plain prop update on an
+# already-present component, just like the click case.
+load_fits_for_graph_clicked = inspect.unwrap(viewer.load_fits_for_graph_clicked)
+
+
+def _set_triggered(prop_id):
+    return context_value.set(types.SimpleNamespace(triggered_inputs=[{"prop_id": prop_id}]))
+
+
+async def test_load_fits_for_graph_clicked_oid_trigger_honours_fits_param(monkeypatch, summary_upstreams):
+    async def fake_get_plot_data(oid, dr, min_mjd=None, max_mjd=None):
+        return {oid: [{"mjd": 58000.0, "mag": 18.0, "oid": oid, "fieldid": 796, "rcid": 12, "filter": "zg"}]}
+
+    monkeypatch.setattr(viewer, "get_plot_data", fake_get_plot_data)
+
+    token = _set_triggered("oid.children")
+    try:
+        with patch.object(viewer, "correct_date", AsyncMock()):
+            children = await load_fits_for_graph_clicked(None, "633207400004730", "dr24", "?fits=last")
+    finally:
+        context_value.reset(token)
+    *_, download_link, _, _ = _project(children)
+    assert download_link["text"] == "Download FITS"
+
+
+async def test_load_fits_for_graph_clicked_oid_trigger_without_fits_param_prevents_update(summary_upstreams):
+    token = _set_triggered("oid.children")
+    try:
+        with pytest.raises(PreventUpdate):
+            await load_fits_for_graph_clicked(None, "633207400004730", "dr24", "")
+    finally:
+        context_value.reset(token)
+
+
+async def test_load_fits_for_graph_clicked_click_trigger_still_works(summary_upstreams):
+    data = {"points": [{"customdata": [58000.0, "633207400004730", 796, 12, "zg"]}]}
+    token = _set_triggered("graph.clickData")
+    try:
+        with patch.object(viewer, "correct_date", AsyncMock()):
+            children = await load_fits_for_graph_clicked(data, "633207400004730", "dr24", "")
+    finally:
+        context_value.reset(token)
+    *_, download_link, _, _ = _project(children)
+    assert download_link["text"] == "Download FITS"

--- a/ztf_viewer/pages/viewer.py
+++ b/ztf_viewer/pages/viewer.py
@@ -2074,9 +2074,11 @@ app.clientside_callback(
     [State("dr", "children"), State("url", "search")],
 )
 async def load_fits_for_graph_clicked(data, oid, dr, search):
-    # `oid` triggers once, right after the object page mounts, so the `?fits=` query
+    # On the very first firing of this callback -- right after the object page mounts -- Dash
+    # hasn't "changed" any Input yet, so `ctx.triggered_id` is None rather than "oid". Treat
+    # anything other than an actual graph click as that initial mount, so the `?fits=` query
     # parameter can be honoured without waiting for a click on the light curve.
-    if ctx.triggered_id == "oid":
+    if ctx.triggered_id != "graph":
         search_query_parsed = parse_search(search)
         fits_param = search_query_parsed["fits"]
         if fits_param is None:

--- a/ztf_viewer/pages/viewer.py
+++ b/ztf_viewer/pages/viewer.py
@@ -199,15 +199,6 @@ async def get_layout(pathname, search):
     search_query_parsed = parse_search(search)
     min_mjd = search_query_parsed.get("min_mjd", min_mjd)
     max_mjd = search_query_parsed.get("max_mjd", max_mjd)
-    fits_param = search_query_parsed.get("fits")
-
-    fits_to_show_children = []
-    if fits_param is not None:
-        own_lc = (await get_plot_data(oid, dr, min_mjd=min_mjd, max_mjd=max_mjd)).get(oid, [])
-        if obs := pick_fits_observation(own_lc, fits_param):
-            fits_to_show_children = await fits_children_for_observation(
-                obs["mjd"], obs["oid"], obs["fieldid"], obs["rcid"], obs["filter"], dr
-            )
 
     try:
         features = await light_curve_features(oid, dr, version="latest", min_mjd=min_mjd, max_mjd=max_mjd)
@@ -426,7 +417,7 @@ async def get_layout(pathname, search):
                         [
                             html.Div(className="JS9", id="JS9"),
                             dji.Import(src="/static/js/js9_helper.js"),
-                            html.Div(fits_to_show_children, id="fits-to-show"),
+                            html.Div(id="fits-to-show"),
                             html.Div(id="skybot"),
                         ],
                         style={"min-width": "450px", "width": "20%", "vertical-align": "top", "flex-shrink": 0},
@@ -2077,8 +2068,27 @@ app.clientside_callback(
 )
 
 
-@app.callback(Output("fits-to-show", "children"), [Input("graph", "clickData")], [State("dr", "children")])
-async def load_fits_for_graph_clicked(data, dr):
+@app.callback(
+    Output("fits-to-show", "children"),
+    [Input("graph", "clickData"), Input("oid", "children")],
+    [State("dr", "children"), State("url", "search")],
+)
+async def load_fits_for_graph_clicked(data, oid, dr, search):
+    # `oid` triggers once, right after the object page mounts, so the `?fits=` query
+    # parameter can be honoured without waiting for a click on the light curve.
+    if ctx.triggered_id == "oid":
+        search_query_parsed = parse_search(search)
+        fits_param = search_query_parsed["fits"]
+        if fits_param is None:
+            raise PreventUpdate
+        own_lc = (
+            await get_plot_data(oid, dr, min_mjd=search_query_parsed["min_mjd"], max_mjd=search_query_parsed["max_mjd"])
+        ).get(oid, [])
+        if (obs := pick_fits_observation(own_lc, fits_param)) is None:
+            raise PreventUpdate
+        return await fits_children_for_observation(
+            obs["mjd"], obs["oid"], obs["fieldid"], obs["rcid"], obs["filter"], dr
+        )
     if data is None:
         raise PreventUpdate
     if not (points := data.get("points")):


### PR DESCRIPTION
## Summary

`?fits=first|last|peak` (added in #727) doesn't do anything in production — reported live at https://master.ztf.snad.space/dr24/view/633207400004730?fits=last.

Root cause, confirmed with a real browser against the live `master` deployment: the JS9-loading `clientside_callback` (`Input("fits-to-show", "children")`) only fires when an *already-mounted* `fits-to-show` div gets a `children` update — which is exactly what happens on a graph click. `get_layout` instead created the `fits-to-show` div for the very first time already populated, as part of a bulk `page-content` subtree replacement, and that never triggers the dependent clientside callback (no console output at all from it, confirmed via Playwright against the live site).

## Fix

Move the `?fits=` handling into the existing graph-click server callback (`load_fits_for_graph_clicked`), adding `Input("oid", "children")` as a second trigger and branching on `ctx.triggered_id`. `oid` mounting is a plain prop update on an already-present component, the same shape as the click case that was already working, so the downstream clientside callback fires correctly. Verified this pattern already works for other data (e.g. `different_field_neighbours`, which similarly reacts to a value that appears fresh at page-mount time).

`get_layout` goes back to rendering an always-empty `fits-to-show` div; `pick_fits_observation`/`fits_children_for_observation` are unchanged.

## Test plan

- [x] `pytest tests/pages/test_viewer.py` — added cases covering the `oid`-triggered branch (with and without a `fits` param) and confirming the click-triggered branch still works
- [x] `ruff check` / `ruff format --diff`
- [ ] Manual check against a deployed preview with `?fits=last` once merged (JS9 isn't buildable in this sandbox — no network access to fetch it during `docker build`)