### PR TITLE
Explain multiple OIDs per star on the search page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ Version schema is `year.month.num_release`
 
 - A dashed cross-hair marks the observation whose FITS image is shown, and the FITS block names that observation's filter and MJD https://github.com/snad-space/ztf-viewer/issues/719
 - The URL follows the MJD range, the new `?lc=antares,panstarrs,gaia` external light curves and the FITS observation, which `?fits=` now also takes as an MJD, so a copied link reproduces the page https://github.com/snad-space/ztf-viewer/issues/329
+- A note on the cone-search results page explains why one star or transient is listed under several OIDs https://github.com/snad-space/ztf-viewer/issues/559
 
 ### Added
 

--- a/tests/pages/test_search.py
+++ b/tests/pages/test_search.py
@@ -1,0 +1,75 @@
+"""Tests for `ztf_viewer.pages.search.get_layout`.
+
+`get_layout` reaches exactly one upstream, `find_ztf_circle.find`, so both of its branches are
+reachable with a stub and no network.
+"""
+
+from unittest.mock import patch
+
+from astropy.coordinates import SkyCoord
+
+from ztf_viewer import config
+
+# See the note in `tests/pages/test_viewer.py`: `ztf_viewer.catalogs` connects to Redis at import
+# time when configured for it, which is before `tests/conftest.py` gets a chance to intervene.
+config.CACHE_TYPE = "memory"
+config.UNAVAILABLE_CATALOGS_CACHE_TYPE = "memory"
+
+from ztf_viewer.exceptions import NotFound
+from ztf_viewer.pages import search
+
+COORD = SkyCoord(10.0, 20.0, unit="deg", frame="icrs")
+
+_STUB_CIRCLE = {
+    "700207400012345": {
+        "separation": 0.12,
+        "meta": {"filter": "zr", "ngoodobs": 300, "duration": 1500.0},
+    },
+    "700207300054321": {
+        "separation": 0.31,
+        "meta": {"filter": "zg", "ngoodobs": 250, "duration": 1450.0},
+    },
+}
+
+
+def _leaves(component):
+    """The component tree flattened to its leaf children, in render order."""
+    children = getattr(component, "children", component)
+    if not isinstance(children, list):
+        return [children]
+    return [leaf for child in children for leaf in _leaves(child)]
+
+
+async def test_get_layout_explains_multiple_oids_above_the_table():
+    async def fake_find(ra, dec, radius_arcsec, dr):
+        return dict(_STUB_CIRCLE)
+
+    with patch.object(search.find_ztf_circle, "find", fake_find):
+        layout = await search.get_layout(COORD, 1.0, "dr24")
+
+    _heading, note, table = _leaves(layout)
+    assert note == search.MULTIPLE_OIDS_NOTE
+    # The note is only useful next to the rows it explains, and only if it precedes them.
+    assert "700207400012345" in table
+
+
+async def test_get_layout_single_result_has_no_note():
+    async def fake_find(ra, dec, radius_arcsec, dr):
+        return {"700207400012345": dict(_STUB_CIRCLE["700207400012345"])}
+
+    with patch.object(search.find_ztf_circle, "find", fake_find):
+        layout = await search.get_layout(COORD, 1.0, "dr24")
+
+    heading, table = _leaves(layout)
+    assert heading.startswith("Objects inside cone")
+    assert "700207400012345" in table
+
+
+async def test_get_layout_404_has_no_note():
+    async def fake_find(ra, dec, radius_arcsec, dr):
+        raise NotFound
+
+    with patch.object(search.find_ztf_circle, "find", fake_find):
+        layout = await search.get_layout(COORD, 1.0, "dr24")
+
+    assert search.MULTIPLE_OIDS_NOTE not in _leaves(layout)

--- a/ztf_viewer/assets/style.css
+++ b/ztf_viewer/assets/style.css
@@ -15,6 +15,15 @@
     font-size: large;
 }
 
+/* Explanatory prose next to a result, not a result itself: smaller and quieter than the
+   surrounding content, and narrow enough to stay readable on a wide screen. */
+.note {
+    font-size: 90%;
+    color: #444;
+    max-width: 60em;
+    margin-bottom: 1.5rem;
+}
+
 /* Links
 –––––––––––––––––––––––––––––––––––––––––––––––––– */
 a {

--- a/ztf_viewer/pages/search.py
+++ b/ztf_viewer/pages/search.py
@@ -13,6 +13,14 @@ COLUMNS = {
     "duration": "Duration, days",
 }
 
+# A cone search usually returns several rows for what is a single star or transient, which reads
+# as a bug unless you know how ZTF data releases are built. Say it on the page instead.
+MULTIPLE_OIDS_NOTE = (
+    "ZTF DR objects are based on the ZTF reference catalog, where a celestial source may be "
+    "represented by multiple objects (OIDs), one per a unique set of passband, field ID and CCD "
+    "quadrant. Several of the OIDs listed here are therefore likely to be the same source."
+)
+
 
 async def get_layout(coordinates, radius_arcsec, dr):
     ra = coordinates.ra.to_value("deg")
@@ -36,6 +44,8 @@ async def get_layout(coordinates, radius_arcsec, dr):
     layout = html.Div(
         [
             html.H1(f"Objects inside cone {cone_str}"),
+            # Nothing to explain when the cone holds a single OID.
+            *([html.P(MULTIPLE_OIDS_NOTE, className="note", id="multiple-oids-note")] if len(j) > 1 else []),
             dcc.Markdown(
                 html_from_astropy_table(table, COLUMNS, html_columns=frozenset({"oid"})),
                 dangerously_allow_html=True,


### PR DESCRIPTION
A cone search usually returns several rows for one star or transient, because a ZTF OID names a single light curve: one passband, one CCD quadrant, one field. Without that context the result table reads as duplicates.

Add a short note above the results saying so, shown only when the cone holds more than one OID, plus a `.note` style for explanatory prose.

Closes #559


Claude-Session: https://claude.ai/code/session_01A1AUCG38DYPKj8PzyEgxJQ