### PR TITLE
Let the URL sync and navigation coexist

### DIFF
--- a/tests/test_go_to_url.py
+++ b/tests/test_go_to_url.py
@@ -1,0 +1,77 @@
+"""`go_to_url` -- the header's OID and coordinate/name boxes.
+
+It drives `dcc.Location`, which is configured with `refresh=True`. In that mode the component
+force-assigns every part of `window.location` that differs from its own props, in order, and the
+last assignment wins. The light-curve page keeps the query string in step with its controls
+through `history.replaceState`, which the component does not observe, so its `search` prop stays
+at the value the page loaded with. Navigating by `pathname` therefore also re-applied that stale
+`search`, sending the browser back to the current page with an empty query instead of to the
+page asked for -- no search could be started from an object page whose URL had picked up a
+`?min_mjd=`, `?lc=` or `?fits=`. Navigating by `href` moves the whole URL at once.
+"""
+
+import pytest
+from dash.exceptions import PreventUpdate
+
+from ztf_viewer import config
+
+config.CACHE_TYPE = "memory"
+config.UNAVAILABLE_CATALOGS_CACHE_TYPE = "memory"
+
+import ztf_viewer.__main__ as main_module
+
+_VIEW_PATH = "/dr24/view/680113300005170"
+
+
+async def _go(**kwargs):
+    """`go_to_url` as the header's callback calls it: every input at its layout default."""
+    call = {
+        "n_clicks_oid": 0,
+        "n_submit_oid": 0,
+        "n_clicks_search": 0,
+        "n_submit_coord_or_name": 0,
+        "n_submit_radius": 0,
+        "oid": None,
+        "coord_or_name": None,
+        "radius_arcsec": 1,
+        "current_pathname": _VIEW_PATH,
+        "dr": "dr24",
+    }
+    return await main_module.go_to_url(**(call | kwargs))
+
+
+async def test_the_search_button_navigates_to_the_search_page():
+    assert await _go(n_clicks_search=1, coord_or_name="M31", radius_arcsec=10) == "/dr24/search/M31/10"
+
+
+async def test_submitting_the_coordinate_box_navigates_to_the_search_page():
+    assert await _go(n_submit_coord_or_name=1, coord_or_name="M31") == "/dr24/search/M31/1"
+
+
+async def test_the_target_carries_no_query_string():
+    """What is navigated to is the whole URL, so a query left over from the object page -- its
+    MJD range, its external light curves -- must not be carried onto the page being opened."""
+    target = await _go(n_clicks_search=1, coord_or_name="M31")
+    assert "?" not in target
+
+
+async def test_a_name_with_a_space_is_quoted():
+    assert await _go(n_clicks_search=1, coord_or_name="NGC 7331") == "/dr24/search/NGC%207331/1"
+
+
+async def test_nothing_submitted_does_not_navigate():
+    """The initial call. Returning the current location would navigate to it stripped of its
+    query string, throwing away the `?min_mjd=`/`?lc=`/`?fits=` an incoming link asked for."""
+    with pytest.raises(PreventUpdate):
+        await _go()
+
+
+def test_the_callback_drives_the_whole_url():
+    """`pathname` alone leaves `dcc.Location` free to re-apply its stale `search` afterwards."""
+    outputs = [
+        str(output)
+        for key in main_module.app.callback_map
+        for output in str(key).split("...")
+        if output.startswith("url.")
+    ]
+    assert outputs == ["url.href"]

--- a/tests/test_go_to_url.py
+++ b/tests/test_go_to_url.py
@@ -1,13 +1,8 @@
 """`go_to_url` -- the header's OID and coordinate/name boxes.
 
-It drives `dcc.Location`, which is configured with `refresh=True`. In that mode the component
-force-assigns every part of `window.location` that differs from its own props, in order, and the
-last assignment wins. The light-curve page keeps the query string in step with its controls
-through `history.replaceState`, which the component does not observe, so its `search` prop stays
-at the value the page loaded with. Navigating by `pathname` therefore also re-applied that stale
-`search`, sending the browser back to the current page with an empty query instead of to the
-page asked for -- no search could be started from an object page whose URL had picked up a
-`?min_mjd=`, `?lc=` or `?fits=`. Navigating by `href` moves the whole URL at once.
+`dcc.Location(refresh=True)` re-applies every part of the URL its props still hold, so
+navigating by `pathname` was undone by the `search` the light-curve page's clientside sync
+leaves stale: no search could be started from an object page whose URL carried a query.
 """
 
 import pytest
@@ -49,8 +44,7 @@ async def test_submitting_the_coordinate_box_navigates_to_the_search_page():
 
 
 async def test_the_target_carries_no_query_string():
-    """What is navigated to is the whole URL, so a query left over from the object page -- its
-    MJD range, its external light curves -- must not be carried onto the page being opened."""
+    """The whole URL is navigated, so the object page's MJD range must not come along."""
     target = await _go(n_clicks_search=1, coord_or_name="M31")
     assert "?" not in target
 
@@ -60,8 +54,7 @@ async def test_a_name_with_a_space_is_quoted():
 
 
 async def test_nothing_submitted_does_not_navigate():
-    """The initial call. Returning the current location would navigate to it stripped of its
-    query string, throwing away the `?min_mjd=`/`?lc=`/`?fits=` an incoming link asked for."""
+    """The initial call: navigating to the current location would drop its query string."""
     with pytest.raises(PreventUpdate):
         await _go()
 

--- a/ztf_viewer/__main__.py
+++ b/ztf_viewer/__main__.py
@@ -333,7 +333,14 @@ async def sky_coord_from_str(s):
 
 
 @app.callback(
-    Output("url", "pathname"),
+    # `href`, not `pathname`: `dcc.Location(refresh=True)` force-assigns every one of
+    # `window.location`'s parts that differs from its own props, in order, and the last
+    # assignment wins. Navigating by `pathname` therefore also re-applied the component's
+    # `search` prop, which the light-curve page's clientside sync deliberately leaves stale --
+    # sending the browser back to the current page with an empty query instead of to the new
+    # one. Setting `href` moves both parts at once, and drops the query the previous page
+    # accumulated rather than carrying its MJD range onto the next object.
+    Output("url", "href"),
     [
         Input("button-oid", "n_clicks"),
         Input("input-oid", "n_submit"),
@@ -367,7 +374,10 @@ async def go_to_url(
     if n_clicks_search != 0 or n_submit_coord_or_name != 0 or n_submit_radius != 0:
         coord_or_name = urllib.parse.quote(coord_or_name)
         return f"/{dr}/search/{coord_or_name}/{radius_arcsec}"
-    return current_pathname
+    # Nothing was submitted -- this is the initial call. Returning the current location would be
+    # a navigation to it stripped of its query string, throwing away the `?min_mjd=`/`?lc=`/
+    # `?fits=` an incoming link asked for.
+    raise PreventUpdate
 
 
 @app.callback(
@@ -378,7 +388,13 @@ async def go_to_url(
     ],
     [
         Input("url", "pathname"),
-        Input("url", "search"),
+    ],
+    # A `State`, not an `Input`: the query string carries the state a page is *built* with, and
+    # is read whenever the pathname changes, page load included. As an `Input` it also fired on
+    # every query-string change the light-curve page's clientside sync makes -- one per keystroke
+    # in the MJD inputs -- rebuilding the whole page and re-running every cross-match.
+    [
+        State("url", "search"),
     ],
 )
 async def app_select_by_url(pathname, search):

--- a/ztf_viewer/__main__.py
+++ b/ztf_viewer/__main__.py
@@ -333,13 +333,8 @@ async def sky_coord_from_str(s):
 
 
 @app.callback(
-    # `href`, not `pathname`: `dcc.Location(refresh=True)` force-assigns every one of
-    # `window.location`'s parts that differs from its own props, in order, and the last
-    # assignment wins. Navigating by `pathname` therefore also re-applied the component's
-    # `search` prop, which the light-curve page's clientside sync deliberately leaves stale --
-    # sending the browser back to the current page with an empty query instead of to the new
-    # one. Setting `href` moves both parts at once, and drops the query the previous page
-    # accumulated rather than carrying its MJD range onto the next object.
+    # `href`, not `pathname`: `refresh=True` re-applies every other part of the URL after it,
+    # including the `search` the clientside sync leaves stale, which undid the navigation.
     Output("url", "href"),
     [
         Input("button-oid", "n_clicks"),
@@ -374,9 +369,7 @@ async def go_to_url(
     if n_clicks_search != 0 or n_submit_coord_or_name != 0 or n_submit_radius != 0:
         coord_or_name = urllib.parse.quote(coord_or_name)
         return f"/{dr}/search/{coord_or_name}/{radius_arcsec}"
-    # Nothing was submitted -- this is the initial call. Returning the current location would be
-    # a navigation to it stripped of its query string, throwing away the `?min_mjd=`/`?lc=`/
-    # `?fits=` an incoming link asked for.
+    # The initial call: returning the current location would navigate to it without its query.
     raise PreventUpdate
 
 
@@ -389,10 +382,8 @@ async def go_to_url(
     [
         Input("url", "pathname"),
     ],
-    # A `State`, not an `Input`: the query string carries the state a page is *built* with, and
-    # is read whenever the pathname changes, page load included. As an `Input` it also fired on
-    # every query-string change the light-curve page's clientside sync makes -- one per keystroke
-    # in the MJD inputs -- rebuilding the whole page and re-running every cross-match.
+    # `State`: the query is read when the page is built. As an `Input` every sync of it rebuilt
+    # the page, once per keystroke in the MJD inputs.
     [
         State("url", "search"),
     ],

--- a/ztf_viewer/pages/viewer.py
+++ b/ztf_viewer/pages/viewer.py
@@ -2287,10 +2287,8 @@ app.clientside_callback(
         // button with every intermediate value. `dcc.Location` only listens for `popstate` and
         // Dash's own pushstate event, so this stays invisible to the router by construction.
         window.history.replaceState(window.history.state, "", url);
-        // ... which is why the component's own `href` and `search` have to be told: they are
-        // what it force-assigns back onto `window.location` on the next navigation, so leaving
-        // them at their page-load values would undo that navigation. `app_select_by_url` takes
-        // the query as a `State`, so this does not rebuild the page.
+        // ... which is why it has to be told: props it still believes are re-applied on the next
+        // navigation, undoing it. Harmless to set, `url.search` being a `State` of the router.
         window.dash_clientside.set_props("url", {search: window.location.search, href: window.location.href});
         return window.dash_clientside.no_update;
     }

--- a/ztf_viewer/pages/viewer.py
+++ b/ztf_viewer/pages/viewer.py
@@ -2287,6 +2287,11 @@ app.clientside_callback(
         // button with every intermediate value. `dcc.Location` only listens for `popstate` and
         // Dash's own pushstate event, so this stays invisible to the router by construction.
         window.history.replaceState(window.history.state, "", url);
+        // ... which is why the component's own `href` and `search` have to be told: they are
+        // what it force-assigns back onto `window.location` on the next navigation, so leaving
+        // them at their page-load values would undo that navigation. `app_select_by_url` takes
+        // the query as a `State`, so this does not rebuild the page.
+        window.dash_clientside.set_props("url", {search: window.location.search, href: window.location.href});
         return window.dash_clientside.no_update;
     }
     """,


### PR DESCRIPTION
Selecting an external light curve, or touching the MJD range, left the header's search and OID boxes dead: submitting either reloaded the current object page with an empty query instead of opening what was asked for.

`dcc.Location` is configured with `refresh=True`, and in that mode it force-assigns every part of `window.location` that differs from its own props -- pathname, href, hash, search, in that order -- with the last assignment winning. The light-curve page keeps the query string in step with its controls through `history.replaceState`, which the component does not observe, so its `search` and `href` props stay at the values the page loaded with. Setting `pathname` therefore navigated, and was then undone by the stale `search` being written back.

Tell the component what the address bar says after each sync, take the query as a `State` of `app_select_by_url` so that telling it does not rebuild the page on every keystroke, and navigate by `href`, which moves the whole URL at once. Navigation now also drops the query the previous page accumulated, instead of carrying one object's MJD range onto the next.


Claude-Session: https://claude.ai/code/session_01A1AUCG38DYPKj8PzyEgxJQ