### PR TITLE
Spell out the SDSS DR16Q redshift source

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,8 @@ Version schema is `year.month.num_release`
 - Light-curve tooltip no longer repeats the photometric error https://github.com/snad-space/ztf-viewer/issues/745
 - Folded plot shows asymmetric diff mag errors
 - Search radius fields accept three decimal digits, so a sub-arcsecond radius, the `1.23` shown as the cone-search placeholder included, is no longer rejected by the browser
+- SDSS DR16 Quasars "redshift source" spells the source out instead of showing the raw `PIPE`/`VI`/`DR6Q_HW`/`DR7QV_SCH`/`DR12QV` code, and links the three borrowed ones to the catalog the redshift comes from https://github.com/snad-space/ztf-viewer/issues/375
+- SDSS DR16 Quasars cross-match no longer prints every row to the server log, and an unknown source class no longer raises `KeyError` and drops the whole catalog from the object page
 
 ### Added
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,8 +18,7 @@ Version schema is `year.month.num_release`
 - Light-curve tooltip no longer repeats the photometric error https://github.com/snad-space/ztf-viewer/issues/745
 - Folded plot shows asymmetric diff mag errors
 - Search radius fields accept three decimal digits, so a sub-arcsecond radius, the `1.23` shown as the cone-search placeholder included, is no longer rejected by the browser
-- SDSS DR16 Quasars "redshift source" spells the source out instead of showing the raw `PIPE`/`VI`/`DR6Q_HW`/`DR7QV_SCH`/`DR12QV` code, and links the three borrowed ones to the catalog the redshift comes from https://github.com/snad-space/ztf-viewer/issues/375
-- SDSS DR16 Quasars cross-match no longer prints every row to the server log, and an unknown source class no longer raises `KeyError` and drops the whole catalog from the object page
+- SDSS DR16 Quasars "redshift source" is spelled out instead of shown as a raw `DR6Q_HW`-like code https://github.com/snad-space/ztf-viewer/issues/375
 
 ### Added
 

--- a/tests/catalogs/conesearch/test_sdss.py
+++ b/tests/catalogs/conesearch/test_sdss.py
@@ -1,0 +1,61 @@
+import pickle
+
+import pytest
+
+from ztf_viewer.catalogs.conesearch.sdss import SdssQuasarsQuery
+
+# A patch of the SDSS Stripe 82 / COSMOS area densely covered by DR16Q spectroscopy, so a
+# 600 arcsec cone returns quasars with several different `r_z` (SOURCE_Z) codes.
+_RA = 150.0
+_DEC = 2.0
+_RADIUS_ARCSEC = 600.0
+
+
+@pytest.mark.parametrize(
+    ("code", "expected"),
+    [
+        ("PIPE", "SDSS pipeline redshift of this catalog"),
+        ("VI", "visual inspection of this catalog"),
+    ],
+)
+def test_redshift_source_plain_codes(code, expected):
+    assert SdssQuasarsQuery._redshift_source(code) == expected
+
+
+@pytest.mark.parametrize(
+    ("code", "vizier_source"),
+    [
+        ("DR6Q_HW", "J/MNRAS/405/2302"),
+        ("DR7QV_SCH", "VII/260"),
+        ("DR12QV", "VII/279"),
+    ],
+)
+def test_redshift_source_links_to_the_original_catalog(code, vizier_source):
+    html = SdssQuasarsQuery._redshift_source(code)
+    assert f"-source={vizier_source}" in html
+
+
+def test_redshift_source_unknown_code_is_escaped():
+    """A future catalog release may add a code; it should still render, and safely.
+
+    The column is rendered unescaped (see `_declared_html_columns`), so anything passed
+    through untranslated has to be escaped here.
+    """
+    assert SdssQuasarsQuery._redshift_source("<b>NEW</b>") == "&lt;b&gt;NEW&lt;/b&gt;"
+
+
+async def test_find_translates_redshift_source():
+    """Regression test for https://github.com/snad-space/ztf-viewer/issues/375
+
+    The raw catalog gives `r_z` as a short code like "DR6Q_HW", which means nothing to a user.
+    """
+    table = await SdssQuasarsQuery("Test SDSS DR16 Quasars").find(_RA, _DEC, _RADIUS_ARCSEC)
+
+    assert len(table) > 0
+    codes = set(SdssQuasarsQuery._redshift_source_map)
+    values = {str(value) for value in table["r_z"]}
+    assert values, "no redshift source values returned"
+    assert not (values & codes), f"untranslated r_z codes left in the table: {values & codes}"
+
+    # `find` is `@cache()`-decorated, and the Redis backend pickles what it stores
+    assert pickle.loads(pickle.dumps(table)) is not None

--- a/ztf_viewer/catalogs/conesearch/sdss.py
+++ b/ztf_viewer/catalogs/conesearch/sdss.py
@@ -1,7 +1,7 @@
 import urllib.parse
 from typing import ClassVar
 
-from markupsafe import Markup
+from markupsafe import Markup, escape
 
 from ztf_viewer.cache import cache
 from ztf_viewer.catalogs.conesearch._base import _BaseVizierQuery
@@ -36,6 +36,42 @@ class SdssQuasarsQuery(_BaseVizierQuery):
         50: "possible blazar",
     }
 
+    # `r_z` (SOURCE_Z) codes, see note (3) of https://cdsarc.cds.unistra.fr/ftp/VII/289/ReadMe
+    # The three catalog-borrowed codes link to the catalog the redshift was taken from.
+    _redshift_source_map: ClassVar[dict] = {
+        "PIPE": "SDSS pipeline redshift of this catalog",
+        "VI": "visual inspection of this catalog",
+        "DR6Q_HW": Markup("""
+            <a href="https://vizier.cds.unistra.fr/viz-bin/VizieR-3?-source=J/MNRAS/405/2302">
+                SDSS DR6Q, Hewett &amp; Wild (2010)
+            </a>
+        """),
+        "DR7QV_SCH": Markup("""
+            <a href="https://vizier.cds.unistra.fr/viz-bin/VizieR-3?-source=VII/260">
+                SDSS DR7Q, Schneider et al. (2010)
+            </a>
+        """),
+        "DR12QV": Markup("""
+            <a href="https://vizier.cds.unistra.fr/viz-bin/VizieR-3?-source=VII/279">
+                SDSS DR12Q, visual inspection
+            </a>
+        """),
+    }
+
+    # `r_z` cells are pre-built HTML, see `_redshift_source()`
+    _declared_html_columns = frozenset({"__link", "r_z"})
+
+    @classmethod
+    def _redshift_source(cls, code) -> str:
+        """Human-readable description of an `r_z` code, as an HTML string.
+
+        Unknown codes are shown as-is: a new catalog release may add one, and that should not
+        hide the rest of the row. They still have to be escaped, because the column as a whole
+        is rendered unescaped.
+        """
+        code = str(code).strip()
+        return cls._redshift_source_map.get(code) or escape(code)
+
     _vizier_columns: ClassVar[list] = [
         "SDSS",
         "Class",
@@ -54,10 +90,10 @@ class SdssQuasarsQuery(_BaseVizierQuery):
     @cache()
     async def find(self, ra, dec, radius_arcsec):
         table = await super().find(ra, dec, radius_arcsec)
-        table["__type"] = table["Class"] = [self._class_map[c] for c in table["Class"]]
+        table["__type"] = table["Class"] = [self._class_map.get(c, f"unknown class {c}") for c in table["Class"]]
+        table["r_z"] = [self._redshift_source(code) for code in table["r_z"]]
         return table
 
     def get_url(self, id, row=None):
-        print(row)
         params = urllib.parse.urlencode({"plateid": row["Plate"], "mjd": row["MJD"], "fiberid": row["Fiber"]})
         return f"//dr16.sdss.org/optical/spectrum/view?{params}"


### PR DESCRIPTION
The `r_z` column showed the raw SOURCE_Z code (`PIPE`, `VI`, `DR6Q_HW`, `DR7QV_SCH`, `DR12QV`), which means nothing without the VizieR ReadMe. Translate it to note (3) of VII/289, and link the three codes that borrow the redshift from another catalog to that catalog.

Along the way: drop a leftover `print(row)` that logged every cross-match row, and fall back to the raw code instead of raising `KeyError` -- and so dropping the whole catalog from the page -- on an unknown source class.

Closes #375


Claude-Session: https://claude.ai/code/session_01A1AUCG38DYPKj8PzyEgxJQ