### PR TITLE
Keep distant Astro-COLIBRI events out of the summary

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ Version schema is `year.month.num_release`
 ### Changed
 
 - Cone searches to Simbad are paced to its published limit of 8 queries per second, so a busy moment cannot get us temporarily blacklisted https://github.com/snad-space/ztf-viewer/issues/51
+- Astro-COLIBRI reaches the summary only within 5″, its own cross-match table keeps the full radius https://github.com/snad-space/ztf-viewer/issues/317
 
 ### Removed
 

--- a/tests/pages/test_viewer.py
+++ b/tests/pages/test_viewer.py
@@ -114,9 +114,9 @@ class _UnavailableCheckingCatalogQuery(_StubCatalogQuery):
         return await super().find(ra, dec, radius_arcsec)
 
 
-def _stub_table(*, objname="Stub Object", type_="SN Ia", distance=None, redshift=None):
+def _stub_table(*, objname="Stub Object", type_="SN Ia", distance=None, redshift=None, separation=4.94):
     table = Table()
-    table["separation"] = [4.94]
+    table["separation"] = [separation]
     table["__objname"] = [objname]
     table["__type"] = [type_]
     if distance is not None:
@@ -284,6 +284,66 @@ async def test_get_summary_skips_catalog_with_no_radius_input(summary_upstreams)
         without = (await _run_get_summary(["other"], summary_upstreams))[-1]
 
     assert _dump(with_missing) == _dump(without)
+
+
+# ---------------------------------------------------------------------------------------------
+# get_summary -- the per-catalog separation cap.
+# ---------------------------------------------------------------------------------------------
+
+
+async def test_get_summary_drops_capped_catalog_match_beyond_the_cap(summary_upstreams):
+    """A 1°-away Astro-COLIBRI event must be indistinguishable from no Astro-COLIBRI match."""
+    far = {"astro-colibri": _StubCatalogQuery("Astro-COLIBRI", table=_stub_table(separation=763.7))}
+    with patch.object(viewer, "catalog_query_objects", lambda: far):
+        with_far_match = (await _run_get_summary(["astro-colibri"], summary_upstreams))[-1]
+
+    none_found = {"astro-colibri": _StubCatalogQuery("Astro-COLIBRI", exc=NotFound())}
+    with patch.object(viewer, "catalog_query_objects", lambda: none_found):
+        without = (await _run_get_summary(["astro-colibri"], summary_upstreams))[-1]
+
+    assert _dump(with_far_match) == _dump(without)
+
+
+async def test_get_summary_keeps_capped_catalog_match_inside_the_cap(summary_upstreams):
+    catalogs = {
+        "astro-colibri": _StubCatalogQuery(
+            "Astro-COLIBRI", table=_stub_table(objname="GW170817", type_="ot_gw", separation=1.2)
+        )
+    }
+    with patch.object(viewer, "catalog_query_objects", lambda: catalogs):
+        div = (await _run_get_summary(["astro-colibri"], summary_upstreams))[-1]
+
+    colibri_link = {"text": "Astro-COLIBRI", "href": "#astro-colibri"}
+    assert [line for line in _project(div) if line[0] in ("Name", "Type")] == [
+        ["Name", ": ", ["GW170817 (1.200″ ", colibri_link, ")"]],
+        ["Type", ": ", ["ot_gw (1.200″ ", colibri_link, ")"]],
+    ]
+
+
+async def test_get_summary_drops_only_the_capped_rows(summary_upstreams):
+    """The cap filters rows, so a near event is still found when a far one is also returned."""
+    table = Table()
+    table["separation"] = [763.7, 1.2]
+    table["__objname"] = ["SN 2024zro", "GW170817"]
+    table["__type"] = ["ot_sn", "ot_gw"]
+    catalogs = {"astro-colibri": _StubCatalogQuery("Astro-COLIBRI", table=table)}
+    with patch.object(viewer, "catalog_query_objects", lambda: catalogs):
+        div = (await _run_get_summary(["astro-colibri"], summary_upstreams))[-1]
+
+    (name_line,) = [line for line in _project(div) if line[0] == "Name"]
+    assert name_line[2][0] == "GW170817 (1.200″ "
+
+
+async def test_get_summary_does_not_cap_an_uncapped_catalog(summary_upstreams):
+    """Only catalogs named in `SUMMARY_MAX_SEPARATION_ARCSEC` are filtered."""
+    assert "other" not in viewer.SUMMARY_MAX_SEPARATION_ARCSEC
+    catalogs = {"other": _StubCatalogQuery("Other Catalog", table=_stub_table(separation=763.7))}
+    with patch.object(viewer, "catalog_query_objects", lambda: catalogs):
+        div = (await _run_get_summary(["other"], summary_upstreams))[-1]
+
+    assert [line for line in _project(div) if line[0] == "Name"] == [
+        ["Name", ": ", ["Stub Object (12′43.7″ ", {"text": "Other Catalog", "href": "#other"}, ")"]]
+    ]
 
 
 async def test_get_summary_mixed_success_and_failures(summary_upstreams):

--- a/ztf_viewer/pages/viewer.py
+++ b/ztf_viewer/pages/viewer.py
@@ -1510,16 +1510,20 @@ async def set_ref_mag_magerr(dr, _n_clicks, link_id, all_mag_ids, all_mag_values
     )
 
 
-async def _find_catalog_for_summary(catalog, query, ra, dec, radii):
-    """Isolate one catalog's query so an expected failure here can never reach its siblings.
+SUMMARY_MAX_SEPARATION_ARCSEC = immutabledict({"astro-colibri": 5.0})
 
-    radii is keyed by the radius inputs the layout renders, which don't cover every registered
-    catalog -- the lookup has to fail inside this per-task coroutine so it stays contained.
-    """
+
+async def _find_catalog_for_summary(catalog, query, ra, dec, radii):
+    """Query one catalog for the summary; expected failures and an empty result return None."""
     try:
         table = await query.find(ra, dec, radii[catalog])
     except NotFound, CatalogUnavailable, KeyError:
         return catalog, None
+    max_separation = SUMMARY_MAX_SEPARATION_ARCSEC.get(catalog)
+    if max_separation is not None:
+        table = table[table["separation"] <= max_separation]
+        if len(table) == 0:
+            return catalog, None
     return catalog, table
 
 


### PR DESCRIPTION
Astro-COLIBRI is searched a whole degree out, which is right for a GRB or a GW localisation in its own section, but meant the summary routinely named a supernova a quarter of a degree away as if it were this object -- supplying its Name, Type and redshift distance.

Cap it at 5" for the summary only. The cap is a per-catalog dict rather than a special case, and it filters the table instead of re-querying at a narrower radius, so Astro-COLIBRI still costs one query per page (#421).

Closes #317


Claude-Session: https://claude.ai/code/session_01A1AUCG38DYPKj8PzyEgxJQ