### PR TITLE
Pin uv, and reclaim images on the dev host

### DIFF
--- a/.github/workflows/deploy-dev.yml
+++ b/.github/workflows/deploy-dev.yml
@@ -67,10 +67,12 @@ jobs:
     - name: Stop
       run: |
         docker context use dev-snad
-        docker compose -f docker-compose-github.yml -p ${SUBDOMAIN} down
+        docker compose -f docker-compose-github.yml -p ${SUBDOMAIN} down --rmi local
+        docker image prune -af --filter until=336h
     - name: Start
       if: ${{ github.event.pull_request.state != 'closed' }}
       run: |
         docker context use dev-snad
         docker compose -f docker-compose-github.yml -p ${SUBDOMAIN} build --build-arg GITHUB_SHA
         docker compose -f docker-compose-github.yml -p ${SUBDOMAIN} up -d
+        docker image prune -af --filter until=336h

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,10 +4,6 @@ FROM python:3.14-bookworm
 ENV TZ=Europe/Moscow
 RUN ln -snf /usr/share/zoneinfo/$TZ /etc/localtime && echo $TZ > /etc/timezone
 
-# Install uv
-COPY --from=ghcr.io/astral-sh/uv:latest /uv /uvx /usr/local/bin/
-ENV UV_COMPILE_BYTECODE=1
-
 # Install JS9 for FITS viewer
 # Original repo: https://github.com/ericmandel/js9
 ARG JS9_VERSION=3.9
@@ -30,6 +26,10 @@ RUN echo "main_memory = 50000000" > /etc/texmf/texmf.d/10main_memory.cnf \
     && update-texmf \
     && texhash \
     && fmtutil-sys --all || test 1
+
+# Install uv
+COPY --from=ghcr.io/astral-sh/uv:0.12.11 /uv /uvx /usr/local/bin/
+ENV UV_COMPILE_BYTECODE=1
 
 # Install dependencies, but not the project itself yet, so this layer stays cached
 # across source changes


### PR DESCRIPTION
`COPY --from=ghcr.io/astral-sh/uv:latest` sat above the JS9 build and the TeX Live install, so every uv release (roughly weekly, and unrelated to this project) invalidated most of the image. Pin uv and move it below both layers.

On the dev host, `docker compose down` left the stack's image behind, so one multi-GB image accumulated per deployment until the disk filled and `Start` began failing. Use `down --rmi local`, and prune images older than two weeks after both `down` and `up`.


Claude-Session: https://claude.ai/code/session_01A1AUCG38DYPKj8PzyEgxJQ