### PR TITLE
Work with Astro-COLIBRI's API access restrictions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ Version schema is `year.month.num_release`
 ### Changed
 
 - Cone searches to Simbad are paced to its published limit of 8 queries per second, so a busy moment cannot get us temporarily blacklisted https://github.com/snad-space/ztf-viewer/issues/51
+- Astro-COLIBRI cone searches use its documented, registered-users-only endpoint and keep to the 100 requests per day that comes with the account, when the new `ASTRO_COLIBRI_UID` environment variable identifies one; without it the older unauthenticated call is made as before https://github.com/snad-space/ztf-viewer/issues/421
 
 ### Fixed
 

--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ Environment variables to configure the server, see default values in `config.py`
 - `TNS_API_URL`: SNAD mirror of the TNS
 - `ZTF_FITS_PROXY_URL`: address of SNAD proxy for ZTF FITS
 - `JS9_URL`: address of full-functional JS9 viewer supporting `JS9.LoadProxy`
+- `ASTRO_COLIBRI_UID`: user id of a registered [Astro-COLIBRI](https://astro-colibri.science) account (found in the account settings), a secret to keep in `secret.env`. Astro-COLIBRI restricts its documented cone-search endpoint to registered users and grants each of them 100 requests per day; with this set, the viewer queries that endpoint and holds itself to the daily quota, and without it, it falls back to the older unauthenticated call. The viewer sends no `filter` of its own, so the account's saved filter configuration decides which events the cone search returns — an account with none configured gets an error back rather than results
 
 ### Running development docker-compose
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -16,6 +16,8 @@ services:
       - OGLE_III_API_URL=http://ogle3.snad.space
       - ZTF_PERIODIC_API_URL=http://periodic.ztf.snad.space
       - TNS_API_URL=http://tns.snad.space
+      # Secret, so passed through from the host environment rather than written here.
+      - ASTRO_COLIBRI_UID
       - VIRTUAL_HOST=ztf.snad.space
       - DYNDNS_HOST=ztf.snad.space
       - LETSENCRYPT_HOST=ztf.snad.space

--- a/tests/catalogs/conesearch/test_colibri.py
+++ b/tests/catalogs/conesearch/test_colibri.py
@@ -1,0 +1,156 @@
+"""Astro-COLIBRI cone search: the two request forms, and the parsing they share.
+
+Only the first test here talks to the real service, and it exercises the unauthenticated legacy
+call, which is what a checkout with no `ASTRO_COLIBRI_UID` makes. The documented `POST` form
+cannot be exercised for real without an account's user id -- the endpoint answers 400 to anyone
+else -- so what is pinned for it is the request body against the published schema
+(https://astro-colibri.science/apidoc), and the fact that the response handling is the same code
+either way is pinned by feeding one canned payload through both paths.
+"""
+
+import pytest
+
+CONE_RA, CONE_DEC = 10.684, 41.269
+CONE_RADIUS_ARCSEC = 18.0
+
+#: One event in the shape the API returns, cut down to the fields the parser touches. `"None"`
+#: as a string is Astro-COLIBRI's own way of saying "no value", which the parser turns into a
+#: real `None`; the empty `simbad_link` is an event with no Simbad counterpart.
+CANNED_EVENT = {
+    "source_name": "TestEvent",
+    "type": "GRB",
+    "ra": CONE_RA,
+    "dec": CONE_DEC,
+    "redshift": "None",
+    "observatory": "Test observatory",
+    "simbad_link": "",
+    "timestamp": 1704067200000,  # 2024-01-01T00:00:00Z, MJD 60310
+}
+
+
+class _FakeResponse:
+    status_code = 200
+    text = ""
+
+    def __init__(self, payload):
+        self._payload = payload
+
+    def json(self):
+        return self._payload
+
+
+class _FakeClient:
+    """Records the one request made through it and answers with a canned payload."""
+
+    def __init__(self, payload):
+        self._payload = payload
+        self.calls = []
+
+    async def get(self, url, **kwargs):
+        self.calls.append(("get", url, kwargs))
+        return _FakeResponse(self._payload)
+
+    async def post(self, url, **kwargs):
+        self.calls.append(("post", url, kwargs))
+        return _FakeResponse(self._payload)
+
+
+@pytest.fixture
+def fake_client(monkeypatch):
+    """Swap the shared httpx client for a recorder, and hand the test what it recorded."""
+    from ztf_viewer.catalogs.conesearch import colibri
+
+    client = _FakeClient({"voevents": [CANNED_EVENT]})
+    monkeypatch.setattr(colibri, "get_client", lambda: client)
+    return client
+
+
+async def test_cone_search():
+    """Regression test against the real Astro-COLIBRI server, over the unauthenticated call.
+
+    The cone is centred on M31, where the service holds a long-standing CBAT nova candidate. As
+    with the other catalog tests, the expected object is whatever the live database currently
+    returns; it was last verified 2026-09-05.
+    """
+    from ztf_viewer.catalogs.conesearch.colibri import ColibriQuery
+
+    query = ColibriQuery("Test Astro-COLIBRI")
+    table = await query._api_query_region(ra=CONE_RA, dec=CONE_DEC, radius_arcsec=CONE_RADIUS_ARCSEC)
+
+    assert len(table) > 0
+    for column in ("source_name", "ra", "dec", "type", "mjd", "date", "simbad_url"):
+        assert column in table.colnames, f"Missing column: {column}"
+
+
+async def test_cone_search_not_found():
+    """A patch of sky Astro-COLIBRI has nothing in answers with an empty list, not an error.
+
+    An arbitrary position rather than a round one: (0, 0) has a real event sitting on it.
+    """
+    from ztf_viewer.catalogs.conesearch.colibri import ColibriQuery
+    from ztf_viewer.exceptions import NotFound
+
+    query = ColibriQuery("Test Astro-COLIBRI 2")
+    with pytest.raises(NotFound):
+        await query._api_query_region(ra=123.4567, dec=-12.3456, radius_arcsec=1.0)
+
+
+async def test_an_unauthenticated_deployment_queries_the_legacy_endpoint(fake_client, monkeypatch):
+    """No uid configured: exactly the call this viewer has always made, unchanged."""
+    from ztf_viewer.catalogs.conesearch.colibri import ColibriQuery
+
+    monkeypatch.setattr("ztf_viewer.config.ASTRO_COLIBRI_UID", "")
+    query = ColibriQuery("Test Astro-COLIBRI 3")
+
+    table = await query._api_query_region(ra=CONE_RA, dec=CONE_DEC, radius_arcsec=CONE_RADIUS_ARCSEC)
+
+    ((method, url, _kwargs),) = fake_client.calls
+    assert method == "get"
+    assert url.startswith("https://astro-colibri.science/cone_search?")
+    assert f"cone=%5B{CONE_RA}%2C{CONE_DEC}%2C{CONE_RADIUS_ARCSEC / 3600.0}%5D" in url
+    assert table["source_name"][0] == "TestEvent"
+
+
+async def test_a_registered_deployment_posts_the_documented_body(fake_client, monkeypatch):
+    """With a uid, the request is the documented one, so it is the metered one.
+
+    Pinned field by field against the published schema, because getting a name wrong here does
+    not fail loudly -- the endpoint would answer 400 and the catalog would simply be missing
+    from every page.
+    """
+    from ztf_viewer.catalogs.conesearch.colibri import ColibriQuery
+
+    monkeypatch.setattr("ztf_viewer.config.ASTRO_COLIBRI_UID", "test-uid")
+    query = ColibriQuery("Test Astro-COLIBRI 4")
+
+    table = await query._api_query_region(ra=CONE_RA, dec=CONE_DEC, radius_arcsec=CONE_RADIUS_ARCSEC)
+
+    ((method, url, kwargs),) = fake_client.calls
+    assert method == "post"
+    assert url == "https://astro-colibri.science/cone_search"
+    assert kwargs["json"] == {
+        "uid": "test-uid",
+        "properties": {
+            "position": {"ra": CONE_RA, "dec": CONE_DEC},
+            # The API takes degrees, and the viewer's search boxes are in arcseconds.
+            "radius": CONE_RADIUS_ARCSEC / 3600.0,
+        },
+        # The widest window the API accepts, matching the legacy call's unix-millisecond bounds.
+        "time_range": {"min": "1970-01-01T00:00:00", "max": "2038-01-19T03:14:07"},
+    }
+    # Same answer out of the same parser, whichever way the question was asked.
+    assert table["source_name"][0] == "TestEvent"
+
+
+async def test_the_response_is_parsed_the_same_way_on_both_paths(fake_client):
+    """Timestamps, absent Simbad links and the API's string `"None"` are handled once, not twice."""
+    from ztf_viewer.catalogs.conesearch.colibri import ColibriQuery
+
+    query = ColibriQuery("Test Astro-COLIBRI 5")
+
+    table = await query._api_query_region(ra=CONE_RA, dec=CONE_DEC, radius_arcsec=CONE_RADIUS_ARCSEC)
+
+    assert table["mjd"][0] == 60310.0
+    assert table["date"][0].startswith("2024-01-01")
+    assert table["simbad_url"][0] == ""
+    assert table["redshift"][0] is None

--- a/tests/test_rate_limit.py
+++ b/tests/test_rate_limit.py
@@ -22,9 +22,9 @@ import time
 
 import pytest
 
-from ztf_viewer.config import SIMBAD_MAX_QUERIES_PER_SECOND
+from ztf_viewer.config import ASTRO_COLIBRI_MAX_QUERIES_PER_DAY, SIMBAD_MAX_QUERIES_PER_SECOND
 from ztf_viewer.exceptions import CatalogUnavailable
-from ztf_viewer.rate_limit import AsyncRateLimiter, RateLimitTimeout
+from ztf_viewer.rate_limit import AsyncCallQuota, AsyncRateLimiter, RateLimitTimeout
 
 PERIOD = 0.2
 
@@ -195,6 +195,118 @@ def test_rejects_a_limit_that_admits_nothing(max_calls, period):
         AsyncRateLimiter(max_calls=max_calls, period=period)
 
 
+async def test_a_quota_spends_its_whole_allowance_without_waiting():
+    """The difference from `AsyncRateLimiter` that the class exists for.
+
+    A daily allowance says nothing about how fast it may be spent, so pacing it would make every
+    caller but the first wait for a slot the upstream never asked us to leave free.
+    """
+    quota = AsyncCallQuota(max_calls=3, period=PERIOD)
+
+    waits = [await quota.acquire() for _ in range(3)]
+
+    assert waits == [0.0, 0.0, 0.0]
+
+
+async def test_a_spent_quota_refuses_rather_than_queueing():
+    """The default `max_wait` of zero: the next slot in a day-long window outlives the request."""
+    quota = AsyncCallQuota(max_calls=2, period=PERIOD)
+    await quota.acquire()
+    await quota.acquire()
+
+    with pytest.raises(RateLimitTimeout):
+        await quota.acquire()
+
+
+async def test_the_window_rolls_rather_than_resetting():
+    """A slot comes back one period after the call that spent it, not at a fixed daily reset.
+
+    Sleeping past the period is the only way to observe this, so the period here is short.
+    """
+    quota = AsyncCallQuota(max_calls=1, period=PERIOD)
+    await quota.acquire()
+
+    await asyncio.sleep(PERIOD)
+
+    assert await quota.acquire() == 0.0
+
+
+async def test_refused_calls_do_not_spend_the_allowance():
+    """Being turned away must not cost the allowance a slot, or a busy day would never recover.
+
+    Each refusal below would otherwise push the window out by another period, and the two calls
+    that the rolled window owes us would not both be there when it comes back around.
+    """
+    quota = AsyncCallQuota(max_calls=2, period=PERIOD)
+    await quota.acquire()
+    await quota.acquire()
+
+    for _ in range(5):
+        with pytest.raises(RateLimitTimeout):
+            await quota.acquire()
+
+    await asyncio.sleep(PERIOD)
+    assert [await quota.acquire() for _ in range(2)] == [0.0, 0.0]
+
+
+async def test_a_caller_may_wait_for_a_slot_when_its_budget_allows():
+    """`max_wait` is a default, not the whole contract: a caller with time to spare can queue."""
+    quota = AsyncCallQuota(max_calls=1, period=PERIOD, max_wait=None)
+    await quota.acquire()
+
+    start = time.monotonic()
+    wait = await quota.acquire()
+
+    assert wait > 0
+    assert time.monotonic() - start >= PERIOD
+
+
+async def test_queued_callers_each_wait_for_a_slot_of_their_own():
+    """A waiter's reservation has to count against the window, not just the calls already sent.
+
+    Measuring the next slot from the oldest entry alone would hand the second and third caller
+    below the same instant, and the upstream would see the day's last allowance spent twice over.
+    """
+    quota = AsyncCallQuota(max_calls=1, period=PERIOD, max_wait=None)
+
+    start = time.monotonic()
+    await asyncio.gather(*(asyncio.create_task(quota.acquire()) for _ in range(3)))
+
+    assert time.monotonic() - start >= 2 * PERIOD
+
+
+async def test_cancelled_caller_gives_its_quota_slot_back():
+    """Navigating away cancels in-flight cone searches, and an unsent query spends nothing."""
+    quota = AsyncCallQuota(max_calls=1, period=PERIOD, max_wait=None)
+    await quota.acquire()
+
+    for _ in range(5):
+        task = asyncio.create_task(quota.acquire())
+        await asyncio.sleep(0)
+        task.cancel()
+        with pytest.raises(asyncio.CancelledError):
+            await task
+
+    # One period of waiting, not six: the five abandoned reservations were handed back.
+    assert await quota.acquire() <= PERIOD
+
+
+def test_quota_window_is_shared_across_event_loops():
+    """Same process-wide scope as `AsyncRateLimiter`, and for the same reason."""
+    quota = AsyncCallQuota(max_calls=1, period=60.0)
+
+    asyncio.run(quota.acquire())
+
+    with pytest.raises(RateLimitTimeout):
+        asyncio.run(quota.acquire())
+
+
+@pytest.mark.parametrize(("max_calls", "period"), [(0, 1.0), (-1, 1.0), (1, 0.0), (1, -1.0)])
+def test_rejects_a_quota_that_admits_nothing(max_calls, period):
+    with pytest.raises(ValueError):
+        AsyncCallQuota(max_calls=max_calls, period=period)
+
+
 def test_simbad_is_the_catalog_that_is_limited():
     """SIMBAD is the only upstream with a published policy today (issue #51).
 
@@ -206,6 +318,49 @@ def test_simbad_is_the_catalog_that_is_limited():
     assert SIMBAD_QUERY._rate_limiter is not None
     assert SIMBAD_QUERY._rate_limiter.max_calls == SIMBAD_MAX_QUERIES_PER_SECOND
     assert SIMBAD_QUERY._rate_limiter.period == 1.0
+
+
+@pytest.fixture
+def colibri_with_uid(monkeypatch):
+    """Import ``conesearch.colibri`` with a chosen ``ASTRO_COLIBRI_UID``, then put it back.
+
+    The quota is built in the class body, so the uid is read at import time and re-importing is
+    the only way to ask the module about a different one. The instance the app actually uses is
+    the one `conesearch/__init__.py` built at its own import and is not touched by this; the
+    teardown reload restores the module object itself.
+    """
+    module_name = "ztf_viewer.catalogs.conesearch.colibri"
+
+    def load(uid):
+        monkeypatch.setattr("ztf_viewer.config.ASTRO_COLIBRI_UID", uid)
+        return importlib.reload(importlib.import_module(module_name))
+
+    yield load
+
+    monkeypatch.undo()
+    importlib.reload(importlib.import_module(module_name))
+
+
+def test_astro_colibri_is_unmetered_without_an_account(colibri_with_uid):
+    """A per-user allowance needs a user: with no uid we make the older, unmetered call instead.
+
+    Capping that one at 100 a day would take the catalog off the page for the rest of the day on
+    behalf of a ledger nobody is keeping.
+    """
+    assert colibri_with_uid("").ColibriQuery._rate_limiter is None
+
+
+def test_astro_colibri_holds_itself_to_its_daily_allowance(colibri_with_uid):
+    """100 requests per day per registered user (issue #421).
+
+    The window matters as much as the count: the policy is a daily allowance, so the same number
+    over any other period would not be that policy.
+    """
+    quota = colibri_with_uid("test-uid").ColibriQuery._rate_limiter
+
+    assert quota is not None
+    assert quota.max_calls == ASTRO_COLIBRI_MAX_QUERIES_PER_DAY
+    assert quota.period == 86400.0
 
 
 @pytest.fixture

--- a/ztf_viewer/catalogs/conesearch/_base.py
+++ b/ztf_viewer/catalogs/conesearch/_base.py
@@ -22,7 +22,7 @@ from ztf_viewer.catalogs import find_ztf_oid, unavailable_catalogs, unavailable_
 from ztf_viewer.config import TIMEOUT_CONESEARCH_API
 from ztf_viewer.exceptions import CatalogUnavailable, NotFound
 from ztf_viewer.http import get_client
-from ztf_viewer.rate_limit import AsyncRateLimiter, RateLimitTimeout
+from ztf_viewer.rate_limit import AsyncCallQuota, AsyncRateLimiter, RateLimitTimeout
 from ztf_viewer.util import async_timeout, compose_plus_minus_expression, safe_link, to_str
 
 COSMO = FlatLambdaCDM(H0=70, Om0=0.3)
@@ -111,10 +111,12 @@ class _BaseCatalogQuery:
     _value_with_uncertainty_columns: ClassVar[list[ValueWithUncertaintyColumn]] = []
 
     # Self-imposed cap on how often this catalog's upstream may be queried, or None where the
-    # upstream publishes no policy. Set on the subclass, so every instance of it -- in practice
-    # the single singleton in `conesearch/__init__.py` -- shares one schedule. See
-    # `conesearch/simbad.py` and `ztf_viewer/rate_limit.py`.
-    _rate_limiter: ClassVar[AsyncRateLimiter | None] = None
+    # upstream publishes no policy. A pace (`AsyncRateLimiter`) or a budget (`AsyncCallQuota`),
+    # whichever shape that upstream words its policy in; both are acquired the same way below.
+    # Set on the subclass, so every instance of it -- in practice the single singleton in
+    # `conesearch/__init__.py` -- shares one schedule. See `conesearch/simbad.py`,
+    # `conesearch/colibri.py` and `ztf_viewer/rate_limit.py`.
+    _rate_limiter: ClassVar[AsyncRateLimiter | AsyncCallQuota | None] = None
 
     # Column keys with pre-built HTML cell values (see html_from_astropy_table's html_columns).
     # Subclasses with extra HTML columns should extend this, e.g. `frozenset({"__link", "x"})`.

--- a/ztf_viewer/catalogs/conesearch/colibri.py
+++ b/ztf_viewer/catalogs/conesearch/colibri.py
@@ -1,14 +1,53 @@
+"""Astro-COLIBRI cone search.
+
+Astro-COLIBRI restricts its documented ``POST /cone_search`` to registered users and meters it
+at 100 requests per day per account (issue #421,
+https://forum.astro-colibri.science/t/upcoming-api-access-restrictions/169). Working with that
+policy takes both halves: identifying ourselves with a ``uid`` so the calls are attributed to an
+account that is allowed to make them, and holding ourselves to the allowance that account gets.
+
+Both halves need a ``uid``, and the viewer has always queried an older, unauthenticated ``GET``
+form of the same endpoint that is not metered. So `ASTRO_COLIBRI_UID` picks the path: configured,
+we use the documented endpoint under its quota; unset, nothing changes and the legacy call
+carries on. That keeps a deployment with no Astro-COLIBRI account working exactly as it does
+today rather than silently capping it at an allowance nobody is counting. It is not somewhere to
+stay, though: the legacy form is a side door around a policy its owners have already announced,
+undocumented and free to disappear without notice, so a deployment that wants this catalog to
+keep working should register an account and set the variable.
+"""
+
+import datetime
 from typing import ClassVar
 
 import numpy as np
 from astropy.table import Table
 from astropy.time import Time
 
+from ztf_viewer import config
 from ztf_viewer.catalogs.conesearch._base import _BaseCatalogApiQuery
-from ztf_viewer.config import TIMEOUT_CONESEARCH_API
 from ztf_viewer.exceptions import NotFound
 from ztf_viewer.http import get_client
+from ztf_viewer.rate_limit import AsyncCallQuota
 from ztf_viewer.util import safe_link
+
+SECONDS_PER_DAY = 86400.0
+
+#: The widest time window the endpoint accepts, as unix seconds: every event Astro-COLIBRI has.
+#: The upper bound is the end of 32-bit time, which is what the legacy endpoint has always been
+#: asked for here; both forms of the query derive their arguments from these two numbers, so the
+#: window cannot drift between them.
+_DATE_MIN_UNIX = 0
+_DATE_MAX_UNIX = (1 << 31) - 1
+
+
+def _isoformat(unix_seconds: int) -> str:
+    """The same instant as an ISO date, which is what `time_range` takes.
+
+    `datetime` rather than `astropy.time.Time`: ERFA has no leap-second table out to 2038 and
+    warns about the "dubious year" every time it is asked to format one, which is noise on a
+    bound that is deliberately far in the future.
+    """
+    return datetime.datetime.fromtimestamp(unix_seconds, datetime.UTC).strftime("%Y-%m-%dT%H:%M:%S")
 
 
 class ColibriQuery(_BaseCatalogApiQuery):
@@ -32,12 +71,60 @@ class ColibriQuery(_BaseCatalogApiQuery):
     _base_api_url = f"{__root_api_url}/cone_search"
     _declared_html_columns = frozenset({"simbad_url"})  # get_link() below returns plain text
 
+    # The daily allowance that comes with the account we identify as, and nothing to enforce
+    # without one -- see the module docstring. `find()` spends one call from it per uncached cone
+    # search, and a page that arrives with the day's budget gone is told the catalog is
+    # unavailable instead of waiting hours for the window to roll.
+    _rate_limiter: ClassVar[AsyncCallQuota | None] = (
+        AsyncCallQuota(max_calls=config.ASTRO_COLIBRI_MAX_QUERIES_PER_DAY, period=SECONDS_PER_DAY)
+        if config.ASTRO_COLIBRI_UID
+        else None
+    )
+
+    @staticmethod
+    def _post_body(ra, dec, radius_deg):
+        """The documented request body, for the endpoint the rate-limit policy applies to.
+
+        No ``filter``: the API then applies the filter configuration saved in the account's
+        member space, and the account we query as is a deployment's, not a viewer's, so what it
+        has saved is the deployment's choice of what this catalog shows. The filter structure
+        itself is documented only by example in Astro-COLIBRI's notebooks, and an account with
+        nothing saved is answered with ``"No filter and no uid data..."`` rather than results, so
+        setting `ASTRO_COLIBRI_UID` means configuring that account's filters too.
+        """
+        return {
+            "uid": config.ASTRO_COLIBRI_UID,
+            "properties": {"position": {"ra": ra, "dec": dec}, "radius": radius_deg},
+            "time_range": {"min": _isoformat(_DATE_MIN_UNIX), "max": _isoformat(_DATE_MAX_UNIX)},
+        }
+
+    @staticmethod
+    def _legacy_query(ra, dec, radius_deg):
+        """The unauthenticated call this viewer has always made. Dates are in unix milliseconds."""
+        return {
+            "cone": f"[{ra},{dec},{radius_deg}]",
+            "datemin": _DATE_MIN_UNIX * 1000,
+            "datemax": _DATE_MAX_UNIX * 1000,
+        }
+
     async def _api_query_region(self, ra, dec, radius_arcsec):
         radius_deg = radius_arcsec / 3600.0
-        query = {"cone": f"[{ra},{dec},{radius_deg}]", "datemin": 0, "datemax": ((1 << 31) - 1) * 1000}
-        response = await get_client().get(self._get_api_url(query), timeout=TIMEOUT_CONESEARCH_API)
+        client = get_client()
+        if config.ASTRO_COLIBRI_UID:
+            response = await client.post(
+                self._base_api_url,
+                json=self._post_body(ra, dec, radius_deg),
+                timeout=config.TIMEOUT_CONESEARCH_API,
+            )
+        else:
+            response = await client.get(
+                self._get_api_url(self._legacy_query(ra, dec, radius_deg)),
+                timeout=config.TIMEOUT_CONESEARCH_API,
+            )
         self._raise_if_not_ok(response)
         data = response.json()
+        # Both forms answer with the same lists (`voevents`, `sources`, ...), so everything below
+        # is shared.
         vo_events = data["voevents"]
 
         if len(vo_events) == 0:

--- a/ztf_viewer/config.py
+++ b/ztf_viewer/config.py
@@ -16,6 +16,13 @@ TNS_API_URL = os.environ.get("TNS_API_URL", "https://tns.snad.space")
 JS9_URL = os.environ.get("JS9_URL", "https://www.js9.org/js9.html")
 DUSTMAPS_API_URL = os.environ.get("DUSTMAPS_API_URL", "https://dustmaps.snad.space")
 
+# Astro-COLIBRI user id, from the account settings of a registered user. Their documented
+# `POST /cone_search` is restricted to registered users and metered per account, so this is what
+# decides which of the two endpoints `conesearch/colibri.py` queries and whether the daily quota
+# below applies. Empty (the default) keeps the unauthenticated legacy call. A secret: it belongs
+# in the deployment's environment, never in this file.
+ASTRO_COLIBRI_UID = os.environ.get("ASTRO_COLIBRI_UID", "")
+
 # Size of both thread pools the entrypoint installs: asyncio's default executor and anyio's
 # sync-route limiter. Caps how many blocking calls the single event loop can have in flight.
 THREAD_POOL_SIZE = int(os.environ.get("THREAD_POOL_SIZE", "64"))
@@ -69,6 +76,12 @@ SIMBAD_MAX_QUERIES_PER_SECOND = 8
 # itself gets from `_BaseCatalogQuery`'s timeout decorator: a request that has already waited a
 # full query's worth of time for a slot is one whose user is unlikely to still be waiting.
 SIMBAD_RATE_LIMIT_MAX_WAIT = 10.0
+# Astro-COLIBRI grants each registered user 100 cone searches per day and asks anyone who needs
+# more to get in touch (https://astro-colibri.science/apidoc, issue #421). A budget rather than a
+# rate, so it is spent at whatever speed traffic arrives and refused once gone -- see
+# `AsyncCallQuota`. Only applies when `ASTRO_COLIBRI_UID` identifies the account it is metered
+# against; only uncached cone searches spend it, as `find()` is `@cache()`d.
+ASTRO_COLIBRI_MAX_QUERIES_PER_DAY = 100
 
 # Must stay well under the deployed proxy's live 60s read-timeout default, in ms.
 WEBSOCKET_HEARTBEAT_INTERVAL_MS = int(os.environ.get("WEBSOCKET_HEARTBEAT_INTERVAL_MS", "20000"))

--- a/ztf_viewer/rate_limit.py
+++ b/ztf_viewer/rate_limit.py
@@ -1,4 +1,19 @@
-"""A rate limiter that paces outbound queries to a single upstream.
+"""Rate limiters that keep outbound queries to a single upstream inside its published policy.
+
+Two shapes, because upstreams publish two different kinds of limit:
+
+* :class:`AsyncRateLimiter` — a **pace**: at most ``max_calls`` per ``period``, spread evenly.
+  For a policy worded as a rate ("no more than 8 queries in the same second"), where the window
+  is short and going over it is what gets a client blacklisted.
+* :class:`AsyncCallQuota` — a **budget**: at most ``max_calls`` per rolling ``period``, spent in
+  whatever pattern the traffic happens to take. For a policy worded as an allowance ("100
+  requests per day"), where the window is far longer than any request can wait.
+
+Both raise :class:`RateLimitTimeout` for a caller that would have to wait longer than its budget
+allows, and :meth:`ztf_viewer.catalogs.conesearch._base._BaseCatalogQuery._wait_for_rate_limit`
+turns that into a shed query. Which of the two a catalog wants is a property of the upstream's
+policy, so the choice lives next to that catalog — see ``conesearch/simbad.py`` (a pace) and
+``conesearch/colibri.py`` (a budget).
 
 Some upstreams publish a query-rate policy and blacklist callers who ignore it. SIMBAD asks for
 no more than 8 queries in the same second and answers an over-eager client with an HTML page
@@ -38,6 +53,7 @@ times the rate and would need the schedule in shared storage (Redis) instead.
 import asyncio
 import threading
 import time
+from collections import deque
 
 
 class RateLimitTimeout(Exception):
@@ -134,3 +150,115 @@ class AsyncRateLimiter:
         with self._lock:
             if self._next_slot == slot + self._min_interval:
                 self._next_slot = slot
+
+
+class AsyncCallQuota:
+    """Admits at most ``max_calls`` acquisitions in any window of ``period``, in any pattern.
+
+    A budget rather than a pace. Astro-COLIBRI grants each registered user 100 cone searches a
+    day (https://astro-colibri.science/apidoc), which is not a statement about how fast queries
+    may be sent: spacing them evenly would put every call 864 seconds behind the last and leave a
+    lone user waiting a quarter of an hour for a catalog nobody else asked for that day, while
+    still spending exactly the same 100 calls. So this one lets traffic spend the allowance at
+    whatever rate it arrives, and refuses only once the allowance is actually gone.
+
+    That refusal, not a wait, is the point. ``max_wait`` therefore defaults to ``0.0`` here where
+    :class:`AsyncRateLimiter` defaults to no limit: the next free slot in a day-long window is
+    typically hours away, and a web request that waited for it would be answering a user who
+    left long ago. Shedding immediately at least tells the page the catalog is unavailable while
+    someone is still there to read it.
+
+    The window is a rolling one — the slot spent by the first call of the day comes back exactly
+    ``period`` after that call, not at a fixed daily reset the upstream never promised.
+
+    Shares :class:`AsyncRateLimiter`'s process-wide scope and its threading lock, for the reasons
+    in this module's docstring; the same caveat about multiple worker processes applies, plus one
+    of its own. A quota is spent per *account*, and a restart forgets what this process spent:
+    both are cases of the upstream's counter running ahead of ours, so ``max_calls`` is better
+    read as our own ceiling than as a guarantee about the upstream's ledger.
+
+    Args:
+        max_calls: how many acquisitions one rolling ``period`` may contain.
+        period: length of that window, in seconds.
+        max_wait: how long :meth:`acquire` may put a caller to sleep before giving up with
+            :class:`RateLimitTimeout` instead. ``None`` waits however long the window demands.
+    """
+
+    def __init__(self, max_calls: int, period: float, max_wait: float | None = 0.0):
+        if max_calls < 1:
+            raise ValueError("max_calls must be at least 1")
+        if period <= 0:
+            raise ValueError("period must be positive")
+        self._max_calls = max_calls
+        self._period = period
+        self._max_wait = max_wait
+        # When each admitted call is considered sent, oldest first. Entries older than one period
+        # are dropped on the next acquisition, so this holds `max_calls` of them plus one per
+        # caller currently asleep waiting for a slot.
+        self._slots: deque[float] = deque()
+        self._lock = threading.Lock()
+
+    @property
+    def max_calls(self) -> int:
+        return self._max_calls
+
+    @property
+    def period(self) -> float:
+        return self._period
+
+    async def acquire(self, max_wait: float | None = None) -> float:
+        """Spend one call from the budget, and return how long that took, in seconds.
+
+        Returns ``0.0`` while the allowance holds, which is the whole of the normal case. Once it
+        is gone, the wait is until the oldest call in the window falls out of it, and with the
+        default ``max_wait`` that raises :class:`RateLimitTimeout` rather than sleeping.
+        """
+        if max_wait is None:
+            max_wait = self._max_wait
+
+        with self._lock:
+            now = time.monotonic()
+            # Calls that have fallen out of the window no longer count against it. Only ever
+            # from the left: `_slots` is sorted (see below), so the first entry still inside the
+            # window ends the pruning.
+            while self._slots and self._slots[0] <= now - self._period:
+                self._slots.popleft()
+
+            if len(self._slots) < self._max_calls:
+                slot = now
+            else:
+                # The window is full, so this call has to wait for the oldest of the `max_calls`
+                # most recent ones to leave it. Counted from the right rather than taking
+                # `_slots[0]`, because entries reserved by callers already asleep are in here
+                # too, and they are what the next slot has to be measured against.
+                slot = self._slots[-self._max_calls] + self._period
+            wait = slot - now
+            if max_wait is not None and wait > max_wait:
+                raise RateLimitTimeout(
+                    f"the {self._max_calls}-call budget for the last {self._period:.0f}s is spent; "
+                    f"the next slot is {wait:.0f}s away, over the {max_wait:.0f}s budget"
+                )
+            # `slot` is never earlier than `_slots[-1]`, so appending keeps the deque sorted:
+            # it is either `now` (which only grows) or a full window's worth after an entry that
+            # is itself no earlier than the one `max_calls` before the end.
+            self._slots.append(slot)
+
+        if wait > 0:
+            try:
+                await asyncio.sleep(wait)
+            except asyncio.CancelledError:
+                self._release(slot)
+                raise
+        return wait
+
+    def _release(self, slot: float) -> None:
+        """Give back a slot reserved by a caller that never sent its query.
+
+        Unlike :meth:`AsyncRateLimiter._release`, this is unconditional: dropping an entry can
+        only ever let a later call go *earlier*, never sooner than the window allows, because
+        every remaining entry keeps the position it was given. Only the last entry can be ours —
+        a later caller would have appended after it.
+        """
+        with self._lock:
+            if self._slots and self._slots[-1] == slot:
+                self._slots.pop()


### PR DESCRIPTION
Astro-COLIBRI restricts its documented POST /cone_search to registered users and meters it at 100 requests per day per account. The viewer has been calling an older, unauthenticated GET form of the endpoint, which is a side door around a policy its owners have already announced.

Set ASTRO_COLIBRI_UID to a registered account's user id and the cone search goes to the documented endpoint, identified by that uid and held to the allowance the account gets; leave it unset and the legacy call is made exactly as before, since a per-user quota has nothing to count against without a user.

The allowance is a budget, not a rate, so the new AsyncCallQuota spends it at whatever speed traffic arrives and refuses once it is gone, rather than pacing calls 864 seconds apart the way AsyncRateLimiter would. A refused cone search leaves the catalog unavailable for that page instead of parking a request for hours on a window that rolls once a day.

Closes #421


Claude-Session: https://claude.ai/code/session_01A1AUCG38DYPKj8PzyEgxJQ