### PR TITLE
Add a CSV download link for the light-curve features

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ Version schema is `year.month.num_release`
 - A dashed cross-hair marks the observation whose FITS image is shown, and the FITS block names that observation's filter and MJD https://github.com/snad-space/ztf-viewer/issues/719
 - The URL follows the MJD range, the new `?lc=antares,panstarrs,gaia` external light curves and the FITS observation, which `?fits=` now also takes as an MJD, so a copied link reproduces the page https://github.com/snad-space/ztf-viewer/issues/329
 - A note on the cone-search results page explains why one star or transient is listed under several OIDs https://github.com/snad-space/ztf-viewer/issues/559
+- Features are downloadable as CSV, for the feature-extraction version and MJD range the Features section is showing https://github.com/snad-space/ztf-viewer/issues/71
 
 ### Added
 

--- a/tests/pages/test_features_csv.py
+++ b/tests/pages/test_features_csv.py
@@ -1,0 +1,107 @@
+"""The features CSV route: rendering, query-parameter plumbing and error mapping.
+
+Hermetic -- `light_curve_features` is stubbed out, so nothing here talks to the feature
+extraction service. The endpoint is called directly rather than through a `TestClient`: building
+one imports `ztf_viewer.__main__` and runs the ASGI lifespan, which registers Dash's `{path:path}`
+catch-all on the shared app (see `tests/test_golden_http.py`), and none of that is needed to pin
+what this module authors.
+"""
+
+from types import SimpleNamespace
+from unittest.mock import patch
+
+import pytest
+from starlette.datastructures import QueryParams
+
+from ztf_viewer import config
+
+# `ztf_viewer.catalogs` connects to Redis at import time unless told otherwise, and `lc_features`
+# pulls it in. `tests/conftest.py`'s per-test hook runs too late for a collection-time import.
+config.CACHE_TYPE = "memory"
+config.UNAVAILABLE_CATALOGS_CACHE_TYPE = "memory"
+
+from ztf_viewer.exceptions import NotFound
+from ztf_viewer.pages import features_csv
+
+DR = "dr24"
+OID = 633207400004730
+
+FEATURES = {"amplitude": 0.5, "beyond_1_std": 0.25, "anderson_darling_normal": 1.5}
+
+
+def _request(query=""):
+    return SimpleNamespace(query_params=QueryParams(query))
+
+
+def test_features_to_csv_is_sorted_and_has_a_header():
+    csv = features_csv.features_to_csv(FEATURES)
+    assert csv.splitlines() == [
+        "feature,value",
+        "amplitude,0.5",
+        "anderson_darling_normal,1.5",
+        "beyond_1_std,0.25",
+    ]
+
+
+def test_features_to_csv_of_no_features():
+    assert features_csv.features_to_csv({}) == "feature,value\r\n"
+
+
+async def test_response_features_csv():
+    async def fake_features(oid, dr, version, min_mjd=None, max_mjd=None):
+        return FEATURES
+
+    with patch.object(features_csv, "light_curve_features", fake_features):
+        response = await features_csv.response_features_csv(DR, OID, _request())
+
+    assert response.status_code == 200
+    assert response.media_type == "text/csv"
+    assert response.headers["content-disposition"] == f"attachment; filename={OID}_features.csv"
+    assert response.body.decode().startswith("feature,value")
+
+
+async def test_response_features_csv_passes_query_parameters_through():
+    calls = []
+
+    async def fake_features(oid, dr, version, min_mjd=None, max_mjd=None):
+        calls.append((oid, dr, version, min_mjd, max_mjd))
+        return FEATURES
+
+    with patch.object(features_csv, "light_curve_features", fake_features):
+        await features_csv.response_features_csv(DR, OID, _request("version=v0.2&min_mjd=58000.5&max_mjd=59000"))
+
+    assert calls == [(OID, DR, "v0.2", 58000.5, 59000.0)]
+
+
+async def test_response_features_csv_defaults_to_the_latest_version_and_no_mjd_limits():
+    calls = []
+
+    async def fake_features(oid, dr, version, min_mjd=None, max_mjd=None):
+        calls.append((version, min_mjd, max_mjd))
+        return FEATURES
+
+    with patch.object(features_csv, "light_curve_features", fake_features):
+        await features_csv.response_features_csv(DR, OID, _request())
+
+    assert calls == [("latest", None, None)]
+
+
+@pytest.mark.parametrize("query", ["min_mjd=not-a-number", "max_mjd=not-a-number"])
+async def test_response_features_csv_rejects_a_non_float_mjd(query):
+    async def fake_features(oid, dr, version, min_mjd=None, max_mjd=None):
+        raise AssertionError("must not be called for an invalid query parameter")
+
+    with patch.object(features_csv, "light_curve_features", fake_features):
+        response = await features_csv.response_features_csv(DR, OID, _request(query))
+
+    assert response.status_code == 400
+
+
+async def test_response_features_csv_of_an_unknown_object():
+    async def fake_features(oid, dr, version, min_mjd=None, max_mjd=None):
+        raise NotFound
+
+    with patch.object(features_csv, "light_curve_features", fake_features):
+        response = await features_csv.response_features_csv(DR, OID, _request())
+
+    assert response.status_code == 404

--- a/tests/pages/test_viewer.py
+++ b/tests/pages/test_viewer.py
@@ -1027,3 +1027,22 @@ async def test_set_figure_rounds_the_brightness_in_the_hover(brightness_type, lc
 @pytest.mark.parametrize("brightness_type", ["mag", "flux", "diffmag", "diffflux"])
 async def test_set_figure_hover_never_shows_mark_size(brightness_type):
     assert "mark_size" not in await _figure_hover_rows(brightness_type=brightness_type)
+
+
+def test_set_features_csv_link_bare():
+    assert viewer.set_features_csv_link(1, "dr24", None, None, None) == "/dr24/features/1"
+
+
+def test_set_features_csv_link_carries_the_version_and_the_mjd_range():
+    """The link must download exactly what the Features section shows, so every input the
+    features callback reads has to end up in the query."""
+    url = viewer.set_features_csv_link(1, "dr24", "v0.2", 58000.5, 59000.0)
+
+    assert url.startswith("/dr24/features/1?")
+    assert sorted(url.split("?", 1)[1].split("&")) == ["max_mjd=59000.0", "min_mjd=58000.5", "version=v0.2"]
+
+
+def test_set_features_csv_link_of_an_empty_mjd_range_prevents_update():
+    """Matches `set_features_list`: an inverted range is a half-typed input, not a new link."""
+    with pytest.raises(PreventUpdate):
+        viewer.set_features_csv_link(1, "dr24", "latest", 59000.0, 58000.0)

--- a/tests/test_sync_callbacks.py
+++ b/tests/test_sync_callbacks.py
@@ -30,6 +30,7 @@ _ALLOWED_SYNC_CALLBACKS = {
     "show_fold_period_layout",
     "show_ref_mag_layout",
     "set_csv_link",
+    "set_features_csv_link",
     "set_figure_link",
     "convert_astro_colibri_search_radius_to_arcsec",
     "dr_from_url",

--- a/ztf_viewer/__main__.py
+++ b/ztf_viewer/__main__.py
@@ -23,6 +23,7 @@ from ztf_viewer.config import THREAD_POOL_SIZE
 from ztf_viewer.exceptions import CatalogUnavailable, NotFound, UnAuthorized
 from ztf_viewer.http import aclose_client
 from ztf_viewer.pages import favicon as _
+from ztf_viewer.pages import features_csv as _  # noqa: F811
 from ztf_viewer.pages import figure as _  # noqa: F811
 from ztf_viewer.pages import lc_csv as _  # noqa: F811,F401
 from ztf_viewer.pages.akb_table import get_layout as get_anomalies_layout

--- a/ztf_viewer/pages/features_csv.py
+++ b/ztf_viewer/pages/features_csv.py
@@ -1,0 +1,54 @@
+"""Light-curve feature CSV download route.
+
+Kept out of `lc_csv.py`: the features come from the feature-extraction service rather than from
+a light-curve catalog, and unlike a light curve they are a flat name -> value mapping, so the
+CSV is two columns rather than one row per observation.
+"""
+
+import csv
+from io import StringIO
+
+from fastapi import Request
+
+from ztf_viewer.app import app
+from ztf_viewer.exceptions import NotFound
+from ztf_viewer.lc_features import light_curve_features
+from ztf_viewer.web import csv_response, error_response, query_args
+
+
+def features_to_csv(features: dict) -> str:
+    """Render a feature mapping as a two-column CSV, sorted by feature name."""
+    string_io = StringIO()
+    writer = csv.writer(string_io, lineterminator="\r\n")
+    writer.writerow(["feature", "value"])
+    writer.writerows(sorted(features.items()))
+    return string_io.getvalue()
+
+
+@app.server.api_route("/{dr}/features/{oid}")
+async def response_features_csv(dr: str, oid: int, request: Request):
+    """Download the light-curve features of a single OID as CSV.
+
+    `version` selects the feature-extraction API version, mirroring the dropdown on the viewer
+    page; `min_mjd`/`max_mjd` restrict the light curve the features are computed from, exactly
+    as they do for the light-curve CSV.
+    """
+    args = query_args(request)
+
+    version = args.get("version", "latest")
+
+    mjd = {}
+    for key in ("min_mjd", "max_mjd"):
+        value = args.get(key, None)
+        if value is not None:
+            try:
+                value = float(value)
+            except ValueError:
+                return error_response(f"{key} query parameter must be a float", 400)
+        mjd[key] = value
+
+    try:
+        features = await light_curve_features(oid, dr, version=version, **mjd)
+    except NotFound:
+        return error_response("", 404)
+    return csv_response(features_to_csv(features), filename=f"{oid}_features.csv")

--- a/ztf_viewer/pages/viewer.py
+++ b/ztf_viewer/pages/viewer.py
@@ -907,6 +907,13 @@ async def get_layout(pathname, search):
                     ),
                     html.Br(),
                     html.Div(id="features-list"),
+                    html.Br(),
+                    html.Div(
+                        [
+                            "Download features: ",
+                            html.A("CSV", href=f"/{dr}/features/{oid}", id="features-csv-link"),
+                        ],
+                    ),
                 ],
                 id="features",
             ),
@@ -2487,6 +2494,34 @@ async def set_features_list(oid, dr, version, min_mjd, max_mjd):
         style={"columns": f"{column_width}ch"},
     )
     return div
+
+
+@app.callback(
+    Output("features-csv-link", "href"),
+    [
+        Input("oid", "children"),
+        Input("dr", "children"),
+        Input("features-api-version", "value"),
+        Input("min-mjd", "value"),
+        Input("max-mjd", "value"),
+    ],
+)
+def set_features_csv_link(oid, dr, version, min_mjd, max_mjd):
+    """Keep the features CSV link pointing at what the Features section currently shows."""
+    if min_mjd is not None and max_mjd is not None and min_mjd >= max_mjd:
+        raise PreventUpdate
+    query = {}
+    if version is not None:
+        query["version"] = version
+    if min_mjd is not None:
+        query["min_mjd"] = min_mjd
+    if max_mjd is not None:
+        query["max_mjd"] = max_mjd
+
+    url = f"/{dr}/features/{oid}"
+    if len(query) > 0:
+        url += "?" + urlencode(query)
+    return url
 
 
 @app.callback(


### PR DESCRIPTION
New `/{dr}/features/{oid}` route renders the feature mapping as a two-column CSV. It takes `version`, `min_mjd` and `max_mjd`, and a callback keeps the link in the Features section pointing at whatever that section is currently showing, so the download matches the numbers on screen.

Closes https://github.com/snad-space/ztf-viewer/issues/71


Claude-Session: https://claude.ai/code/session_01A1AUCG38DYPKj8PzyEgxJQ