### PR TITLE
Give each page its own HTML document title

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ Version schema is `year.month.num_release`
 
 ## [Unreleased]
 
+### Added
+
+- Per-page HTML document titles, so browser tabs, history and bookmarks name the object, search or page they show https://github.com/snad-space/ztf-viewer/issues/99
+
 ## [2026.8.1] 2026 August 28
 
 ### Added

--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -1,0 +1,93 @@
+"""`ztf_viewer/routes.py`: the URL patterns the page router matches on, and the document title
+derived from the same patterns, so a tab or a bookmark says which page it is."""
+
+import pytest
+from dash.development.base_component import Component
+
+from ztf_viewer.routes import SITE_TITLE, page_title
+from ztf_viewer.util import DEFAULT_DR
+
+_DR = DEFAULT_DR.upper()
+_OID = "633207400004730"
+
+
+@pytest.mark.parametrize(
+    ("pathname", "expected"),
+    [
+        ("/", f"SNAD ZTF {_DR} viewer"),
+        ("/dr23/", "SNAD ZTF DR23 viewer"),
+        (f"/view/{_OID}", f"{_OID} — SNAD ZTF {_DR} viewer"),
+        (f"/dr23/view/{_OID}", f"{_OID} — SNAD ZTF DR23 viewer"),
+        ("/dr23/search/M57/1.5", "Search M57 r=1.5″ — SNAD ZTF DR23 viewer"),
+        ("/login", f"Login — {SITE_TITLE}"),
+        ("/anomalies", f"Anomalies — {SITE_TITLE}"),
+        ("/akb", f"Anomalies — {SITE_TITLE}"),
+        ("/tags", f"Tags — {SITE_TITLE}"),
+        ("/dr7/view/1", f"DR7 is not supported — {SITE_TITLE}"),
+        ("/no/such/page", f"404 — {SITE_TITLE}"),
+    ],
+)
+def test_page_title(pathname, expected):
+    assert page_title(pathname) == expected
+
+
+def test_search_title_shows_the_decoded_query():
+    """The pathname carries the query percent-encoded, the title must not."""
+    title = page_title("/search/00h00m00s%20%2B00d00m00s/2")
+
+    assert "00h00m00s +00d00m00s" in title
+    assert "%" not in title
+
+
+def test_page_title_of_a_pathname_dash_has_not_set_yet():
+    """`url.pathname` is `None` until the first navigation; the router skips those, and the
+    title falls back rather than raising."""
+    assert page_title(None) == SITE_TITLE
+
+
+def test_pages_have_distinct_titles():
+    pathnames = ["/", f"/view/{_OID}", "/dr23/search/M57/1.5", "/login", "/anomalies", "/tags", "/no/such/page"]
+
+    titles = [page_title(pathname) for pathname in pathnames]
+
+    assert len(set(titles)) == len(titles)
+
+
+def _load_app():
+    """Import the fully wired app, forcing the in-memory cache backends first.
+
+    Same dance as `tests/test_golden_http.py`: `ztf_viewer.catalogs.unavailable_catalogs`
+    connects to Redis eagerly at import time.
+    """
+    from ztf_viewer import config
+
+    config.CACHE_TYPE = "memory"
+    config.UNAVAILABLE_CATALOGS_CACHE_TYPE = "memory"
+
+    import ztf_viewer.__main__ as main_module
+
+    return main_module.app
+
+
+def _component_ids(component):
+    children = getattr(component, "children", None)
+    if isinstance(children, Component):
+        children = [children]
+    for child in children or ():
+        if not isinstance(child, Component):
+            continue
+        if (id_ := getattr(child, "id", None)) is not None:
+            yield id_
+        yield from _component_ids(child)
+
+
+def test_title_callback_is_wired_to_the_layout():
+    """The store the server callback writes, and the sink the clientside one writes, must carry
+    the ids that are really in the layout -- nothing else validates that, the app is built with
+    `suppress_callback_exceptions`."""
+    app = _load_app()
+
+    # Clientside entries are the ones with no "callback" key.
+    assert "callback" in app.callback_map["page-title.data"]
+    assert "callback" not in app.callback_map["page-title-sink.children"]
+    assert {"page-title", "page-title-sink"} <= set(_component_ids(app.layout))

--- a/tests/test_sync_callbacks.py
+++ b/tests/test_sync_callbacks.py
@@ -34,6 +34,7 @@ _ALLOWED_SYNC_CALLBACKS = {
     "convert_astro_colibri_search_radius_to_arcsec",
     "dr_from_url",
     "set_dr_title",
+    "set_page_title",
 }
 
 

--- a/ztf_viewer/__main__.py
+++ b/ztf_viewer/__main__.py
@@ -4,7 +4,6 @@ import argparse
 import asyncio
 import logging
 import pathlib
-import re
 import urllib.parse
 from concurrent.futures import ThreadPoolExecutor
 
@@ -31,6 +30,7 @@ from ztf_viewer.pages.search import get_layout as get_search_layout
 from ztf_viewer.pages.tags import get_layout as get_tags_layout
 from ztf_viewer.pages.viewer import get_layout as get_viewer_layout
 from ztf_viewer.procpool import shutdown_pool
+from ztf_viewer.routes import ANOMALIES, DR7, HOME, LOGIN, SEARCH, SITE_TITLE, TAGS, VIEW, VIEW_DEFAULT_DR, page_title
 from ztf_viewer.util import DEFAULT_DR, YEAR, available_drs, list_join
 from ztf_viewer.version import version_string, version_url
 
@@ -60,12 +60,15 @@ app.server.router.add_event_handler("shutdown", aclose_client)
 app.server.router.add_event_handler("shutdown", shutdown_pool)
 
 
-app.title = "SNAD ZTF viewer"
+app.title = SITE_TITLE
 
 
 app.layout = html.Div(
     [
         dcc.Location(id="url", refresh=True),
+        dcc.Store(id="page-title"),
+        # Written by the clientside callback below, which really outputs to `document.title`.
+        html.Div(id="page-title-sink", style={"display": "none"}),
         html.Div(
             [
                 html.H1(
@@ -244,6 +247,28 @@ def set_dr_title(dr):
 
 
 @app.callback(
+    Output("page-title", "data"),
+    [Input("url", "pathname")],
+)
+def set_page_title(pathname):
+    return page_title(pathname)
+
+
+# `app.title` only covers the index Dash serves; the title has to be rewritten on every
+# clientside navigation as well.
+app.clientside_callback(
+    """
+    function(title) {
+        document.title = title;
+        return window.dash_clientside.no_update;
+    }
+    """,
+    Output("page-title-sink", "children"),
+    [Input("page-title", "data")],
+)
+
+
+@app.callback(
     Output("username", "children"),
     [Input("url", "pathname")],
 )
@@ -358,7 +383,7 @@ async def app_select_by_url(pathname, search):
     if not isinstance(pathname, str):
         raise PreventUpdate
     # DR7 is not supported anymore:
-    if m := re.search(r"^/dr7((?:/.*)?)$", pathname):
+    if m := DR7.search(pathname):
         href = m.group(1) or "/"
         return [
             [
@@ -372,7 +397,7 @@ async def app_select_by_url(pathname, search):
             no_update,
             no_update,
         ]
-    if m := re.search(r"^/+(?:(dr\d{1,2})/+)?$", pathname):
+    if m := HOME.search(pathname):
         dr = m.group(1) or DEFAULT_DR
         other_drs = [other_dr for other_dr in available_drs if other_dr != dr]
         return [
@@ -520,29 +545,19 @@ archivePrefix = {arXiv},
             no_update,
             no_update,
         ]
-    if match := re.search(r"^/+view/+(\d+)", pathname):
+    if match := VIEW_DEFAULT_DR.search(pathname):
         return [
-            await get_viewer_layout(f"/{DEFAULT_DR}/view/{match.group(1)}", search),
+            await get_viewer_layout(f"/{DEFAULT_DR}/view/{match['oid']}", search),
             no_update,
             no_update,
         ]
-    if re.search(r"^/+dr\d{1,2}/+view/+(\d+)", pathname):
+    if VIEW.search(pathname):
         return [
             await get_viewer_layout(pathname, search),
             no_update,
             no_update,
         ]
-    if search_match := re.search(
-        r"""^
-                                     (?:/+(?P<dr>dr\d{1,2}))?
-                                     /+search
-                                     /+(?P<coord_or_name>[^/]+)
-                                     /+(?P<radius_arcsec>[^/]+)
-                                     /*
-                                     $""",
-        pathname,
-        flags=re.VERBOSE,
-    ):
+    if search_match := SEARCH.search(pathname):
         coord_or_name = urllib.parse.unquote(search_match["coord_or_name"])
         try:
             coordinates = await sky_coord_from_str(coord_or_name)
@@ -577,19 +592,19 @@ archivePrefix = {arXiv},
             coord_or_name,
             radius_arcsec,
         ]
-    if re.search(r"^/+login/*$", pathname):
+    if LOGIN.search(pathname):
         return [
             get_login_layout(pathname, search),
             no_update,
             no_update,
         ]
-    if re.search("^/+(?:(?:anomalies)|(?:akb))/*$", pathname):
+    if ANOMALIES.search(pathname):
         return [
             get_anomalies_layout(pathname, search),
             no_update,
             no_update,
         ]
-    if re.search("^/+tags/*$", pathname):
+    if TAGS.search(pathname):
         return [
             get_tags_layout(pathname, search),
             no_update,

--- a/ztf_viewer/routes.py
+++ b/ztf_viewer/routes.py
@@ -1,0 +1,64 @@
+"""URL patterns of the Dash pages, and the document title that goes with each.
+
+The page router in `ztf_viewer/__main__.py` and `page_title` must agree on which page a
+pathname belongs to, so the patterns live here rather than inline at the router's call sites.
+"""
+
+import re
+import urllib.parse
+
+from ztf_viewer.util import DEFAULT_DR
+
+#: Title suffix for the pages that do not belong to a single data release.
+SITE_TITLE = "SNAD ZTF viewer"
+
+DR7 = re.compile(r"^/dr7((?:/.*)?)$")
+HOME = re.compile(r"^/+(?:(dr\d{1,2})/+)?$")
+VIEW_DEFAULT_DR = re.compile(r"^/+view/+(?P<oid>\d+)")
+VIEW = re.compile(r"^/+(?P<dr>dr\d{1,2})/+view/+(?P<oid>\d+)")
+SEARCH = re.compile(
+    r"""^
+        (?:/+(?P<dr>dr\d{1,2}))?
+        /+search
+        /+(?P<coord_or_name>[^/]+)
+        /+(?P<radius_arcsec>[^/]+)
+        /*
+        $""",
+    flags=re.VERBOSE,
+)
+LOGIN = re.compile(r"^/+login/*$")
+ANOMALIES = re.compile(r"^/+(?:(?:anomalies)|(?:akb))/*$")
+TAGS = re.compile(r"^/+tags/*$")
+
+
+def _site_title(dr: str | None = None) -> str:
+    """The site title, naming the data release on the pages that belong to one."""
+    if dr is None:
+        return SITE_TITLE
+    return f"SNAD ZTF {dr.upper()} viewer"
+
+
+def _page_title(page: str, dr: str | None = None) -> str:
+    return f"{page} — {_site_title(dr)}"
+
+
+def page_title(pathname) -> str:
+    """The document title for `pathname`, matching the page the router builds for it."""
+    if not isinstance(pathname, str):
+        return SITE_TITLE
+    if DR7.search(pathname):
+        return _page_title("DR7 is not supported")
+    if match := HOME.search(pathname):
+        return _site_title(match.group(1) or DEFAULT_DR)
+    if match := VIEW.search(pathname) or VIEW_DEFAULT_DR.search(pathname):
+        return _page_title(match["oid"], match.groupdict().get("dr") or DEFAULT_DR)
+    if match := SEARCH.search(pathname):
+        coord_or_name = urllib.parse.unquote(match["coord_or_name"])
+        return _page_title(f"Search {coord_or_name} r={match['radius_arcsec']}″", match["dr"] or DEFAULT_DR)
+    if LOGIN.search(pathname):
+        return _page_title("Login")
+    if ANOMALIES.search(pathname):
+        return _page_title("Anomalies")
+    if TAGS.search(pathname):
+        return _page_title("Tags")
+    return _page_title("404")


### PR DESCRIPTION
Closes #99.

Every page was titled `SNAD ZTF viewer`, so browser tabs, history entries and bookmarks were indistinguishable. Following [the Dash docs' "Update the Document Title Dynamically Based on the URL"](https://dash.plotly.com/external-resources), a server callback derives a title from `url.pathname` and a clientside callback writes `document.title` — `app.title` only sets the title of the index Dash serves once, and never changes again during clientside navigation.

The router's URL regexes moved from inline `re.search` calls in `app_select_by_url` to `ztf_viewer/routes.py`, so the title and the page it labels are decided by the same patterns instead of two copies drifting apart.

### Titles

| Pathname | Title |
| --- | --- |
| `/` | `SNAD ZTF DR24 viewer` |
| `/dr23/` | `SNAD ZTF DR23 viewer` |
| `/view/633207400004730` | `633207400004730 — SNAD ZTF DR24 viewer` |
| `/dr23/view/633207400004730` | `633207400004730 — SNAD ZTF DR23 viewer` |
| `/dr23/search/M57/1.5` | `Search M57 r=1.5″ — SNAD ZTF DR23 viewer` |
| `/login` | `Login — SNAD ZTF viewer` |
| `/anomalies`, `/akb` | `Anomalies — SNAD ZTF viewer` |
| `/tags` | `Tags — SNAD ZTF viewer` |
| `/dr7/...` | `DR7 is not supported — SNAD ZTF viewer` |
| anything else | `404 — SNAD ZTF viewer` |

The data release is part of the title wherever the page has one, so two tabs on the same object in different DRs are still tellable apart.

Dash's own `update_title` ("Updating...") keeps working: its `MutationObserver` on `<title>` stashes whatever the clientside callback wrote and restores it once the callbacks settle.

### Test evidence

`pytest -m "not network"` — 43 passed, 2 skipped (JS9, not installed outside the image):

```
$ python -m pytest --basetemp=/tmp/pytest -q -m "not network"
...........................................                              [100%]
SKIPPED [1] tests/test_app.py:61: JS9 not installed locally
SKIPPED [1] tests/test_golden_http.py:135: JS9 not installed locally
```

New `tests/test_routes.py` covers the title for every route, percent-decoding of the search query, the `pathname is None` case before the first navigation, distinctness across pages, and that the store/sink ids the callbacks use are the ones really in the layout (nothing else checks that — the app is built with `suppress_callback_exceptions`). `set_page_title` is added to `test_sync_callbacks.py`'s reviewed-sync allowlist: it is pure string formatting, no I/O.

Checked by hand in Firefox against a local `uvicorn` run, including clientside navigation without a reload, `/view/633207400004730` and `/dr23/search/M57/1.5` both settling on the titles above after their callbacks finish.

`pre-commit run --files <changed>` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FpoPGgsw2UExGF1oT9LfLC