### PR TITLE
Clean up the light-curve point tooltip

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@ Version schema is `year.month.num_release`
 - Simbad cross-match works again: astroquery ≥0.4.8 returns `ra`/`dec` in degrees instead of `RA`/`DEC` in hours, so every Simbad cone search raised `KeyError` and the catalog was silently absent from every object page
 - Simbad rows are no longer duplicated once per object type, distance and variability measurement, and each measurement group now shows the one Simbad ranks first
 - Simbad "Variable type" is populated again, and its period is back in the summary and the cross-match table
+- Light-curve tooltip no longer repeats the photometric error https://github.com/snad-space/ztf-viewer/issues/745
+- Folded plot shows asymmetric diff mag errors
 
 ### Added
 

--- a/tests/pages/test_viewer.py
+++ b/tests/pages/test_viewer.py
@@ -916,11 +916,14 @@ def test_crosshair_callback_javascript_has_the_indexes_substituted():
 # ---------------------------------------------------------------------------------------------
 #
 # The hover rows are built by plotly express out of the x/y columns, the `color`/`symbol`/`size`
-# dimensions and `hover_data`, in that order. Both of the things pinned here are consequences of
-# that ordering rather than of anything written literally in the template, so they can regress
-# silently: the brightness error has to sit right below the brightness it belongs to, and
-# `mark_size` -- which encodes whether the point belongs to the current OID, not anything
-# measured -- must not show up as a data row at all.
+# dimensions and `hover_data`, in that order. Everything pinned here is a consequence of that
+# ordering rather than of anything written literally in the template, so it can regress silently.
+#
+# The brightness error is not a row of its own: plotly.js appends the error bars to the brightness
+# value itself (`mag=18.000 ± 0.050`), so listing the error columns in `hover_data` on top of that
+# repeats them, detached from the value they belong to -- issue #745. `mark_size`, which encodes
+# whether the point belongs to the current OID rather than anything measured, must not show up as
+# a data row either.
 
 set_figure = inspect.unwrap(viewer.set_figure)
 
@@ -931,7 +934,7 @@ def _hover_rows(figure) -> list[str]:
     return [row.split("=", maxsplit=1)[0] for row in template.split("<br>")]
 
 
-async def _figure_hover_rows(brightness_type="mag", lc_type="full", period=None):
+async def _figure(brightness_type="mag", lc_type="full", period=None):
     lc = [
         {
             "mjd": 58000.0 + i,
@@ -972,18 +975,53 @@ async def _figure_hover_rows(brightness_type="mag", lc_type="full", period=None)
             name_model=None,
             fit_params=None,
         )
-    return _hover_rows(figure)
+    return figure
 
 
-async def test_set_figure_hover_puts_the_error_right_after_the_brightness():
-    assert await _figure_hover_rows() == ["filter", "oid", "mjd − 58000", "mag", "mag error", "date"]
+async def _figure_hover_rows(**kwargs):
+    return _hover_rows(await _figure(**kwargs))
 
 
-async def test_set_figure_hover_of_a_folded_curve_puts_the_error_right_after_the_brightness():
-    # The folded branch passes no `labels` for the brightness columns, so they keep their raw
-    # names here -- what is pinned is the position of the error row, not how it is spelled.
+async def test_set_figure_hover_ends_at_the_brightness_and_the_date():
+    assert await _figure_hover_rows() == ["filter", "oid", "mjd − 58000", "mag", "date"]
+
+
+async def test_set_figure_hover_of_a_folded_curve_keeps_the_folded_times_after_the_brightness():
     rows = await _figure_hover_rows(lc_type="folded", period=1.5)
-    assert rows == ["filter", "oid", "phase", "mag", "magerr", "folded_time", "mjd − 58000", "date"]
+    assert rows == ["filter", "oid", "phase", "mag", "folded time", "mjd − 58000", "date"]
+
+
+@pytest.mark.parametrize("lc_type,period", [("full", None), ("folded", 1.5)])
+@pytest.mark.parametrize("brightness_type", ["mag", "flux", "diffmag", "diffflux"])
+async def test_set_figure_hover_does_not_repeat_the_error_columns(brightness_type, lc_type, period):
+    """The error bars are rendered by plotly.js next to the brightness value, so a row of their
+    own is a duplicate -- and the one for an asymmetric error shows only half of it."""
+    figure = await _figure(brightness_type=brightness_type, lc_type=lc_type, period=period)
+
+    for column, label in viewer.BRIGHTERR_LABELS.items():
+        assert column not in figure.data[0].hovertemplate
+        assert label not in figure.data[0].hovertemplate
+
+
+@pytest.mark.parametrize("lc_type,period", [("full", None), ("folded", 1.5)])
+async def test_set_figure_keeps_asymmetric_diffmag_errors(lc_type, period):
+    """`diffmag` is the one brightness with a separate minus error; the folded branch used to drop
+    it and mirror the plus one instead."""
+    figure = await _figure(brightness_type="diffmag", lc_type=lc_type, period=period)
+
+    error_y = figure.data[0].error_y
+    assert error_y.arrayminus is not None
+    assert not error_y.symmetric
+
+
+@pytest.mark.parametrize("lc_type,period", [("full", None), ("folded", 1.5)])
+@pytest.mark.parametrize("brightness_type", ["mag", "flux", "diffmag", "diffflux"])
+async def test_set_figure_rounds_the_brightness_in_the_hover(brightness_type, lc_type, period):
+    """`yaxis.hoverformat` is what rounds the error bars too -- they are formatted by plotly.js
+    with the y axis' hover format, not by anything in the template."""
+    figure = await _figure(brightness_type=brightness_type, lc_type=lc_type, period=period)
+
+    assert figure.layout.yaxis.hoverformat
 
 
 @pytest.mark.parametrize("brightness_type", ["mag", "flux", "diffmag", "diffflux"])

--- a/ztf_viewer/pages/viewer.py
+++ b/ztf_viewer/pages/viewer.py
@@ -107,6 +107,13 @@ BRIGHTERR_LABELS = {
     "diffmagerr_minus": "diff mag error -",
     "difffluxerr_Jy": "diff flux error, Jy",
 }
+# d3 format for the brightness value and its error bars in the tooltip, see `layout.yaxis.hoverformat`
+BRIGHT_HOVER_FORMATS = {
+    "mag": ".3f",
+    "flux_Jy": ".4g",
+    "diffmag": ".3f",
+    "diffflux_Jy": ".4g",
+}
 
 
 def parse_pathname(pathname):
@@ -183,6 +190,37 @@ def pick_fits_observation(own_lc: list[dict], fits_param: str) -> dict | None:
 # folded light curve. The cross-hair reads coordinates from here: plotly sends `x`/`y` as base64.
 CUSTOM_DATA = ["mjd", "oid", "fieldid", "rcid", "filter"]
 CUSTOM_DATA_X, CUSTOM_DATA_Y = len(CUSTOM_DATA), len(CUSTOM_DATA) + 1
+
+
+def lc_hover_layout(lc_type, bright, brighterr, brighterr_minus):
+    """Labels and `hover_data` for the light-curve scatter tooltip.
+
+    Plotly appends the error bar values to the brightness value in the tooltip itself, so the error columns must not
+    be listed in `hover_data`: they would be repeated there, detached from the value they belong to.
+    """
+    labels = {
+        f"mjd_{MJD_OFFSET}": f"mjd − {MJD_OFFSET}",
+        "folded_time": "folded time",
+        bright: BRIGHT_LABELS[bright],
+        brighterr: BRIGHTERR_LABELS[brighterr],
+    }
+    if brighterr_minus is not None:
+        labels[brighterr_minus] = BRIGHTERR_LABELS[brighterr_minus]
+
+    if lc_type == "full":
+        hover_data = {"mark_size": False, f"mjd_{MJD_OFFSET}": ":.5f", "date": True}
+    elif lc_type == "folded":
+        hover_data = {
+            "mark_size": False,
+            "phase": ":.5f",
+            "folded_time": ":.5f",
+            f"mjd_{MJD_OFFSET}": ":.5f",
+            "date": True,
+        }
+    else:
+        raise ValueError(f"{lc_type = } is unknown")
+
+    return labels, hover_data
 
 
 async def fits_children_for_observation(mjd, oid, fieldid, rcid, fltr, dr):
@@ -1861,6 +1899,7 @@ async def set_figure(
     else:
         raise ValueError(f'Wrong brightness_type "{brightness_type}"')
     df = pd.DataFrame.from_records(lcs)
+    labels, hover_data = lc_hover_layout(lc_type, bright, brighterr, brighterr_minus)
     if lc_type == "full":
         figure = px.scatter(
             df,
@@ -1870,17 +1909,12 @@ async def set_figure(
             error_y_minus=brighterr_minus,
             color="filter",
             range_y=range_y,
-            labels={
-                f"mjd_{MJD_OFFSET}": f"mjd − {MJD_OFFSET}",
-                bright: BRIGHT_LABELS[bright],
-                brighterr: BRIGHTERR_LABELS[brighterr],
-            }
-            | ({} if brighterr_minus is None else {brighterr_minus: BRIGHTERR_LABELS[brighterr_minus]}),
+            labels=labels,
             color_discrete_map=FILTER_COLORS,
             symbol="oid",
             size="mark_size",
             size_max=MARKER_SIZE,
-            hover_data={brighterr: True, "mark_size": False, f"mjd_{MJD_OFFSET}": ":.5f", "date": True},
+            hover_data=hover_data,
             custom_data=CUSTOM_DATA + [f"mjd_{MJD_OFFSET}", bright],
             render_mode=render_mode,
         )
@@ -1890,21 +1924,15 @@ async def set_figure(
             x="phase",
             y=bright,
             error_y=brighterr,
-            error_y_minus=None,
+            error_y_minus=brighterr_minus,
             color="filter",
             range_y=range_y,
-            labels={f"mjd_{MJD_OFFSET}": f"mjd − {MJD_OFFSET}"},
+            labels=labels,
             color_discrete_map=FILTER_COLORS,
             symbol="oid",
             size="mark_size",
             size_max=MARKER_SIZE,
-            hover_data={
-                brighterr: True,
-                "mark_size": False,
-                "folded_time": True,
-                f"mjd_{MJD_OFFSET}": ":.5f",
-                "date": True,
-            },
+            hover_data=hover_data,
             custom_data=CUSTOM_DATA + ["phase", bright],
             range_x=[0.0, 1.0],
             render_mode=render_mode,
@@ -1946,6 +1974,8 @@ async def set_figure(
     )
     fw = go.FigureWidget(figure)
     fw.layout.hovermode = "closest"
+    # Applies to both the brightness value and the error bars appended to it in the tooltip
+    fw.layout.yaxis.hoverformat = BRIGHT_HOVER_FORMATS[bright]
     fw.layout.xaxis.title.standoff = 0
     fw.layout.yaxis.title.standoff = 0
     fw.layout.legend.orientation = "h"


### PR DESCRIPTION
Plotly.js already appends the error bars to the brightness value in the hover box (`diff mag=19.813 +0.091 / -0.084`), so also listing the error columns in `hover_data` printed them a second time, at the bottom of the box, detached from the value they belong to -- and for the asymmetric `diffmag` error only the positive half was shown there.

Drop the error columns from `hover_data`, and set `yaxis.hoverformat` so the brightness and the error bars plotly.js formats with it are rounded instead of printed at full float precision.

While here, make the folded plot match the full one: it now shares the same `labels`, so its axes and hover rows are spelled "diff mag" rather than "diffmag"; it rounds phase and folded time; and it passes `error_y_minus`, which it used to drop, mirroring the positive error onto the negative side.

Fixes https://github.com/snad-space/ztf-viewer/issues/745


Claude-Session: https://claude.ai/code/session_01A1AUCG38DYPKj8PzyEgxJQ