### PR TITLE
Give each page its own browser title

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ Version schema is `year.month.num_release`
 
 ## [Unreleased]
 
+### Added
+
+- Per-page browser titles, so that tabs for different objects, searches and pages are distinguishable https://github.com/snad-space/ztf-viewer/issues/99
+
 ## [2026.8.1] 2026 August 28
 
 ### Added

--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -1,0 +1,45 @@
+"""`ztf_viewer.routes` gives every page its own browser title, for the same URLs the router
+dispatches on."""
+
+import pytest
+
+from ztf_viewer.routes import BASE_TITLE, page_title
+from ztf_viewer.util import DEFAULT_DR
+
+_DEFAULT_DR_TITLE = f"SNAD ZTF {DEFAULT_DR.upper()} viewer"
+
+
+@pytest.mark.parametrize(
+    "pathname,expected",
+    [
+        ("/", _DEFAULT_DR_TITLE),
+        ("/dr17/", "SNAD ZTF DR17 viewer"),
+        ("/view/633207400004730", f"633207400004730 — {_DEFAULT_DR_TITLE}"),
+        ("/dr17/view/633207400004730", "633207400004730 — SNAD ZTF DR17 viewer"),
+        ("/search/M31/10", f"M31 search — {_DEFAULT_DR_TITLE}"),
+        ("/dr17/search/M31/10", "M31 search — SNAD ZTF DR17 viewer"),
+        ("/login", f"Login — {BASE_TITLE}"),
+        ("/anomalies", f"Anomalies — {BASE_TITLE}"),
+        ("/akb", f"Anomalies — {BASE_TITLE}"),
+        ("/tags", f"Tags — {BASE_TITLE}"),
+        ("/dr7/view/633207400004730", f"DR7 is not supported — {BASE_TITLE}"),
+        ("/no-such-page", f"404 — {BASE_TITLE}"),
+    ],
+)
+def test_page_title(pathname, expected):
+    assert page_title(pathname) == expected
+
+
+def test_search_title_is_url_decoded():
+    assert page_title("/search/00h00m00s%20%2B00d00m00s/1").startswith("00h00m00s +00d00m00s search")
+
+
+def test_page_title_of_a_missing_pathname():
+    """`dcc.Location.pathname` is None until the browser reports it."""
+    assert page_title(None) == BASE_TITLE
+
+
+def test_every_page_has_a_distinct_title():
+    pathnames = ["/", "/view/1", "/search/M31/10", "/login", "/anomalies", "/tags", "/no-such-page"]
+    titles = [page_title(pathname) for pathname in pathnames]
+    assert len(set(titles)) == len(titles)

--- a/tests/test_sync_callbacks.py
+++ b/tests/test_sync_callbacks.py
@@ -34,6 +34,7 @@ _ALLOWED_SYNC_CALLBACKS = {
     "convert_astro_colibri_search_radius_to_arcsec",
     "dr_from_url",
     "set_dr_title",
+    "set_page_title",
 }
 
 

--- a/ztf_viewer/__main__.py
+++ b/ztf_viewer/__main__.py
@@ -4,7 +4,6 @@ import argparse
 import asyncio
 import logging
 import pathlib
-import re
 import urllib.parse
 from concurrent.futures import ThreadPoolExecutor
 
@@ -15,6 +14,7 @@ from astropy.coordinates.name_resolve import NameResolveError
 from dash import Input, Output, State, dcc, html, no_update
 from dash.exceptions import PreventUpdate
 
+from ztf_viewer import routes
 from ztf_viewer.akb import akb
 from ztf_viewer.app import app
 from ztf_viewer.catalogs.conesearch import ANTARES_QUERY, TNS_QUERY
@@ -66,6 +66,7 @@ app.title = "SNAD ZTF viewer"
 app.layout = html.Div(
     [
         dcc.Location(id="url", refresh=True),
+        dcc.Store(id="page-title"),
         html.Div(
             [
                 html.H1(
@@ -206,6 +207,29 @@ app.clientside_callback(
     """,
     Output("webgl-is-available", "children"),
     [Input("main-layout", "children")],
+)
+
+
+@app.callback(
+    Output("page-title", "data"),
+    [Input("url", "pathname")],
+)
+def set_page_title(pathname):
+    return routes.page_title(pathname)
+
+
+# Dash renders the index with `app.title` only; the document title has to be set from the browser.
+app.clientside_callback(
+    """
+    function(title) {
+        if (typeof title === "string" && title.length > 0) {
+            document.title = title;
+        }
+        return window.dash_clientside.no_update;
+    }
+    """,
+    [],
+    [Input("page-title", "data")],
 )
 
 
@@ -358,7 +382,7 @@ async def app_select_by_url(pathname, search):
     if not isinstance(pathname, str):
         raise PreventUpdate
     # DR7 is not supported anymore:
-    if m := re.search(r"^/dr7((?:/.*)?)$", pathname):
+    if m := routes.DR7.search(pathname):
         href = m.group(1) or "/"
         return [
             [
@@ -372,8 +396,8 @@ async def app_select_by_url(pathname, search):
             no_update,
             no_update,
         ]
-    if m := re.search(r"^/+(?:(dr\d{1,2})/+)?$", pathname):
-        dr = m.group(1) or DEFAULT_DR
+    if m := routes.HOME.search(pathname):
+        dr = m["dr"] or DEFAULT_DR
         other_drs = [other_dr for other_dr in available_drs if other_dr != dr]
         return [
             [
@@ -520,29 +544,19 @@ archivePrefix = {arXiv},
             no_update,
             no_update,
         ]
-    if match := re.search(r"^/+view/+(\d+)", pathname):
+    if match := routes.VIEWER_DEFAULT_DR.search(pathname):
         return [
-            await get_viewer_layout(f"/{DEFAULT_DR}/view/{match.group(1)}", search),
+            await get_viewer_layout(f"/{DEFAULT_DR}/view/{match['oid']}", search),
             no_update,
             no_update,
         ]
-    if re.search(r"^/+dr\d{1,2}/+view/+(\d+)", pathname):
+    if routes.VIEWER.search(pathname):
         return [
             await get_viewer_layout(pathname, search),
             no_update,
             no_update,
         ]
-    if search_match := re.search(
-        r"""^
-                                     (?:/+(?P<dr>dr\d{1,2}))?
-                                     /+search
-                                     /+(?P<coord_or_name>[^/]+)
-                                     /+(?P<radius_arcsec>[^/]+)
-                                     /*
-                                     $""",
-        pathname,
-        flags=re.VERBOSE,
-    ):
+    if search_match := routes.SEARCH.search(pathname):
         coord_or_name = urllib.parse.unquote(search_match["coord_or_name"])
         try:
             coordinates = await sky_coord_from_str(coord_or_name)
@@ -571,25 +585,25 @@ archivePrefix = {arXiv},
                 coord_or_name,
                 search_match["radius_arcsec"],
             ]
-        dr = search_match.group("dr") or DEFAULT_DR
+        dr = search_match["dr"] or DEFAULT_DR
         return [
             await get_search_layout(coordinates, radius_arcsec, dr),
             coord_or_name,
             radius_arcsec,
         ]
-    if re.search(r"^/+login/*$", pathname):
+    if routes.LOGIN.search(pathname):
         return [
             get_login_layout(pathname, search),
             no_update,
             no_update,
         ]
-    if re.search("^/+(?:(?:anomalies)|(?:akb))/*$", pathname):
+    if routes.ANOMALIES.search(pathname):
         return [
             get_anomalies_layout(pathname, search),
             no_update,
             no_update,
         ]
-    if re.search("^/+tags/*$", pathname):
+    if routes.TAGS.search(pathname):
         return [
             get_tags_layout(pathname, search),
             no_update,

--- a/ztf_viewer/routes.py
+++ b/ztf_viewer/routes.py
@@ -1,0 +1,63 @@
+"""URL patterns of the single-page router, and the browser title of every page.
+
+The patterns live here rather than inline in `ztf_viewer.__main__` so that the page router and
+`page_title` cannot drift apart: both match the same pathname against the same regular
+expressions.
+"""
+
+import re
+import urllib.parse
+
+from ztf_viewer.util import DEFAULT_DR
+
+DR7 = re.compile(r"^/dr7((?:/.*)?)$")
+HOME = re.compile(r"^/+(?:(?P<dr>dr\d{1,2})/+)?$")
+VIEWER_DEFAULT_DR = re.compile(r"^/+view/+(?P<oid>\d+)")
+VIEWER = re.compile(r"^/+(?P<dr>dr\d{1,2})/+view/+(?P<oid>\d+)")
+SEARCH = re.compile(
+    r"""^
+        (?:/+(?P<dr>dr\d{1,2}))?
+        /+search
+        /+(?P<coord_or_name>[^/]+)
+        /+(?P<radius_arcsec>[^/]+)
+        /*
+        $""",
+    flags=re.VERBOSE,
+)
+LOGIN = re.compile(r"^/+login/*$")
+ANOMALIES = re.compile(r"^/+(?:(?:anomalies)|(?:akb))/*$")
+TAGS = re.compile(r"^/+tags/*$")
+
+
+BASE_TITLE = "SNAD ZTF viewer"
+
+
+def _dr_title(dr: str | None) -> str:
+    return f"SNAD ZTF {(dr or DEFAULT_DR).upper()} viewer"
+
+
+def page_title(pathname: str | None) -> str:
+    """Browser title for a pathname, the distinguishing part first.
+
+    Tab labels are truncated, so the object or search being looked at goes before the site name.
+    """
+    if not isinstance(pathname, str):
+        return BASE_TITLE
+    if DR7.search(pathname):
+        return f"DR7 is not supported — {BASE_TITLE}"
+    if match := HOME.search(pathname):
+        return _dr_title(match["dr"])
+    if match := VIEWER_DEFAULT_DR.search(pathname):
+        return f"{match['oid']} — {_dr_title(None)}"
+    if match := VIEWER.search(pathname):
+        return f"{match['oid']} — {_dr_title(match['dr'])}"
+    if match := SEARCH.search(pathname):
+        coord_or_name = urllib.parse.unquote(match["coord_or_name"])
+        return f"{coord_or_name} search — {_dr_title(match['dr'])}"
+    if LOGIN.search(pathname):
+        return f"Login — {BASE_TITLE}"
+    if ANOMALIES.search(pathname):
+        return f"Anomalies — {BASE_TITLE}"
+    if TAGS.search(pathname):
+        return f"Tags — {BASE_TITLE}"
+    return f"404 — {BASE_TITLE}"


### PR DESCRIPTION
Closes #99.

## What

Every page rendered with the same document title, `SNAD ZTF viewer`, so a row of tabs with several objects open was unreadable. Now the title follows the URL, distinguishing part first (tab labels get truncated):

| URL | title |
| --- | --- |
| `/`, `/dr17/` | `SNAD ZTF DR24 viewer`, `SNAD ZTF DR17 viewer` |
| `/dr17/view/633207400004730` | `633207400004730 — SNAD ZTF DR17 viewer` |
| `/dr17/search/M31/10` | `M31 search — SNAD ZTF DR17 viewer` |
| `/login`, `/anomalies`, `/akb`, `/tags` | `Login — …`, `Anomalies — …`, `Tags — …` |
| `/dr7/…` | `DR7 is not supported — SNAD ZTF viewer` |
| anything else | `404 — SNAD ZTF viewer` |

## How

Dash renders the index with `app.title` alone, so the title has to be set from the browser (as the [Dash docs section linked in the issue](https://dash.plotly.com/external-resources) suggests). A `dcc.Store` holds the title computed for the current `url.pathname`, and a small no-output clientside callback writes it to `document.title`.

The mapping itself is Python, in the new `ztf_viewer/routes.py`, which also now owns the router's URL patterns — `app_select_by_url` matches against the same compiled regexes, so the titles cannot drift away from the routes they describe. That module move is the bulk of the diff in `__main__.py`; the only behavior change there is the two new callbacks.

Dash still flips the title to `Updating...` while callbacks are in flight and restores it when the queue drains — unchanged, and the restored value is the new title.

## Testing

- `tests/test_routes.py`: title per route, URL-decoding of the search term, `None` pathname (`dcc.Location.pathname` before the browser reports it), and that no two pages share a title.
- `set_page_title` added to the reviewed-sync-callbacks allowlist in `tests/test_sync_callbacks.py` (pure string formatting, no I/O).
- `pytest -m "not network"`: 473 passed, 2 skipped (JS9 not installed locally).
- Checked in Firefox against a local server on `/`, `/dr17/view/633207400004730`, `/dr17/search/M31/10`, `/tags` and an unknown path — `document.title` settles to the expected value on each.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KmwjZH6fepmXB3EVUSNdhF