### PR TITLE
Put brightness error right after brightness in LC hover

### DIFF
--- a/tests/pages/test_viewer.py
+++ b/tests/pages/test_viewer.py
@@ -48,6 +48,7 @@ config.UNAVAILABLE_CATALOGS_CACHE_TYPE = "memory"
 
 from ztf_viewer.catalogs import unavailable_catalogs
 from ztf_viewer.exceptions import CatalogUnavailable, NotFound
+from ztf_viewer.lc_data.plot_data import folded_plot_data, plot_data
 from ztf_viewer.pages import viewer
 
 # Callback registration leaves coroutine functions unwrapped, but unwrap anyway: it's a no-op if
@@ -832,3 +833,83 @@ def test_crosshair_callback_javascript_has_the_indexes_substituted():
     assert len(crosshair) == 1
     assert "CUSTOM_DATA_INDEXES" not in crosshair[0]
     assert f"[0, 1, {viewer.CUSTOM_DATA_X}, {viewer.CUSTOM_DATA_Y}]" in crosshair[0]
+
+
+# ---------------------------------------------------------------------------------------------
+# set_figure -- the hover box over a light-curve point.
+# ---------------------------------------------------------------------------------------------
+#
+# The hover rows are built by plotly express out of the x/y columns, the `color`/`symbol`/`size`
+# dimensions and `hover_data`, in that order. Both of the things pinned here are consequences of
+# that ordering rather than of anything written literally in the template, so they can regress
+# silently: the brightness error has to sit right below the brightness it belongs to, and
+# `mark_size` -- which encodes whether the point belongs to the current OID, not anything
+# measured -- must not show up as a data row at all.
+
+set_figure = inspect.unwrap(viewer.set_figure)
+
+
+def _hover_rows(figure) -> list[str]:
+    """The left-hand labels of the hover box, in the order they are rendered."""
+    template = figure.data[0].hovertemplate.replace("<extra></extra>", "")
+    return [row.split("=", maxsplit=1)[0] for row in template.split("<br>")]
+
+
+async def _figure_hover_rows(brightness_type="mag", lc_type="full", period=None):
+    lc = [
+        {
+            "mjd": 58000.0 + i,
+            "mag": 18.0 + 0.1 * i,
+            "magerr": 0.05,
+            "filter": "zr",
+            "oid": "633207400004730",
+            "fieldid": 633,
+            "rcid": 12,
+        }
+        for i in range(3)
+    ]
+    lcs = {"633207400004730": plot_data(lc, mark_size=3)}
+    if lc_type == "folded":
+        lcs = {oid: folded_plot_data(one, period=period) for oid, one in lcs.items()}
+
+    with (
+        patch.object(viewer, "get_plot_data", AsyncMock(return_value=lcs)),
+        patch.object(viewer, "get_folded_plot_data", AsyncMock(return_value=lcs)),
+    ):
+        figure, _message, _version = await set_figure(
+            cur_oid="633207400004730",
+            dr="dr24",
+            different_filter=None,
+            different_field=None,
+            min_mjd=None,
+            max_mjd=None,
+            brightness_type=brightness_type,
+            lc_type=lc_type,
+            period=period,
+            phase0=None,
+            ref_mag_ids=[],
+            ref_mag_values=[],
+            ref_magerr_ids=[],
+            ref_magerr_values=[],
+            additional_lc_types=[],
+            webgl_available="1",
+            name_model=None,
+            fit_params=None,
+        )
+    return _hover_rows(figure)
+
+
+async def test_set_figure_hover_puts_the_error_right_after_the_brightness():
+    assert await _figure_hover_rows() == ["filter", "oid", "mjd − 58000", "mag", "mag error", "date"]
+
+
+async def test_set_figure_hover_of_a_folded_curve_puts_the_error_right_after_the_brightness():
+    # The folded branch passes no `labels` for the brightness columns, so they keep their raw
+    # names here -- what is pinned is the position of the error row, not how it is spelled.
+    rows = await _figure_hover_rows(lc_type="folded", period=1.5)
+    assert rows == ["filter", "oid", "phase", "mag", "magerr", "folded_time", "mjd − 58000", "date"]
+
+
+@pytest.mark.parametrize("brightness_type", ["mag", "flux", "diffmag", "diffflux"])
+async def test_set_figure_hover_never_shows_mark_size(brightness_type):
+    assert "mark_size" not in await _figure_hover_rows(brightness_type=brightness_type)

--- a/ztf_viewer/pages/viewer.py
+++ b/ztf_viewer/pages/viewer.py
@@ -1846,7 +1846,7 @@ async def set_figure(
             symbol="oid",
             size="mark_size",
             size_max=MARKER_SIZE,
-            hover_data={f"mjd_{MJD_OFFSET}": ":.5f", "date": True, brighterr: True},
+            hover_data={brighterr: True, "mark_size": False, f"mjd_{MJD_OFFSET}": ":.5f", "date": True},
             custom_data=CUSTOM_DATA + [f"mjd_{MJD_OFFSET}", bright],
             render_mode=render_mode,
         )
@@ -1864,7 +1864,13 @@ async def set_figure(
             symbol="oid",
             size="mark_size",
             size_max=MARKER_SIZE,
-            hover_data={"folded_time": True, f"mjd_{MJD_OFFSET}": ":.5f", "date": True, brighterr: True},
+            hover_data={
+                brighterr: True,
+                "mark_size": False,
+                "folded_time": True,
+                f"mjd_{MJD_OFFSET}": ":.5f",
+                "date": True,
+            },
             custom_data=CUSTOM_DATA + ["phase", bright],
             range_x=[0.0, 1.0],
             render_mode=render_mode,


### PR DESCRIPTION
The light-curve hover box listed the brightness error last, three rows below the brightness it belongs to, and showed `mark_size` -- a plotting detail encoding whether a point belongs to the current OID -- as if it were data.

Plotly express builds the hover rows from x/y, then the color/symbol/size dimensions, then `hover_data` in dict order, so both are fixed by reordering `hover_data` and setting `mark_size: False` there.

Closes #170


Claude-Session: https://claude.ai/code/session_01A1AUCG38DYPKj8PzyEgxJQ