### PR TITLE
Mark the observation whose FITS image is shown

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ Version schema is `year.month.num_release`
 
 ### Added
 
+- A dashed cross-hair marks the observation whose FITS image is shown, and the FITS block names that observation's filter and MJD https://github.com/snad-space/ztf-viewer/issues/719
+
+### Added
+
 - Per-page browser titles, so that tabs for different objects, searches and pages are distinguishable https://github.com/snad-space/ztf-viewer/issues/99
 
 ## [2026.8.1] 2026 August 28

--- a/tests/pages/test_viewer.py
+++ b/tests/pages/test_viewer.py
@@ -719,7 +719,8 @@ def test_pick_fits_observation_peak_is_brightest():
 async def test_fits_children_for_observation(summary_upstreams):
     with patch.object(viewer, "correct_date", AsyncMock()):
         children = await fits_children_for_observation(58000.0, "633207400004730", 796, 12, "zg", "dr24")
-    ra_text, dec_text, cutout_text, js9_link, _, download_link, _, prod_link = _project(children)
+    info_text, ra_text, dec_text, cutout_text, js9_link, _, download_link, _, prod_link = _project(children)
+    assert info_text == "FITS image for: zg, MJD 58000.00000"
     assert ra_text == "10.0"
     assert dec_text == "20.0"
     assert "size=449pix" in cutout_text
@@ -758,11 +759,12 @@ async def test_load_fits_for_graph_clicked_initial_mount_honours_fits_param(monk
     token = _set_triggered()
     try:
         with patch.object(viewer, "correct_date", AsyncMock()):
-            children = await load_fits_for_graph_clicked(None, "633207400004730", "dr24", "?fits=last")
+            children, selected = await load_fits_for_graph_clicked(None, "633207400004730", "dr24", "?fits=last")
     finally:
         context_value.reset(token)
     *_, download_link, _, _ = _project(children)
     assert download_link["text"] == "Download FITS"
+    assert selected == {"mjd": 58000.0, "oid": "633207400004730"}
 
 
 async def test_load_fits_for_graph_clicked_oid_trigger_honours_fits_param(monkeypatch, summary_upstreams):
@@ -774,11 +776,12 @@ async def test_load_fits_for_graph_clicked_oid_trigger_honours_fits_param(monkey
     token = _set_triggered("oid.children")
     try:
         with patch.object(viewer, "correct_date", AsyncMock()):
-            children = await load_fits_for_graph_clicked(None, "633207400004730", "dr24", "?fits=last")
+            children, selected = await load_fits_for_graph_clicked(None, "633207400004730", "dr24", "?fits=last")
     finally:
         context_value.reset(token)
     *_, download_link, _, _ = _project(children)
     assert download_link["text"] == "Download FITS"
+    assert selected == {"mjd": 58000.0, "oid": "633207400004730"}
 
 
 async def test_load_fits_for_graph_clicked_oid_trigger_without_fits_param_prevents_update(summary_upstreams):
@@ -795,8 +798,37 @@ async def test_load_fits_for_graph_clicked_click_trigger_still_works(summary_ups
     token = _set_triggered("graph.clickData")
     try:
         with patch.object(viewer, "correct_date", AsyncMock()):
-            children = await load_fits_for_graph_clicked(data, "633207400004730", "dr24", "")
+            children, selected = await load_fits_for_graph_clicked(data, "633207400004730", "dr24", "")
     finally:
         context_value.reset(token)
     *_, download_link, _, _ = _project(children)
     assert download_link["text"] == "Download FITS"
+    assert selected == {"mjd": 58000.0, "oid": "633207400004730"}
+
+
+# ---------------------------------------------------------------------------------------------
+# The cross-hair over the observation whose FITS frame is on screen.
+# ---------------------------------------------------------------------------------------------
+#
+# The cross-hair is positioned by a clientside callback, which cannot read the trace `x`/`y`
+# arrays: plotly serializes those as base64 typed arrays. It reads the coordinates out of
+# `customdata` instead, which stays a plain array of arrays -- so what these tests pin is the
+# contract between the two sides, the only part of it that can go wrong silently.
+
+
+def test_custom_data_indexes_point_past_the_identity_columns():
+    """The x and y the cross-hair needs are appended after the identity columns, so the existing
+    `mjd, oid, fieldid, rcid, fltr, *_ = point["customdata"]` unpacking keeps working."""
+    assert viewer.CUSTOM_DATA[:2] == ["mjd", "oid"]
+    assert viewer.CUSTOM_DATA_X == len(viewer.CUSTOM_DATA)
+    assert viewer.CUSTOM_DATA_Y == len(viewer.CUSTOM_DATA) + 1
+
+
+def test_crosshair_callback_javascript_has_the_indexes_substituted():
+    """A rename of the placeholder would otherwise leave the JS referencing an undefined name,
+    which fails silently in the browser -- the cross-hair simply never appears."""
+    crosshair = [script for script in viewer.app._inline_scripts if "shapes" in script]
+
+    assert len(crosshair) == 1
+    assert "CUSTOM_DATA_INDEXES" not in crosshair[0]
+    assert f"[0, 1, {viewer.CUSTOM_DATA_X}, {viewer.CUSTOM_DATA_Y}]" in crosshair[0]

--- a/ztf_viewer/pages/viewer.py
+++ b/ztf_viewer/pages/viewer.py
@@ -5,6 +5,7 @@ from functools import partial
 from itertools import chain
 from typing import Any
 from urllib.parse import parse_qs, urlencode, urljoin, urlparse
+from uuid import uuid4
 
 import dash_defer_js_import as dji
 import numpy as np
@@ -140,6 +141,12 @@ def pick_fits_observation(own_lc: list[dict], fits_param: str) -> dict | None:
     return None
 
 
+# Point identity; `set_figure` appends the plotted x and y, which differ between the full and the
+# folded light curve. The cross-hair reads coordinates from here: plotly sends `x`/`y` as base64.
+CUSTOM_DATA = ["mjd", "oid", "fieldid", "rcid", "filter"]
+CUSTOM_DATA_X, CUSTOM_DATA_Y = len(CUSTOM_DATA), len(CUSTOM_DATA) + 1
+
+
 async def fits_children_for_observation(mjd, oid, fieldid, rcid, fltr, dr):
     ra, dec = await find_ztf_oid.get_coord(oid, dr)
     coord = await find_ztf_oid.get_sky_coord(oid, dr)
@@ -151,6 +158,7 @@ async def fits_children_for_observation(mjd, oid, fieldid, rcid, fltr, dr):
     js9_url = f'{JS9_URL}?{urlencode({"url": fits_url,"zoom": 10,"ra": ra,"dec": dec,"scale": "histeq","flip": "y"})}'
     prod_dir_url = urljoin(ZTF_FITS_PROXY_URL, date.products_path)
     return [
+        html.Div(f"FITS image for: {fltr}, MJD {mjd:.5f}", id="fits-to-show-info"),
         html.Div(ra, id="fits-to-show-ra", style={"display": "none"}),
         html.Div(dec, id="fits-to-show-dec", style={"display": "none"}),
         html.Div(fits_cutout_url, id="fits-to-show-cutout-url", style={"display": "none"}),
@@ -212,6 +220,8 @@ async def get_layout(pathname, search):
     layout = html.Div(
         [
             html.Div("", id="placeholder", style={"display": "none"}),
+            dcc.Store(id="selected-observation"),
+            dcc.Store(id="figure-version"),
             html.Div(f"{oid}", id="oid", style={"display": "none"}),
             html.Div(f"{dr}", id="dr", style={"display": "none"}),
             html.H2(id="title"),
@@ -1688,7 +1698,11 @@ def neighbour_oids(different_filter, different_field) -> frozenset:
 
 
 @app.callback(
-    [Output("graph", "figure"), Output("error-fit-curve-message-hidden", "value")],
+    [
+        Output("graph", "figure"),
+        Output("error-fit-curve-message-hidden", "value"),
+        Output("figure-version", "data"),
+    ],
     [
         Input("oid", "children"),
         Input("dr", "children"),
@@ -1833,7 +1847,7 @@ async def set_figure(
             size="mark_size",
             size_max=MARKER_SIZE,
             hover_data={f"mjd_{MJD_OFFSET}": ":.5f", "date": True, brighterr: True},
-            custom_data=["mjd", "oid", "fieldid", "rcid", "filter"],
+            custom_data=CUSTOM_DATA + [f"mjd_{MJD_OFFSET}", bright],
             render_mode=render_mode,
         )
     elif lc_type == "folded":
@@ -1851,7 +1865,7 @@ async def set_figure(
             size="mark_size",
             size_max=MARKER_SIZE,
             hover_data={"folded_time": True, f"mjd_{MJD_OFFSET}": ":.5f", "date": True, brighterr: True},
-            custom_data=["mjd", "oid", "fieldid", "rcid", "filter"],
+            custom_data=CUSTOM_DATA + ["phase", bright],
             range_x=[0.0, 1.0],
             render_mode=render_mode,
         )
@@ -1898,7 +1912,7 @@ async def set_figure(
     fw.layout.legend.xanchor = "left"
     fw.layout.legend.y = -0.1
     fw.layout.plot_bgcolor = "#E8E8E8"
-    return fw, message_fit
+    return fw, message_fit, str(uuid4())
 
 
 def set_figure_link(
@@ -2069,7 +2083,7 @@ app.clientside_callback(
 
 
 @app.callback(
-    Output("fits-to-show", "children"),
+    [Output("fits-to-show", "children"), Output("selected-observation", "data")],
     [Input("graph", "clickData"), Input("oid", "children")],
     [State("dr", "children"), State("url", "search")],
 )
@@ -2088,16 +2102,66 @@ async def load_fits_for_graph_clicked(data, oid, dr, search):
         ).get(oid, [])
         if (obs := pick_fits_observation(own_lc, fits_param)) is None:
             raise PreventUpdate
-        return await fits_children_for_observation(
+        children = await fits_children_for_observation(
             obs["mjd"], obs["oid"], obs["fieldid"], obs["rcid"], obs["filter"], dr
         )
+        return children, {"mjd": obs["mjd"], "oid": obs["oid"]}
     if data is None:
         raise PreventUpdate
     if not (points := data.get("points")):
         raise PreventUpdate
     point = points[0]
     mjd, oid, fieldid, rcid, fltr, *_ = point["customdata"]
-    return await fits_children_for_observation(mjd, oid, fieldid, rcid, fltr, dr)
+    children = await fits_children_for_observation(mjd, oid, fieldid, rcid, fltr, dr)
+    return children, {"mjd": mjd, "oid": oid}
+
+
+# Layout shapes, not an extra trace, so the cross-hair spans the axes and cannot be hovered or
+# clicked like a data point. It goes into `graph.figure` rather than through `Plotly.relayout`,
+# which races with the figure `set_figure` builds in parallel and loses. `figure-version` is the
+# "figure was replaced" trigger; `graph.figure` itself would be a circular dependency here.
+app.clientside_callback(
+    """
+    function(selected, _version, figure) {
+        const [MJD, OID, X, Y] = CUSTOM_DATA_INDEXES;
+        if (!figure) {
+            return window.dash_clientside.no_update;
+        }
+        let x = null;
+        let y = null;
+        for (const trace of selected ? figure.data || [] : []) {
+            // Coordinates come from `customdata`, a plain array; trace `x`/`y` reach the browser
+            // as base64-packed typed arrays.
+            for (const point of trace.customdata || []) {
+                if (Math.abs(point[MJD] - selected.mjd) < 1e-9 && String(point[OID]) === String(selected.oid)) {
+                    x = point[X];
+                    y = point[Y];
+                    break;
+                }
+            }
+            if (x !== null) {
+                break;
+            }
+        }
+        const line = {color: "#333333", width: 1, dash: "dash"};
+        const shapes = x === null ? [] : [
+            {type: "line", layer: "above", line: line, xref: "x", yref: "paper", x0: x, x1: x, y0: 0, y1: 1},
+            {type: "line", layer: "above", line: line, xref: "paper", yref: "y", x0: 0, x1: 1, y0: y, y1: y},
+        ];
+        const layout = figure.layout || {};
+        if (JSON.stringify(layout.shapes || []) === JSON.stringify(shapes)) {
+            return window.dash_clientside.no_update;
+        }
+        return {...figure, layout: {...layout, shapes: shapes}};
+    }
+    """.replace(
+        "CUSTOM_DATA_INDEXES", str([CUSTOM_DATA.index("mjd"), CUSTOM_DATA.index("oid"), CUSTOM_DATA_X, CUSTOM_DATA_Y])
+    ),
+    Output("graph", "figure", allow_duplicate=True),
+    [Input("selected-observation", "data"), Input("figure-version", "data")],
+    [State("graph", "figure")],
+    prevent_initial_call=True,
+)
 
 
 @app.callback(


### PR DESCRIPTION
Closes #719 — both halves: highlight the selected point on the light curve, and say something about the FITS image being displayed.

## What changed

**Cross-hair.** A dashed cross-hair spans the axes through the observation the FITS frame belongs to. It follows the point through every figure rebuild — folding, brightness type, MJD range — and disappears if a rebuild filters that observation out. `?fits=first|last|peak` gets the cross-hair on page load, with no click.

**FITS label.** The FITS block above the JS9 links now opens with `FITS image for: zr, MJD 58353.26811`.

## Two things worth a reviewer's attention

**Why not `Plotly.relayout`.** That was the first implementation and it is subtly broken: on page load `set_figure` and `load_fits_for_graph_clicked` are dispatched together, so a relayout can be applied and then wiped by the figure landing after it. It failed on roughly half of `?fits=peak` loads. The shapes now go into `graph.figure` itself, through a clientside callback, so they travel the same path as the figure and cannot be overtaken.

That callback cannot take `graph.figure` as an `Input` (it is also its `Output` — a circular dependency), so `set_figure` emits a new `figure-version` token on every rebuild and the cross-hair callback triggers on that instead. The figure is passed as `State` to a *clientside* callback, so it never leaves the browser.

**Why coordinates live in `customdata`.** plotly serializes trace `x`/`y` as base64-packed typed arrays (`{dtype, bdata}`), so `trace.x[i]` is `undefined` in the browser. `custom_data` stays a plain array of arrays, so `set_figure` now appends the two plotted axis columns to it — `mjd_58000`/`bright` for the full curve, `phase`/`bright` for the folded one — and the callback reads the coordinates from there. The identity columns keep their positions, so the existing `mjd, oid, fieldid, rcid, fltr, *_ = point["customdata"]` unpacking is unaffected.

## Test evidence

`pytest -m "not network"` — **475 passed, 2 skipped** (JS9, only present in the built image).

Updated the existing `fits_children_for_observation` / `load_fits_for_graph_clicked` tests for the new info line and the second output, and added two that pin the contract between the Python and JS sides — the part that can otherwise break silently (a wrong index just means the cross-hair never appears):

- `test_custom_data_indexes_point_past_the_identity_columns`
- `test_crosshair_callback_javascript_has_the_indexes_substituted`

Driven by hand in Firefox against a local `uvicorn` run, checking `gd.layout.shapes` against the selected point's coordinates each time:

| Case | Result |
| --- | --- |
| `?fits=peak` on load | cross-hair on the brightest point, x=357.27, y=19.284 |
| `?fits=first` on load | cross-hair on the earliest point, x=198.42, y=20.755 |
| click a point | moves to x=353.27, y=20.022; label follows |
| switch mag → flux | horizontal line moves to 3.04e-5 Jy, same point |
| switch to folded, P=100 | vertical line moves to phase 0.533 |
| MJD range excludes the point | cross-hair removed, not left stale |

`pre-commit run --files <changed>` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FpoPGgsw2UExGF1oT9LfLC