### PR TITLE
Drop the retired MARS broker link

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@ Version schema is `year.month.num_release`
 
 - Cone searches to Simbad are paced to its published limit of 8 queries per second, so a busy moment cannot get us temporarily blacklisted https://github.com/snad-space/ztf-viewer/issues/51
 
+### Removed
+
+- MARS from "Search in brokers", the broker is retired https://github.com/snad-space/ztf-viewer/issues/382
+
 ### Fixed
 
 - Simbad cross-match works again: astroquery ≥0.4.8 returns `ra`/`dec` in degrees instead of `RA`/`DEC` in hours, so every Simbad cone search raised `KeyError` and the catalog was silently absent from every object page

--- a/tests/pages/test_viewer.py
+++ b/tests/pages/test_viewer.py
@@ -318,8 +318,6 @@ async def test_get_summary_mixed_success_and_failures(summary_upstreams):
             {"text": "Antares", "href": antares_href},
             ", ",
             {"text": "Fink", "href": "https://ztf.fink-portal.org/?action=conesearch&ra=10.0&dec=20.0&radius=3"},
-            ", ",
-            {"text": "MARS", "href": "https://mars.lco.global/?cone=10.0%2C20.0%2C0.0008333333333333334"},
         ],
         ["Coordinates", ": ", "Eq 10.00000 +20.00000", ", ", "Gal 00h40m00s +20d00m00s"],
     ]

--- a/ztf_viewer/brokers.py
+++ b/ztf_viewer/brokers.py
@@ -46,13 +46,3 @@ def fink_conesearch_url(ra, dec, radius_arcsec=DEFAULT_SEARCH_RADIUS_ARCSEC):
 
 def fink_tag(ra, dec, radius_arcsec=DEFAULT_SEARCH_RADIUS_ARCSEC):
     return _a_tag("Fink", fink_conesearch_url(ra, dec, radius_arcsec))
-
-
-def mars_conesearch_url(ra, dec, radius_arcsec=DEFAULT_SEARCH_RADIUS_ARCSEC):
-    radius_deg = radius_arcsec / 3600.0
-    cone = quote_plus(f"{ra},{dec},{radius_deg}")
-    return f"https://mars.lco.global/?cone={cone}"
-
-
-def mars_tag(ra, dec, radius_arcsec=DEFAULT_SEARCH_RADIUS_ARCSEC):
-    return _a_tag("MARS", mars_conesearch_url(ra, dec, radius_arcsec))

--- a/ztf_viewer/pages/viewer.py
+++ b/ztf_viewer/pages/viewer.py
@@ -1717,7 +1717,6 @@ async def get_summary(oid, dr, different_filter, different_field, radius_ids, ra
         brokers.alerce_tag(ra, dec),
         brokers.antares_tag(ra, dec, oid=oid),
         brokers.fink_tag(ra, dec),
-        brokers.mars_tag(ra, dec),
     ]
 
     elements["Coordinates"] = [


### PR DESCRIPTION
MARS was shut down by LCO and mars.lco.global no longer resolves, so the "Search in brokers" MARS link led nowhere.

Closes #382


Claude-Session: https://claude.ai/code/session_01A1AUCG38DYPKj8PzyEgxJQ